### PR TITLE
Add support to capture image in student enrollment

### DIFF
--- a/src/simba/students/enroll.html
+++ b/src/simba/students/enroll.html
@@ -19,5 +19,112 @@ current_page: Enroll
       </div>
     </div>
   </div>
-
+{% include './includes/capture_and_preview_image_modal.html' %}
 {% endblock content %}
+{% block extra_scripts %}
+<script src="/node_modules/preline/dist/preline.js"></script>
+<script>
+    document.addEventListener("alpine:init", () => {
+        Alpine.store("profile", {
+            imageSrc: null, // Stores the captured image
+        });
+    });
+    document.addEventListener("alpine:init", () => {
+        Alpine.data("cameraComponent", () => ({
+            stream: null,
+            photoCaptured: false,
+            lastCapturedImage: null,
+            loading: false,
+
+            init() {
+                setTimeout(() => {
+                    if (typeof HSOverlay === "undefined") {
+                        console.error("HSOverlay is not defined. Make sure Preline.js is loaded before this script.");
+                        return;
+                    }
+                
+                    const modalInstance = HSOverlay.getInstance("#camera-modal", true);
+                    if (!modalInstance) {
+                        console.error("HSOverlay instance not found for #camera-modal");
+                        return;
+                    }
+                
+                    const modalElement = modalInstance.element;
+                
+                    modalElement.on("open", () => {
+                        this.openModal()
+                    });
+                
+                    modalElement.on("close", () => {
+                        this.closeModal()
+                    });
+                
+                }, 500);
+            },
+    
+            async openModal() {
+                this.resetState();
+                this.startCamera();
+            },
+    
+            async startCamera() {
+                this.loading = true;
+                try {
+                    this.stream = await navigator.mediaDevices.getUserMedia({ video: true });
+                    this.$refs.video.srcObject = this.stream;
+    
+                    this.$refs.video.onloadedmetadata = () => {
+                        this.loading = false;
+                    };
+                } catch (error) {
+                    HSOverlay.close('#camera-modal');
+                    alert("Could not access camera. Please allow camera permissions.");
+                }
+            },
+    
+            capturePhoto() {
+                const context = this.$refs.canvas.getContext("2d");
+                this.$refs.canvas.width = this.$refs.video.videoWidth;
+                this.$refs.canvas.height = this.$refs.video.videoHeight;
+                context.drawImage(this.$refs.video, 0, 0, this.$refs.canvas.width, this.$refs.canvas.height);
+    
+                this.lastCapturedImage = this.$refs.canvas.toDataURL("image/png");
+                this.photoCaptured = true;
+                this.stopCamera();
+            },
+    
+            retakePhoto() {
+                this.lastCapturedImage = null;
+                this.photoCaptured = false;
+                this.startCamera();
+            },
+    
+            confirmPhoto() {
+                Alpine.store("profile").imageSrc = this.lastCapturedImage;
+            },
+    
+            stopCamera() {
+                if (this.stream) {
+                    this.stream.getTracks().forEach(track => track.stop());
+                    this.stream = null;
+                }
+            },
+    
+            closeModal() {
+                this.stopCamera();
+                this.$dispatch('close-modal', { modalId: 'camera-modal' });
+            },
+    
+            resetState() {
+                this.photoCaptured = false;
+                this.lastCapturedImage = null;
+            }
+        }));
+
+    
+        Alpine.store("profile", {
+            imageSrc: null,
+        });
+    });
+</script>
+{% endblock extra_scripts %}

