### PR TITLE
ui: Add usage UI to institute settings

### DIFF
--- a/src/_data/storage_logs.json
+++ b/src/_data/storage_logs.json
@@ -1,0 +1,152 @@
+[
+    {
+        "date": "April 30, 2025",
+        "active_storage": "834.7 MB",
+        "bandwidth_used": "1.2 MB"
+    },
+    {
+        "date": "April 29, 2025",
+        "active_storage": "812.3 MB",
+        "bandwidth_used": "1.1 MB"
+    },
+    {
+        "date": "April 28, 2025",
+        "active_storage": "795.8 MB",
+        "bandwidth_used": "985.2 KB"
+    },
+    {
+        "date": "April 27, 2025",
+        "active_storage": "768.4 MB",
+        "bandwidth_used": "912.0 KB"
+    },
+    {
+        "date": "April 26, 2025",
+        "active_storage": "745.2 MB",
+        "bandwidth_used": "856.4 KB"
+    },
+    {
+        "date": "April 25, 2025",
+        "active_storage": "723.1 MB",
+        "bandwidth_used": "812.7 KB"
+    },
+    {
+        "date": "April 24, 2025",
+        "active_storage": "702.4 MB",
+        "bandwidth_used": "785.3 KB"
+    },
+    {
+        "date": "April 23, 2025",
+        "active_storage": "685.8 MB",
+        "bandwidth_used": "756.0 KB"
+    },
+    {
+        "date": "April 22, 2025",
+        "active_storage": "662.3 MB",
+        "bandwidth_used": "724.5 KB"
+    },
+    {
+        "date": "April 21, 2025",
+        "active_storage": "645.8 MB",
+        "bandwidth_used": "698.2 KB"
+    },
+    {
+        "date": "April 20, 2025",
+        "active_storage": "634.2 MB",
+        "bandwidth_used": "645.7 KB"
+    },
+    {
+        "date": "April 19, 2025",
+        "active_storage": "622.7 MB",
+        "bandwidth_used": "612.3 KB"
+    },
+    {
+        "date": "April 18, 2025",
+        "active_storage": "612.3 MB",
+        "bandwidth_used": "585.8 KB"
+    },
+    {
+        "date": "April 17, 2025",
+        "active_storage": "598.6 MB",
+        "bandwidth_used": "534.2 KB"
+    },
+    {
+        "date": "April 16, 2025",
+        "active_storage": "585.2 MB",
+        "bandwidth_used": "498.6 KB"
+    },
+    {
+        "date": "April 15, 2025",
+        "active_storage": "572.8 MB",
+        "bandwidth_used": "456.3 KB"
+    },
+    {
+        "date": "April 14, 2025",
+        "active_storage": "558.4 MB",
+        "bandwidth_used": "423.7 KB"
+    },
+    {
+        "date": "April 13, 2025",
+        "active_storage": "545.6 MB",
+        "bandwidth_used": "398.2 KB"
+    },
+    {
+        "date": "April 12, 2025",
+        "active_storage": "532.3 MB",
+        "bandwidth_used": "365.4 KB"
+    },
+    {
+        "date": "April 11, 2025",
+        "active_storage": "518.7 MB",
+        "bandwidth_used": "334.8 KB"
+    },
+    {
+        "date": "April 10, 2025",
+        "active_storage": "505.2 MB",
+        "bandwidth_used": "312.5 KB"
+    },
+    {
+        "date": "April 9, 2025",
+        "active_storage": "492.8 MB",
+        "bandwidth_used": "285.6 KB"
+    },
+    {
+        "date": "April 8, 2025",
+        "active_storage": "478.4 MB",
+        "bandwidth_used": "256.0 KB"
+    },
+    {
+        "date": "April 7, 2025",
+        "active_storage": "465.2 MB",
+        "bandwidth_used": "228.4 KB"
+    },
+    {
+        "date": "April 6, 2025",
+        "active_storage": "452.7 MB",
+        "bandwidth_used": "196.8 KB"
+    },
+    {
+        "date": "April 5, 2025",
+        "active_storage": "438.3 MB",
+        "bandwidth_used": "168.2 KB"
+    },
+    {
+        "date": "April 4, 2025",
+        "active_storage": "425.6 MB",
+        "bandwidth_used": "142.5 KB"
+    },
+    {
+        "date": "April 3, 2025",
+        "active_storage": "412.8 MB",
+        "bandwidth_used": "118.7 KB"
+    },
+    {
+        "date": "April 2, 2025",
+        "active_storage": "398.4 MB",
+        "bandwidth_used": "92.3 KB"
+    },
+    {
+        "date": "April 1, 2025",
+        "active_storage": "385.2 MB",
+        "bandwidth_used": "64.0 KB"
+    }
+] 

