### PR TITLE
Add confirmation input box for empty trash action

### DIFF
--- a/src/tpstreams/deleted_assets/includes/empty_trash_model.html
+++ b/src/tpstreams/deleted_assets/includes/empty_trash_model.html
@@ -30,7 +30,7 @@
               </div>
               <div class="mt-4">
                 <label for="confirmation" class="block text-sm font-medium leading-6 text-gray-900">
-                  Type <span class="font-semibold">CONFIRM</span> to proceed
+                  Type <span class="font-semibold text-red-400">CONFIRM</span> to proceed
                 </label>
                 <input type="text" id="confirmation" x-model="confirmationText"
                   :class="confirmationText !== 'CONFIRM' ? 'border-red-600 focus:ring-red-600' : 'border-gray-300 focus:ring-indigo-600'"

--- a/src/tpstreams/deleted_assets/includes/empty_trash_model.html
+++ b/src/tpstreams/deleted_assets/includes/empty_trash_model.html
@@ -26,14 +26,24 @@
             <div>
               <h3 class="text-base font-semibold leading-6 text-gray-900" id="modal-title">Empty Trash</h3>
               <div class="mt-2">
-                <p class="text-sm text-gray-500">Are you sure you want to permanently delete all the assets? This action cannot be undone.
-                </p>
+                <p class="text-sm text-gray-500">Are you sure you want to permanently delete all the assets? </br>  This action cannot be undone.</p>
+              </div>
+              <div class="mt-4">
+                <label for="confirmation" class="block text-sm font-medium leading-6 text-gray-900">
+                  Type <span class="font-semibold">CONFIRM</span> to proceed
+                </label>
+                <input type="text" id="confirmation" x-model="confirmationText"
+                  :class="confirmationText !== 'CONFIRM' ? 'border-red-600 focus:ring-red-600' : 'border-gray-300 focus:ring-indigo-600'"
+                  class="mt-2 block w-2/3 rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset placeholder:text-gray-400 sm:text-sm sm:leading-6"
+                  placeholder="CONFIRM">
               </div>
             </div>
           </div>
         </div>
         <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-          <button type="button" @click="deleting=true"
+          <button type="button" @click="if (confirmationText === 'CONFIRM') { deleting = true; /* Submit form or action */ }"
+            :class="{'cursor-not-allowed opacity-50': confirmationText !== 'CONFIRM'}"
+            :disabled="confirmationText !== 'CONFIRM'"
             class="inline-flex w-20 justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:ml-3">
             <svg x-show="deleting" class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg"
               fill="none" viewBox="0 0 24 24">

--- a/src/tpstreams/deleted_assets/includes/empty_trash_model.html
+++ b/src/tpstreams/deleted_assets/includes/empty_trash_model.html
@@ -1,4 +1,4 @@
-<div x-show="showEmptyTrashModel" x-cloak class="relative z-50" aria-labelledby="modal-title" role="dialog"
+<div x-data="{ confirmationText: '', deleting: false }" x-show="showEmptyTrashModel" x-cloak class="relative z-50" aria-labelledby="modal-title" role="dialog"
   aria-modal="true">
   <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" x-transition:enter="ease-out duration-300"
     x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-200"


### PR DESCRIPTION
- This commit adds a confirmation input box to the "Empty Trash" modal to prevent accidental deletions.
- Users must type "CONFIRM" to enable the "Delete" button. 