### PR TITLE
fix: Remove last activity from student content detail panel

### DIFF
--- a/src/content_detail_page/includes/heading_section.html
+++ b/src/content_detail_page/includes/heading_section.html
@@ -8,7 +8,6 @@
     </div>
     <div class="mt-2 text-xs text-gray-700">
       <div> 46% Complete</div>
-      <div> Last activity on October 20, 2023</div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
- This commit removes last activity from student content detail panel because it is redundant. 