### PR TITLE
Add assignment evaluations menu under evaluate dropdown

### DIFF
--- a/src/_includes/partials/admin_navbar.html
+++ b/src/_includes/partials/admin_navbar.html
@@ -19,10 +19,6 @@
               <a href="{{ '/questions/reports'|url }}"
               class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Questions</a>
 
-            <a href="#"
-              class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Videos</a>
-
-
               <div class="relative inline-block flex" x-data="{showdropdown:false}">
                 <div class="flex">
                   <button type="button" @click="showdropdown=!showdropdown" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
@@ -41,6 +37,25 @@
                   </div>
                 </div>
               </div>
+
+              <div class="relative inline-block flex" x-data="{showdropdown:false}">
+                <div class="flex">
+                  <button type="button" @click="showdropdown=!showdropdown" class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
+                    <p class="ml-2 whitespace-nowrap">Evaluate</p>
+                    <svg class="ml-2 h-5 w-5 flex-none text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"></path>
+                    </svg>
+                  </button>
+                  <div class="absolute right-0 z-50 w-48 origin-top-right top-full rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" x-show="showdropdown" @click.away="showdropdown=false" style="display: none;">
+                    <div class="py-1" role="none">
+                      <!-- Active: "bg-gray-100 text-gray-900", Not Active: "text-gray-700" -->
+                      <a href="#" class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 text-gray-900 hover:curson-pointer" role="menuitem" tabindex="-1" id="menu-item-0">Exam Evaluations</a>
+                      <a href="{{'/testpress/assignment_submissions/'|url}}" class="{% if page.url == '/testpress/assignment_submissions/' %}bg-gray-100 text-gray-900{% else %}text-gray-700{% endif %} block px-4 py-2 text-sm hover:bg-gray-100 hover:curson-pointer" role="menuitem" tabindex="-1" id="menu-item-1">Assignment Evaluations</a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              
 
             <a href="{{ '/doubts/'|url }}"
               class="border-indigo-500 text-gray-900 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"


### PR DESCRIPTION
- Introduced a dropdown menu under "Evaluate" to include:
  - "Exam Evaluations"
  - "Assignment Evaluations" (linked to `/testpress/assignment_submissions/`)
- Improved navigation structure for evaluation-related sections