--- a/src/simba/students/includes/capture_and_preview_image_modal.html
+++ b/src/simba/students/includes/capture_and_preview_image_modal.html
@@ -1,0 +1,61 @@
+
+  <!-- Add Discount Modal -->
+  <div id="camera-modal" x-data="cameraComponent()" class="hs-overlay hidden size-full fixed top-0 start-0 z-[80] overflow-x-hidden overflow-y-auto [--close-when-click-inside:true] pointer-events-none" role="dialog" tabindex="-1" aria-labelledby="camera-modal-label">
+    <div class="hs-overlay-open:mt-7 hs-overlay-open:opacity-100 hs-overlay-open:duration-500 mt-0 opacity-0 ease-out transition-all sm:max-w-lg sm:w-full m-3 sm:mx-auto h-[calc(100%-3.5rem)] min-h-[calc(100%-3.5rem)] flex items-center">
+      <div class="w-full max-h-full flex flex-col bg-white rounded-xl pointer-events-auto shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)] dark:bg-neutral-800">
+        <!-- Header -->
+        <div class="py-3 px-4 flex justify-between items-center border-b border-stone-200 dark:border-neutral-700">
+          <h3 id="camera-modal-label" class="font-semibold text-stone-800 dark:text-neutral-200">
+            Capture Image
+          </h3>
+          <button type="button" @click="closeModal" class="size-8 inline-flex justify-center items-center gap-x-2 rounded-full border border-transparent bg-stone-100 text-stone-800 hover:bg-stone-200 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-stone-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:text-neutral-400 dark:focus:bg-neutral-600" aria-label="Close"  onclick="HSOverlay.close('#camera-modal')">
+            <span class="sr-only">Close</span>
+            <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M18 6 6 18" />
+              <path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </div>
+        <!-- End Header -->
+
+        <!-- Body -->
+        <div class="overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-stone-100 [&::-webkit-scrollbar-thumb]:bg-stone-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500">
+          <div class="p-4 text-center relative w-full h-auto">
+            <div id="video-container" class="relative w-full h-auto">
+                <svg x-cloak x-show="loading" class="animate-spin m-auto size-8 text-green-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                <video x-ref="video" class="w-full h-auto rounded-lg" autoplay playsinline disablePictureInPicture x-cloak x-show="!photoCaptured && !loading"></video>
+                <canvas x-ref="canvas" :class="{'hidden': !photoCaptured}" class="w-full h-auto rounded-lg"></canvas>
+            </div>
+         </div>
+        
+        </div>
+      <!-- End Body -->
+
+        <!-- Footer -->
+        <div class="p-4 flex justify-center items-center gap-x-2">
+          <button x-cloak x-show="photoCaptured" @click="retakePhoto" :disabled="loading" type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-800 focus:outline-hidden focus:bg-gray-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
+            <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/></svg>
+            Retake Photo
+          </button>
+
+          <button x-cloak x-show="!photoCaptured" @click="capturePhoto" :disabled="loading" type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-800 focus:outline-hidden focus:bg-gray-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
+            <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 9a3.75 3.75 0 1 0 0 7.5A3.75 3.75 0 0 0 12 9Z" />
+              <path fill-rule="evenodd" d="M9.344 3.071a49.52 49.52 0 0 1 5.312 0c.967.052 1.83.585 2.332 1.39l.821 1.317c.24.383.645.643 1.11.71.386.054.77.113 1.152.177 1.432.239 2.429 1.493 2.429 2.909V18a3 3 0 0 1-3 3h-15a3 3 0 0 1-3-3V9.574c0-1.416.997-2.67 2.429-2.909.382-.064.766-.123 1.151-.178a1.56 1.56 0 0 0 1.11-.71l.822-1.315a2.942 2.942 0 0 1 2.332-1.39ZM6.75 12.75a5.25 5.25 0 1 1 10.5 0 5.25 5.25 0 0 1-10.5 0Zm12-1.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd" />
+            </svg>
+            Take Photo
+          </button>
+
+          <button x-cloak x-show="photoCaptured" @click="confirmPhoto" :disabled="loading" type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-transparent bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:ring-2 focus:ring-green-500" data-hs-overlay="#camera-modal">
+            <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"/><path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7"/><path d="M7 3v4a1 1 0 0 0 1 1h7"/></svg>
+            Save and Continue
+          </button>
+        </div>
+        <!-- End Footer -->
+      </div>
+    </div>
+  </div>
+  <!-- End Add Discount Modal -->

--- a/src/simba/students/includes/personal_info_form.html
+++ b/src/simba/students/includes/personal_info_form.html
@@ -99,14 +99,55 @@
         </label>
         <input id="hs-pro-eapnm" type="email" class="py-2 px-3 block w-full border-stone-200 rounded-lg text-sm text-stone-800 placeholder:text-stone-500 focus:z-10 focus:border-green-600 focus:ring-green-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-neutral-600" placeholder="john.doe@example.com" value="">
       </div>