--- a/src/usage/empty.html
+++ b/src/usage/empty.html
@@ -1,0 +1,68 @@
+---
+slug: usage/empty
+---
+
+{% extends "layouts/admin_base.html" %}
+
+{% block body_class %}overflow-y-scroll min-h-screen bg-gray-100{% endblock %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto xl:px-8 py-8 lg:grid lg:grid-cols-12 lg:gap-x-5" x-data="{ selectedMonth: 'April 2025' }">
+  <!-- Admin Sidebar -->
+  {% include "partials/admin_sidebar.html" %}
+
+  <!-- Main Content -->
+  <div class="space-y-6 sm:px-6 lg:px-0 lg:col-span-9">
+    <div class="flex flex-1 flex-col bg-gray-100">
+      <div class="flex-1 pb-8 pt-1">
+        <!-- Header Section -->
+        <header class="flex items-center justify-between border-b border-gray-200 px-6 py-4 lg:flex-none sm:px-0">
+          <div>
+            <h1 class="text-xl font-semibold text-gray-900">Storage Usage</h1>
+          </div>
+          <div class="flex items-center">
+            <div class="relative">
+              <select
+                x-model="selectedMonth"
+                class="block w-48 rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6"
+              >
+                <option>April 2025</option>
+                <option>March 2025</option>
+                <option>February 2025</option>
+              </select>
+            </div>
+          </div>
+        </header>
+
+
+        <!-- Table Section -->
+        <div class="sm:block mt-6">
+          <div class="mx-auto max-w-6xl">
+            <div class="mt-2 flex flex-col">
+              <div class="min-w-full overflow-hidden overflow-x-auto align-middle shadow sm:rounded-lg">
+                  {% include "./includes/empty.html" %}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Update Notice -->
+        <div class="mt-6">
+          <div class="rounded-md bg-blue-50 p-4">
+            <div class="flex">
+              <div class="flex-shrink-0">
+                <svg class="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clip-rule="evenodd" />
+                </svg>
+              </div>
+              <div class="ml-3">
+                <p class="text-sm text-blue-700">This will get updated every 24hrs.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %} 

--- a/src/usage/includes/empty.html
+++ b/src/usage/includes/empty.html
@@ -1,0 +1,4 @@
+<div class="text-center py-12">
+  <h3 class="mt-2 text-sm font-medium text-gray-900">No records found</h3>
+  <p class="mt-1 text-sm text-gray-500">Storage usage data will appear here once available.</p>
+</div> 

--- a/src/usage/includes/list_table.html
+++ b/src/usage/includes/list_table.html
@@ -1,0 +1,17 @@
+<div class="overflow-x-auto w-full">
+  <table class="min-w-full divide-y divide-gray-200">
+    {% include "./table_header.html" %}
+    <tbody class="divide-y divide-gray-200 bg-white">
+      {% for storage_log in storage_logs %}
+        <tr>
+            {% include "./table_item.html" %}
+        </tr>
+      {% endfor %}
+      {% if not storage_logs %}
+      <tr>
+        <td colspan="2" class="p-8 text-center text-sm">No Records Found</td>
+      </tr>
+      {% endif %}
+    </tbody>
+  </table>
+</div> 

--- a/src/usage/includes/table_header.html
+++ b/src/usage/includes/table_header.html
@@ -1,0 +1,13 @@
+<thead class="bg-gray-50">
+  <tr>
+    <th scope="col" class="px-6 py-3 text-left text-sm font-semibold text-gray-900">
+      Date
+    </th>
+    <th scope="col" class="px-6 py-3 text-left text-sm font-semibold text-gray-900">
+      Bandwidth
+    </th>
+    <th scope="col" class="px-6 py-3 text-left text-sm font-semibold text-gray-900">
+      Storage
+    </th>
+  </tr>
+</thead> 

--- a/src/usage/includes/table_item.html
+++ b/src/usage/includes/table_item.html
@@ -1,0 +1,9 @@
+<td class="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+    <span class="font-medium text-gray-600">{{storage_log.date}}</span>
+</td>
+<td class="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+    <span class="font-medium text-gray-600">{{storage_log.bandwidth_used}}</span>
+</td> 
+<td class="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+    <span class="font-medium text-gray-600">{{storage_log.active_storage}}</span>
+</td> 

--- a/src/usage/index.html
+++ b/src/usage/index.html
@@ -20,7 +20,18 @@ title: Usage
         <!-- Header Section -->
         <header class="flex items-center justify-between px-6 py-4 lg:flex-none sm:px-0">
           <div>
-            <h1 class="text-xl font-semibold text-gray-900">Usage</h1>
+            <h1 class="text-xl font-semibold text-gray-900">Usage
+              <span class="hs-tooltip [--placement:right] inline-block align-middle">
+                <svg class="shrink-0 size-4 text-stone-500 dark:text-neutral-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M12 16v-4" />
+                  <path d="M12 8h.01" />
+                </svg>
+                <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 transition-opacity hidden invisible z-60 max-w-60 py-1 px-2 bg-stone-900 text-xs font-normal text-white rounded-lg shadow-2xs dark:bg-neutral-700" role="tooltip">
+                  This will get updated every 24hrs.
+                </span>
+              </span>
+            </h1>
           </div>
           <div class="flex items-center">
             <div class="relative">
