### PR TITLE
fix: Tab switching scrolls Asset Detail View to Top

### DIFF
--- a/src/tpstreams/assets/detail.html
+++ b/src/tpstreams/assets/detail.html
@@ -191,6 +191,25 @@ date: 2023-08-29
       }
     };
   }
+  function toggleTabs(){
+    return{
+      active_tab:"embed_link",
+      tab : {
+        ["x-html"](){
+          switch (this.active_tab) {
+            case "embed_link":
+              return `{% include "./includes/embed_link.html" %}`;
+            case "watch_metrics":
+              return `{% include "./includes/watch_metrics.html" %}`;
+            case "analytics":
+              return `{% include "./includes/analytics.html" %}`;
+            default:
+              return "";
+          }
+        }
+      },
+    }
+  }
 </script>
 </div>
 {% endblock %}

--- a/src/tpstreams/assets/detail.html
+++ b/src/tpstreams/assets/detail.html
@@ -191,25 +191,6 @@ date: 2023-08-29
       }
     };
   }
-  function toggleTabs(){
-    return{
-      active_tab:"embed_link",
-      tab : {
-        ["x-html"](){
-          switch (this.active_tab) {
-            case "embed_link":
-              return `{% include "./includes/embed_link.html" %}`;
-            case "watch_metrics":
-              return `{% include "./includes/watch_metrics.html" %}`;
-            case "analytics":
-              return `{% include "./includes/analytics.html" %}`;
-            default:
-              return "";
-          }
-        }
-      },
-    }
-  }
 </script>
 </div>
 {% endblock %}

--- a/src/tpstreams/assets/includes/analytics.html
+++ b/src/tpstreams/assets/includes/analytics.html
@@ -20,12 +20,12 @@
   </div>
 
   <div class="flex justify-center">
-    <div id="views_chart" x-show="showSeparate" class="w-80 h-52 sm:w-[600px] sm:h-[400px] md:w-[700px] sm:w-[600px] sm:h-[400px] md:h-[400px] 2xl:w-[1000px] 2xl:h-[500px] mt-4"></div>
+    <div id="views_chart" :hidden="!showSeparate" class="w-80 h-52 sm:w-[600px] sm:h-[400px] md:w-[700px] sm:w-[600px] sm:h-[400px] md:h-[400px] 2xl:w-[1000px] 2xl:h-[500px] mt-4"></div>
   </div>
   <div class="flex justify-center">
-    <div id="minutes_watched_chart" x-show="showSeparate" class="w-80 h-52 sm:w-[600px] sm:h-[400px] md:w-[700px] sm:w-[600px] sm:h-[400px] md:h-[400px] 2xl:w-[1000px] 2xl:h-[500px] mt-4"></div>
+    <div id="minutes_watched_chart" :hidden="!showSeparate" class="w-80 h-52 sm:w-[600px] sm:h-[400px] md:w-[700px] sm:w-[600px] sm:h-[400px] md:h-[400px] 2xl:w-[1000px] 2xl:h-[500px] mt-4"></div>
   </div>
   <div class="flex justify-center">
-    <div id="chart" x-show="!showSeparate" class="w-80 h-52 sm:w-[600px] sm:h-[400px] md:w-[700px] sm:w-[600px] sm:h-[400px] md:h-[400px] 2xl:w-[1000px] 2xl:h-[500px] mt-4"></div>
+    <div id="chart" :hidden="showSeparate" class="w-80 h-52 sm:w-[600px] sm:h-[400px] md:w-[700px] sm:w-[600px] sm:h-[400px] md:h-[400px] 2xl:w-[1000px] 2xl:h-[500px] mt-4"></div>
   </div>
 </div>

--- a/src/tpstreams/assets/includes/asset_detail_tabs.html
+++ b/src/tpstreams/assets/includes/asset_detail_tabs.html
@@ -1,4 +1,4 @@
-<div x-data="{ active_tab: 'embed_link' }" class="px-4 xl:col-span-2 sm:px-0 2xl:col-span-3 2xl:row-span-2">
+<div x-data="tabs" class="px-4 xl:col-span-2 sm:px-0 2xl:col-span-3 2xl:row-span-2">
   <div class="sm:hidden">
     <label for="tabs" class="sr-only">Select a tab</label>
     <select id="tabs" name="tabs"