-      <div>
+      <div x-data>
         <label for="hs-pro-daufvd" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
             Profile picture
           </label>
           
-            <input type="file" name="profile_picture" class="block w-full rounded-lg border border-stone-200 text-sm text-stone-800 file:me-4 file:border-0 file:bg-green-600 file:px-3 file:py-2 file:text-white placeholder:text-stone-500 hover:file:bg-green-700 focus:z-10 focus:border-green-600 focus:outline-none focus:ring-green-600 disabled:pointer-events-none disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:file:bg-neutral-700 dark:file:text-neutral-400 dark:placeholder:text-neutral-500 dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-neutral-600" required="" aria-describedby="id_profile_picture_helptext" id="id_profile_picture">
-            
-        <p class="mt-1.5 text-xs text-stone-500 dark:text-neutral-500">Your image should be square, at least 100x100px, and JPG or PNG. </p>
+          <div data-hs-file-upload='{
+            "url": "/upload",
+            "acceptedFiles": "image/*",
+            "maxFiles": 1,
+            "singleton": true
+          }'>
+            <template data-hs-file-upload-preview="">
+              <div class="size-20">
+                <img class="w-full object-contain rounded-full" data-dz-thumbnail="">
+              </div>
+            </template>
+          
+            <div class="flex flex-wrap items-center gap-3 sm:gap-5">
+              <div class="group">
+                <span id="image-preview-container" class="group-has-[div]:hidden flex shrink-0 justify-center items-center size-20 border-2 border-dotted border-stone-300 text-stone-400 cursor-pointer rounded-full hover:bg-stone-50">
+                  <img :src="$store.profile.imageSrc" x-cloak x-show="$store.profile.imageSrc" class="w-full h-full object-cover rounded-full" />
+                  <svg x-cloak x-show="!$store.profile.imageSrc" class="shrink-0 size-7" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="10"></circle>
+                      <circle cx="12" cy="10" r="3"></circle>
+                      <path d="M7 20.662V19a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v1.662"></path>
+                  </svg>
+                </span>
+              </div>
+
+          
+              <div class="grow">
+                <div class="flex items-center gap-x-2">
+                  <button @click="$dispatch('camera-modal-open')" type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-medium rounded-lg border border-transparent bg-green-600 text-white hover:bg-green-700 focus:outline-hidden focus:bg-green-700 disabled:opacity-50 disabled:pointer-events-none"  data-hs-overlay="#camera-modal">
+                    <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/></svg>
+                    Capture Image
+                  </button>
+                  <button type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-medium rounded-lg border border-transparent bg-green-600 text-white hover:bg-green-700 focus:outline-hidden focus:bg-green-700 disabled:opacity-50 disabled:pointer-events-none" data-hs-file-upload-trigger="">
+                    <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                      <polyline points="17 8 12 3 7 8"></polyline>
+                      <line x1="12" x2="12" y1="3" y2="15"></line>
+                    </svg>
+                    Upload photo
+                  </button>
+                  <button type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-semibold rounded-lg border border-stone-200 bg-white text-stone-500 shadow-2xs hover:bg-stone-50 focus:outline-hidden focus:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none" data-hs-file-upload-clear="">Delete</button>
+                </div>
+              </div>
+            </div>
+          </div>
       </div>
     </div>
     <!-- End Body -->

--- a/src/simba/students/includes/personal_info_form.html
+++ b/src/simba/students/includes/personal_info_form.html
@@ -101,53 +101,53 @@
       </div>
       <div x-data>
         <label for="hs-pro-daufvd" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