@@ -88,7 +99,7 @@ title: Usage
           <div class="mx-auto max-w-6xl">
             <div class="mt-2 flex flex-col">
               <div class="border border-gray-200 rounded-lg shadow">
-                <div class="h-[calc(100vh-24rem)] overflow-y-auto">
+                <div class="overflow-y-auto">
                   <div class="min-w-full overflow-x-auto align-middle">
                     {% if request.query.empty %}
                       {% include "./includes/empty.html" %}
@@ -97,22 +108,6 @@ title: Usage
                     {% endif %}
                   </div>
                 </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Update Notice -->
-        <div class="mt-6">
-          <div class="rounded-md bg-blue-50 p-4">
-            <div class="flex">
-              <div class="flex-shrink-0">
-                <svg class="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor">
-                  <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clip-rule="evenodd" />
-                </svg>
-              </div>
-              <div class="ml-3">
-                <p class="text-sm text-blue-700">This will get updated every 24hrs.</p>
               </div>
             </div>
           </div>

--- a/src/usage/index.html
+++ b/src/usage/index.html
@@ -1,0 +1,124 @@
+---
+slug: usage
+tags: testpress
+title: Usage
+---
+
+{% extends "layouts/admin_base.html" %}
+
+{% block body_class %}overflow-y-scroll min-h-screen bg-gray-100{% endblock %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto xl:px-8 py-8 lg:grid lg:grid-cols-12 lg:gap-x-5" x-data="{ selectedMonth: 'April 2025' }">
+  <!-- Admin Sidebar -->
+  {% include "partials/admin_sidebar.html" %}
+
+  <!-- Main Content -->
+  <div class="space-y-6 sm:px-6 lg:px-0 lg:col-span-9">
+    <div class="flex flex-1 flex-col bg-gray-100">
+      <div class="flex-1 pb-8 pt-1">
+        <!-- Header Section -->
+        <header class="flex items-center justify-between px-6 py-4 lg:flex-none sm:px-0">
+          <div>
+            <h1 class="text-xl font-semibold text-gray-900">Usage</h1>
+          </div>
+          <div class="flex items-center">
+            <div class="relative">
+              <select
+                x-model="selectedMonth"
+                class="block w-48 rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6"
+              >
+                <option>April 2025</option>
+                <option>March 2025</option>
+                <option>February 2025</option>
+              </select>
+            </div>
+          </div>
+        </header>
+
+        <!-- Usage Stats Cards -->
+        <div class="mt-4">
+          <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-2">
+            <!-- Bandwidth Usage Card -->
+            <div class="overflow-hidden rounded-lg bg-white shadow">
+              <div class="p-5">
+                <div class="flex items-center">
+                  <div class="flex-shrink-0">
+                    <svg class="h-6 w-6 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                    </svg>
+                  </div>
+                  <div class="ml-5 w-0 flex-1">
+                    <dl>
+                      <dt class="text-sm font-medium text-gray-500 truncate">Total Bandwidth Used</dt>
+                      <dd class="flex items-baseline">
+                        <div class="text-2xl font-semibold text-gray-900">264.0 GB</div>
+                      </dd>
+                    </dl>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Storage Usage Card -->
+            <div class="overflow-hidden rounded-lg bg-white shadow">
+              <div class="p-5">
+                <div class="flex items-center">
+                  <div class="flex-shrink-0">
+                    <svg class="h-6 w-6 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
+                    </svg>
+                  </div>
+                  <div class="ml-5 w-0 flex-1">
+                    <dl>
+                      <dt class="text-sm font-medium text-gray-500 truncate">Total Storage Used</dt>
+                      <dd class="flex items-baseline">
+                        <div class="text-2xl font-semibold text-gray-900">1.2 TB</div>
+                      </dd>
+                    </dl>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Table Section -->
+        <div class="sm:block mt-6 mb-6">
+          <div class="mx-auto max-w-6xl">
+            <div class="mt-2 flex flex-col">
+              <div class="border border-gray-200 rounded-lg shadow">
+                <div class="h-[calc(100vh-24rem)] overflow-y-auto">
+                  <div class="min-w-full overflow-x-auto align-middle">
+                    {% if request.query.empty %}
+                      {% include "./includes/empty.html" %}
+                    {% else %}
+                      {% include "./includes/list_table.html" %}
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Update Notice -->
+        <div class="mt-6">
+          <div class="rounded-md bg-blue-50 p-4">
+            <div class="flex">
+              <div class="flex-shrink-0">
+                <svg class="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clip-rule="evenodd" />
+                </svg>
+              </div>
+              <div class="ml-3">
+                <p class="text-sm text-blue-700">This will get updated every 24hrs.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %} 


### PR DESCRIPTION
- This commit adds usage UI in institute settings page with daily breakdown.
- This has been taken from [email_analytics ui](https://design.testpress.in/email_analtyics/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new admin dashboard to monitor daily storage and bandwidth usage.
  - Displayed usage data through interactive tables and informative cards.
  - Added a month selection option to filter usage statistics.
  - Included clear notifications for data updates and empty record states.
  - New HTML templates for displaying storage logs and usage statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->