@@ -77,8 +77,7 @@
       </nav>
     </div>
   </div>
-  <div x-show="active_tab == 'embed_link'">
-    {% include "./embed_link.html" %}
+  <div x-bind="tab">
   </div>
   <div x-show="active_tab == 'thumbnails'">
     Thumbnails
@@ -86,10 +85,25 @@
   <div x-show="active_tab == 'chapters'">
     Chapters
   </div>
-  <div x-show="active_tab == 'watch_metrics'">
-    {% include "./watch_metrics.html" %}
-  </div>
-  <div x-show="active_tab == 'analytics'">
-    {% include "./analytics.html" %}
-  </div>
+  <script>
+    document.addEventListener("alpine:init", () => {
+      Alpine.data("tabs", () => ({
+        active_tab:"embed_link",
+        tab : {
+          ["x-html"](){
+            switch (this.active_tab) {
+              case "embed_link":
+                return `{% include "./embed_link.html" %}`;
+              case "watch_metrics":
+                return `{% include "./watch_metrics.html" %}`;
+              case "analytics":
+                return `{% include "./analytics.html" %}`;
+              default:
+                return "";
+            }
+          }
+        },
+      }));
+    });
+  </script>
 </div>

--- a/src/tpstreams/assets/includes/asset_detail_tabs.html
+++ b/src/tpstreams/assets/includes/asset_detail_tabs.html
@@ -1,4 +1,4 @@
-<div x-data="tabs" class="px-4 xl:col-span-2 sm:px-0 2xl:col-span-3 2xl:row-span-2">
+<div x-data="toggleTabs()" class="px-4 xl:col-span-2 sm:px-0 2xl:col-span-3 2xl:row-span-2">
   <div class="sm:hidden">
     <label for="tabs" class="sr-only">Select a tab</label>
     <select id="tabs" name="tabs"
@@ -85,25 +85,4 @@
   <div x-show="active_tab == 'chapters'">
     Chapters
   </div>
-  <script>
-    document.addEventListener("alpine:init", () => {
-      Alpine.data("tabs", () => ({
-        active_tab:"embed_link",
-        tab : {
-          ["x-html"](){
-            switch (this.active_tab) {
-              case "embed_link":
-                return `{% include "./embed_link.html" %}`;
-              case "watch_metrics":
-                return `{% include "./watch_metrics.html" %}`;
-              case "analytics":
-                return `{% include "./analytics.html" %}`;
-              default:
-                return "";
-            }
-          }
-        },
-      }));
-    });
-  </script>
 </div>

--- a/src/tpstreams/assets/includes/asset_detail_tabs.html
+++ b/src/tpstreams/assets/includes/asset_detail_tabs.html
@@ -1,4 +1,4 @@
-<div x-data="toggleTabs()" class="px-4 xl:col-span-2 sm:px-0 2xl:col-span-3 2xl:row-span-2">
+<div x-data="{ active_tab: 'embed_link' }" class="px-4 xl:col-span-2 sm:px-0 2xl:col-span-3 2xl:row-span-2">
   <div class="sm:hidden">
     <label for="tabs" class="sr-only">Select a tab</label>
     <select id="tabs" name="tabs"
@@ -77,12 +77,19 @@
       </nav>
     </div>
   </div>
-  <div x-bind="tab">
-  </div>
-  <div x-show="active_tab == 'thumbnails'">
+  <template x-if="active_tab === 'embed_link'">
+    {% include "./embed_link.html" %}
+  </template>
+  <template x-if="active_tab === 'watch_metrics'">
+    {% include "./watch_metrics.html" %}
+  </template>
+  <template x-if="active_tab === 'analytics'">
+    {% include "./analytics.html" %}
+  </template>
+  <template x-if="active_tab === 'thumbnails'">
     Thumbnails
-  </div>
-  <div x-show="active_tab == 'chapters'">
+  </template>
+  <template x-if="active_tab === 'chapters'">
     Chapters
-  </div>
+  </template>
 </div>


### PR DESCRIPTION
- In the asset detail view, tab switching triggers an unwanted page scroll to the top due to the use of `x-show`
- The `x-if` directive offers better control over element rendering compared to `x-show`, by completely adding or removing the element rather than just changing the display property to none.
- The same issue is faced while toggling the chart, this is fixed by using the bind class