-            Profile picture
-          </label>
-          
-          <div data-hs-file-upload='{
-            "url": "/upload",
-            "acceptedFiles": "image/*",
-            "maxFiles": 1,
-            "singleton": true
-          }'>
-            <template data-hs-file-upload-preview="">
-              <div class="size-20">
-                <img class="w-full object-contain rounded-full" data-dz-thumbnail="">
-              </div>
-            </template>
-          
-            <div class="flex flex-wrap items-center gap-3 sm:gap-5">
-              <div class="group">
-                <span id="image-preview-container" class="group-has-[div]:hidden flex shrink-0 justify-center items-center size-20 border-2 border-dotted border-stone-300 text-stone-400 cursor-pointer rounded-full hover:bg-stone-50">
-                  <img :src="$store.profile.imageSrc" x-cloak x-show="$store.profile.imageSrc" class="w-full h-full object-cover rounded-full" />
-                  <svg x-cloak x-show="!$store.profile.imageSrc" class="shrink-0 size-7" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                      <circle cx="12" cy="12" r="10"></circle>
-                      <circle cx="12" cy="10" r="3"></circle>
-                      <path d="M7 20.662V19a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v1.662"></path>
+          Profile picture
+        </label>
+        <div data-hs-file-upload='{
+          "url": "/upload",
+          "acceptedFiles": "image/*",
+          "maxFiles": 1,
+          "singleton": true
+        }'>
+          <template data-hs-file-upload-preview="">
+            <div class="size-20">
+              <img class="w-full object-contain rounded-full" data-dz-thumbnail="">
+            </div>
+          </template>
+        
+          <div class="flex flex-wrap items-center gap-3 sm:gap-5">
+            <div class="group" data-hs-file-upload-previews="" data-hs-file-upload-pseudo-trigger="">
+              <span class="group-has-[div]:hidden flex shrink-0 justify-center items-center size-20 border-2 border-dotted border-stone-300 text-stone-400 cursor-pointer rounded-full hover:bg-stone-50 dark:border-neutral-700 dark:text-neutral-600 dark:hover:bg-neutral-700/50">
+                <img :src="$store.profile.imageSrc" x-cloak x-show="$store.profile.imageSrc" class="size-full shrink-0 object-cover rounded-full" />
+                <svg x-cloak x-show="!$store.profile.imageSrc" class="shrink-0 size-7" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="10"></circle>
+                  <circle cx="12" cy="10" r="3"></circle>
+                  <path d="M7 20.662V19a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v1.662"></path>
+                </svg>
+              </span>
+            </div>
+        
+            <div class="grow">
+              <div class="flex items-center gap-x-2">
+                <button type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-medium rounded-lg border border-transparent bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:ring-2 focus:ring-green-500" data-hs-overlay="#camera-modal">
+                  <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/></svg>
+                  Capture Image
+                </button>
+                <button type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-medium rounded-lg border border-transparent bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:ring-2 focus:ring-green-500" data-hs-file-upload-trigger="">
+                  <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                    <polyline points="17 8 12 3 7 8"></polyline>
+                    <line x1="12" x2="12" y1="3" y2="15"></line>
                   </svg>
-                </span>
-              </div>
-
-          
-              <div class="grow">
-                <div class="flex items-center gap-x-2">
-                  <button @click="$dispatch('camera-modal-open')" type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-medium rounded-lg border border-transparent bg-green-600 text-white hover:bg-green-700 focus:outline-hidden focus:bg-green-700 disabled:opacity-50 disabled:pointer-events-none"  data-hs-overlay="#camera-modal">
-                    <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/></svg>
-                    Capture Image
-                  </button>
-                  <button type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-medium rounded-lg border border-transparent bg-green-600 text-white hover:bg-green-700 focus:outline-hidden focus:bg-green-700 disabled:opacity-50 disabled:pointer-events-none" data-hs-file-upload-trigger="">
-                    <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                      <polyline points="17 8 12 3 7 8"></polyline>
-                      <line x1="12" x2="12" y1="3" y2="15"></line>
-                    </svg>
-                    Upload photo
-                  </button>
-                  <button type="button" class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-semibold rounded-lg border border-stone-200 bg-white text-stone-500 shadow-2xs hover:bg-stone-50 focus:outline-hidden focus:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none" data-hs-file-upload-clear="">Delete</button>
-                </div>
+                  Upload photo
+                </button>
+                <button type="button"  @click="Alpine.store('profile').imageSrc = null" class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-medium rounded-lg border border-stone-200 bg-white text-red-500 shadow-2xs hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-stone-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-red-500 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" data-hs-file-upload-clear="">
+                  Delete
+                </button>
               </div>
             </div>
           </div>
+        </div>
       </div>
     </div>
     <!-- End Body -->


### PR DESCRIPTION

- This update enables staff to capture and set student profile images during enrollment. 
- Staff can take a photo using the camera, preview it, and either confirm or retake the image. 
- Additionally, staff can delete the image if needed.
