### PR TITLE
Add UI for platform preference in OTT

### DIFF
--- a/src/flimix/partials/sidebar.html
+++ b/src/flimix/partials/sidebar.html
@@ -193,8 +193,8 @@
           <li><a href="/flimix/settings/domain_management/"
               class="hover:bg-gray-50 block rounded-md py-2 pr-2 pl-9 text-sm leading-6 text-gray-700 {% if 'flimix/settings/domain_management' in page.url %}bg-gray-50{% endif %}">Domain
               Management</a></li>
-          <li><a href="#"
-              class="hover:bg-gray-50 block rounded-md py-2 pr-2 pl-9 text-sm leading-6 text-gray-700">Platform
+          <li><a href="/flimix/settings/platform_preference/"
+              class="hover:bg-gray-50 block rounded-md py-2 pr-2 pl-9 text-sm leading-6 text-gray-700 {% if 'flimix/settings/platform_preference' in page.url %}bg-gray-50{% endif %} ">Platform
               Preferences</a></li>
           <li><a href="/flimix/settings/staff_management/" class="hover:bg-gray-50 block rounded-md py-2 pr-2 pl-9 text-sm leading-6 text-gray-700 {% if 'flimix/settings/staff_management' in page.url %}bg-gray-50{% endif %}">Staff
               Management</a></li>

--- a/src/flimix/settings/platform_preference/general/index.html
+++ b/src/flimix/settings/platform_preference/general/index.html
@@ -1,0 +1,36 @@
+---
+permalink: flimix/settings/platform_preference/
+tags: flimix
+view: "Settings"
+title: Platform Preference
+---
+
+
+{% extends "src/flimix/layouts/sidebar_layout.html" %}
+{% block main_class %}bg-stone-50 min-h-[92vh]{% endblock %}
+
+
+{% block main_content %}
+<div class="space-y-5">
+  {% include "../includes/header.html" %}
+  {% include "./tabs.html" %}
+
+  <form>
+    <div class="space-y-12">
+
+        {% include "./organization_info.html" %}
+        {% include "./localization.html" %}
+        {% include "./theme_preference.html" %}
+
+    </div>
+
+    <div class="mt-6 flex items-center justify-end gap-x-6">
+      <button type="button" class="text-sm/6 font-semibold text-gray-900">Cancel</button>
+      <button type="submit"
+        class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Save</button>
+    </div>
+  </form>
+
+</div>
+
+{% endblock main_content %}

--- a/src/flimix/settings/platform_preference/general/localization.html
+++ b/src/flimix/settings/platform_preference/general/localization.html
@@ -1,0 +1,189 @@
+<div
+class="grid grid-cols-1 gap-x-8  border-b border-gray-900/10 pb-12 md:grid-cols-12 gap-y-1.5 md:gap-y-0 md:gap-x-5 lg:gap-x-8">
+<div class="md:col-span-4 flex flex-col mb-3 md:mb-0">
+  <div class="space-y-2">
+    <h2 class="font-medium text-stone-800 dark:text-neutral-200">
+      Localization
+    </h2>
+    <p class="text-sm text-stone-500 dark:text-neutral-500">
+      Configure default language, available UI languages, and timezone for the platform.
+    </p>
+  </div>
+</div>
+<!-- End Col -->
+
+<div class="md:col-span-8">
+  <!-- Business Vertical Settings Card -->
+  <div
+    class="p-5 space-y-5 flex flex-col bg-white border border-stone-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+    <!-- Input Grid -->
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <!-- Input -->
+      <!-- End Input -->
+
+      <!-- Input -->
+      <div>
+        <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Default Language
+        </label>
+        <!-- Language Select -->
+        <div class="relative">
+          <select id="hs-pro-select-language" data-hs-select='{
+    "placeholder": "Select Language",
+    "toggleTag": "<button type=\"button\" aria-expanded=\"false\"><div data-icon></div></button>",
+    "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 relative py-2 px-3 pe-7 flex items-center gap-x-2 text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm text-gray-800 hover:border-gray-300 focus:outline-hidden focus:border-gray-300 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-200 dark:hover:border-neutral-700 dark:focus:border-neutral-700",
+    "dropdownClasses": "end-0 w-full min-w-45 max-h-72 p-1 space-y-0.5 z-50 w-full overflow-hidden overflow-y-auto bg-white rounded-xl shadow-xl [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500 dark:bg-neutral-900",
+    "optionClasses": "hs-selected:bg-gray-100 dark:hs-selected:bg-neutral-800 py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800",
+    "optionTemplate": "<div><div class=\"flex items-center gap-x-2\"><div data-icon></div><div class=\"text-gray-800 dark:text-neutral-200 \" data-title></div><span class=\"hidden hs-selected:block ms-auto\"><svg class=\"shrink-0 size-3.5 text-gray-800 dark:text-neutral-200 \" xmlns=\"http:.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"20 6 9 17 4 12\"/></svg></span></div></div>"
+  }' class="hidden">
+            <option value="">Choose</option>
+            <option value="en" selected>English</option>
+            <option value="hi">Hindi</option>
+            <option value="ta">Tamil</option>
+            <option value="te">Telugu</option>
+            <option value="ml">Malayalam</option>
+            <option value="kn">Kannada</option>
+            <option value="mr">Marathi</option>
+            <option value="gu">Gujarati</option>
+            <option value="bn">Bengali</option>
+            <option value="pa">Punjabi</option>
+            <option value="ur">Urdu</option>
+            <option value="as">Assamese</option>
+            <option value="or">Odia</option>
+            <option value="fr">French</option>
+            <option value="es">Spanish</option>
+            <option value="de">German</option>
+            <option value="zh">Chinese</option>
+            <option value="ja">Japanese</option>
+            <option value="ko">Korean</option>
+            <option value="ar">Arabic</option>
+
+          </select>
+
+          <div class="absolute top-1/2 end-2.5 -translate-y-1/2">
+            <svg class="shrink-0 size-3.5 text-gray-500 dark:text-neutral-500"
+              xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m7 15 5 5 5-5" />
+              <path d="m7 9 5-5 5 5" />
+            </svg>
+          </div>
+          <!-- End Header -->
+        </div>
+        <!-- End Language Select -->
+      </div>
+      <!-- End Input -->
+
+      <!-- Input -->
+      <div>
+        <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Timezone
+        </label>
+        <div class="relative">
+          <select id="hs-pro-select-language" data-hs-select='{
+            "placeholder": "Select Language",
+            "toggleTag": "<button type=\"button\" aria-expanded=\"false\"><div data-icon></div></button>",
+            "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 relative py-2 px-3 pe-7 flex items-center gap-x-2 text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm text-gray-800 hover:border-gray-300 focus:outline-hidden focus:border-gray-300 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-200 dark:hover:border-neutral-700 dark:focus:border-neutral-700",
+            "dropdownClasses": "end-0 w-full min-w-45 max-h-72 p-1 space-y-0.5 z-50 w-full overflow-hidden overflow-y-auto bg-white rounded-xl shadow-xl [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500 dark:bg-neutral-900",
+            "optionClasses": "hs-selected:bg-gray-100 dark:hs-selected:bg-neutral-800 py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800",
+            "optionTemplate": "<div><div class=\"flex items-center gap-x-2\"><div data-icon></div><div class=\"text-gray-800 dark:text-neutral-200 \" data-title></div><span class=\"hidden hs-selected:block ms-auto\"><svg class=\"shrink-0 size-3.5 text-gray-800 dark:text-neutral-200 \" xmlns=\"http:.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"20 6 9 17 4 12\"/></svg></span></div></div>"
+          }' class="hidden">
+            <option value="">Choose</option>
+            <option value="Asia/Kolkata" selected>Asia/Kolkata (IST)</option>
+            <option value="UTC">UTC (Coordinated Universal Time)</option>
+            <option value="Asia/Dubai">Asia/Dubai (GST)</option>
+            <option value="Asia/Shanghai">Asia/Shanghai (CST)</option>
+            <option value="Asia/Tokyo">Asia/Tokyo (JST)</option>
+            <option value="Europe/London">Europe/London (GMT/BST)</option>
+            <option value="Europe/Berlin">Europe/Berlin (CET/CEST)</option>
+            <option value="Europe/Paris">Europe/Paris (CET/CEST)</option>
+            <option value="America/New_York">America/New_York (EST/EDT)</option>
+            <option value="America/Chicago">America/Chicago (CST/CDT)</option>
+            <option value="America/Los_Angeles">America/Los_Angeles (PST/PDT)</option>
+            <option value="Australia/Sydney">Australia/Sydney (AEST/AEDT)</option>
+            <option value="Asia/Bangkok">Asia/Bangkok (ICT)</option>
+            <option value="Asia/Jakarta">Asia/Jakarta (WIB)</option>
+            <option value="Asia/Singapore">Asia/Singapore (SGT)</option>
+            <option value="Asia/Seoul">Asia/Seoul (KST)</option>
+            <option value="Asia/Hong_Kong">Asia/Hong_Kong (HKT)</option>
+            <option value="Asia/Kathmandu">Asia/Kathmandu (NPT)</option>
+            <option value="America/Toronto">America/Toronto (EST/EDT)</option>
+          </select>
+
+          <div class="absolute top-1/2 end-2.5 -translate-y-1/2">
+            <svg class="shrink-0 size-3.5 text-gray-500 dark:text-neutral-500"
+              xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m7 15 5 5 5-5" />
+              <path d="m7 9 5-5 5 5" />
+            </svg>
+          </div>
+          <!-- End Header -->
+        </div>
+      </div>
+      <!-- End Input -->
+    </div>
+    <!-- End Input Grid -->
+
+    <!-- Input Grid -->
+    <div class="col-span-2">
+      <label for="hs-pro-esssa" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+        Available Languages
+      </label>
+      <div class="relative w-full">
+        <select id="hs-pro-select-tags" multiple data-hs-select='{"placeholder": "Select available languages...",
+        "dropdownClasses": "mt-2 z-50 w-full max-h-72 p-1 space-y-0.5 bg-white border border-gray-200 rounded-lg overflow-hidden overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500 dark:bg-neutral-900 dark:border-neutral-700",
+        "optionClasses": "py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-none focus:bg-gray-100 hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 dark:bg-neutral-900 dark:hover:bg-neutral-800 dark:text-neutral-200 dark:focus:bg-neutral-800",
+        "mode": "tags",
+        "wrapperClasses": "relative ps-0.5 pe-9 flex items-center flex-wrap text-nowrap w-full border border-gray-200 rounded-lg text-start text-sm focus:border-emerald-500 focus:ring-emerald-500 dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-400",
+        "tagsItemTemplate": "<div class=\"flex flex-nowrap items-center relative z-10 bg-white border border-gray-200 rounded-full p-1 m-1 dark:bg-neutral-900 dark:border-neutral-700 \"><div class=\"size-6 me-1 text-xs\" data-icon></div><div class=\"whitespace-nowrap text-gray-800 dark:text-neutral-200 \" data-title></div><div class=\"inline-flex shrink-0 justify-center items-center size-5 ms-2 rounded-full text-gray-800 bg-gray-200 hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 text-sm dark:bg-neutral-700/50 dark:hover:bg-neutral-700 dark:text-neutral-400 cursor-pointer\" data-remove><svg class=\"shrink-0 size-3\" xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M18 6 6 18\"/><path d=\"m6 6 12 12\"/></svg></div></div>",
+        "tagsInputClasses": "focus:ring-0 border-0 py-2 px-3 rounded-lg order-1 text-sm outline-none dark:bg-neutral-900 dark:placeholder-neutral-500 dark:text-neutral-400",
+        "optionTemplate": "<div class=\"flex items-center\"><div class=\"size-8 me-2 text-xs\" data-icon></div><div><div class=\"text-sm font-semibold text-gray-800 dark:text-neutral-200 \" data-title></div><div class=\"text-xs text-gray-500 dark:text-neutral-500 \" data-description></div></div><div class=\"ms-auto\"><span class=\"hidden hs-selected:block\"><svg class=\"shrink-0 size-4 text-green-600\" xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" fill=\"currentColor\" viewBox=\"0 0 16 16\"><path d=\"M12.736 3.97a.733.733 0 0 1 1.047 0c.286.289.29.756.01 1.05L7.88 12.01a.733.733 0 0 1-1.065.02L3.217 8.384a.757.757 0 0 1 0-1.06.733.733 0 0 1 1.047 0l3.052 3.093 5.4-6.425a.247.247 0 0 1 .02-.022Z\"/></svg></span></div></div>",
+        "extraMarkup": ""
+      }' class="hidden">
+          <option value="">Choose</option>
+          <option value="en" selected>English</option>
+          <option value="hi" selected>Hindi</option>
+          <option value="ta" selected>Tamil</option>
+          <option value="te">Telugu</option>
+          <option value="ml">Malayalam</option>
+          <option value="kn">Kannada</option>
+          <option value="mr">Marathi</option>
+          <option value="gu">Gujarati</option>
+          <option value="bn">Bengali</option>
+          <option value="pa">Punjabi</option>
+          <option value="ur">Urdu</option>
+          <option value="as">Assamese</option>
+          <option value="or">Odia</option>
+          <option value="fr">French</option>
+          <option value="es">Spanish</option>
+          <option value="de">German</option>
+          <option value="zh">Chinese</option>
+          <option value="ja">Japanese</option>
+          <option value="ko">Korean</option>
+          <option value="ar">Arabic</option>
+        </select>
+
+        <div class="absolute top-1/2 end-2.5 -translate-y-1/2">
+          <svg class="shrink-0 size-3.5 text-gray-500 dark:text-neutral-500" xmlns="http://www.w3.org/2000/svg"
+            width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="m7 15 5 5 5-5" />
+            <path d="m7 9 5-5 5 5" />
+          </svg>
+        </div>
+      </div>
+
+      <p class="mt-1.5 text-sm   text-stone-500 dark:text-neutral-500">
+        Allows users to switch between the available languages.
+      </p>
+    </div>
+    <!-- End Input Grid -->
+
+    <!-- Input Grid -->
+
+    <!-- End Input Grid -->
+  </div>
+</div>
+<!-- End Col -->
+</div>

--- a/src/flimix/settings/platform_preference/general/organization_info.html
+++ b/src/flimix/settings/platform_preference/general/organization_info.html
@@ -1,0 +1,114 @@
+<div
+class="grid grid-cols-1 gap-x-8  pt-4 border-b border-gray-900/10 pb-12 md:grid-cols-12 gap-y-1.5 md:gap-y-0 md:gap-x-5 lg:gap-x-8">
+<div class="md:col-span-4 flex flex-col mb-3 md:mb-0">
+  <div class="space-y-2">
+    <h2 class="font-medium text-stone-800 dark:text-neutral-200">
+      Organization Info
+    </h2>
+    <p class="text-sm text-stone-500 dark:text-neutral-500">
+      Basic details about the organization to be shown across the platform.
+    </p>
+  </div>
+</div>
+<!-- End Col -->
+
+<div class="md:col-span-8">
+  <!-- Business Vertical Settings Card -->
+  <div
+    class="p-5 space-y-5 flex flex-col bg-white border border-stone-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+    <!-- Input Grid -->
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <!-- Input -->
+      <div class="col-span-2">
+        <label for="hs-pro-esssn" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Organization Name
+        </label>
+        <input id="hs-pro-esssn" type="text"
+          class="py-1.5 sm:py-2 px-3 block w-full border-stone-200 rounded-lg sm:text-sm text-stone-800 placeholder:text-stone-500 focus:z-10 focus:border-indigo-600 focus:ring-indigo-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:outline-hidden dark:focus:ring-1 dark:focus:ring-neutral-600"
+          value="Art of Living">
+      </div>
+      <!-- End Input -->
+
+      <!-- Input -->
+      <div class="col-span-2">
+        <label for="hs-pro-epii" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Description
+        </label>
+        <textarea id="hs-pro-epii"
+          class="py-1.5 sm:py-2 px-3 block w-full border-stone-200 rounded-lg sm:text-sm text-stone-800 placeholder:text-stone-500 focus:z-10 focus:border-indigo-600 focus:ring-indigo-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:outline-hidden dark:focus:ring-1 dark:focus:ring-neutral-600"
+          rows="3" placeholder="Provide a brief description of your ott platform..."
+          spellcheck="false"></textarea>
+      </div>
+      <!-- End Input -->
+
+      <!-- Input -->
+      <div>
+        <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Email
+        </label>
+        <input id="hs-pro-esscp" type="email"
+          class="py-1.5 sm:py-2 px-3 block w-full border-stone-200 rounded-lg sm:text-sm text-stone-800 placeholder:text-stone-500 focus:z-10 focus:border-indigo-600 focus:ring-indigo-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:outline-hidden dark:focus:ring-1 dark:focus:ring-neutral-600"
+          value="support@verandarace.in">
+      </div>
+      <!-- End Input -->
+
+      <!-- Input -->
+      <div>
+        <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Phone number
+        </label>
+        <input id="hs-pro-esscp" type="text"
+          class="py-1.5 sm:py-2 px-3 block w-full border-stone-200 rounded-lg sm:text-sm text-stone-800 placeholder:text-stone-500 focus:z-10 focus:border-indigo-600 focus:ring-indigo-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:outline-hidden dark:focus:ring-1 dark:focus:ring-neutral-600"
+          value="9876543210">
+      </div>
+      <!-- End Input -->
+    </div>
+    <!-- End Input Grid -->
+
+    <!-- Input Grid -->
+    <div class="col-span-2">
+      <label for="hs-pro-esssa" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+        Address
+      </label>
+      <input id="hs-pro-esssa" type="email"
+        class="py-1.5 sm:py-2 px-3 block w-full border-stone-200 rounded-lg sm:text-sm text-stone-800 placeholder:text-stone-500 focus:z-10 focus:border-indigo-600 focus:ring-indigo-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:outline-hidden dark:focus:ring-1 dark:focus:ring-neutral-600">
+    </div>
+    <!-- End Input Grid -->
+
+    <!-- Input Grid -->
+    <div class="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-5">
+      <!-- Input -->
+      <div class="sm:col-span-1">
+        <label for="hs-pro-esscy" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          City
+        </label>
+        <input id="hs-pro-esscy" type="text"
+          class="py-1.5 sm:py-2 px-3 block w-full border-stone-200 rounded-lg sm:text-sm text-stone-800 placeholder:text-stone-500 focus:z-10 focus:border-indigo-600 focus:ring-indigo-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:outline-hidden dark:focus:ring-1 dark:focus:ring-neutral-600">
+      </div>
+      <!-- End Input -->
+      <!-- Input -->
+      <div class="col-span-1">
+        <label for="hs-pro-essun" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          State
+        </label>
+        <input id="hs-pro-essun" type="text"
+          class="py-1.5 sm:py-2 px-3 block w-full border-stone-200 rounded-lg sm:text-sm text-stone-800 placeholder:text-stone-500 focus:z-10 focus:border-indigo-600 focus:ring-indigo-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:outline-hidden dark:focus:ring-1 dark:focus:ring-neutral-600">
+      </div>
+      <!-- End Input -->
+
+      <!-- Input -->
+      <div class="col-span-1">
+        <label for="hs-pro-esszc" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          ZIP / Postal code
+        </label>
+        <input id="hs-pro-esszc" type="text"
+          class="py-1.5 sm:py-2 px-3 block w-full border-stone-200 rounded-lg sm:text-sm text-stone-800 placeholder:text-stone-500 focus:z-10 focus:border-indigo-600 focus:ring-indigo-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:outline-hidden dark:focus:ring-1 dark:focus:ring-neutral-600">
+      </div>
+      <!-- End Input -->
+    </div>
+    <!-- End Input Grid -->
+  </div>
+  <!-- End Business Vertical Settings Card -->
+</div>
+<!-- End Col -->
+</div>

--- a/src/flimix/settings/platform_preference/general/organization_info.html
+++ b/src/flimix/settings/platform_preference/general/organization_info.html
@@ -48,7 +48,7 @@ class="grid grid-cols-1 gap-x-8  pt-4 border-b border-gray-900/10 pb-12 md:grid-
         </label>
         <input id="hs-pro-esscp" type="email"
           class="py-1.5 sm:py-2 px-3 block w-full border-stone-200 rounded-lg sm:text-sm text-stone-800 placeholder:text-stone-500 focus:z-10 focus:border-indigo-600 focus:ring-indigo-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:outline-hidden dark:focus:ring-1 dark:focus:ring-neutral-600"
-          value="support@verandarace.in">
+          value="artofliving@gmail.com">
       </div>
       <!-- End Input -->
 

--- a/src/flimix/settings/platform_preference/general/tabs.html
+++ b/src/flimix/settings/platform_preference/general/tabs.html
@@ -1,0 +1,20 @@
+<div>
+  <div class="grid grid-cols-1 sm:hidden">
+    <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
+    <select onchange="location.href=this.value"  aria-label="Select a tab" class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600">
+      <option :value="`${previewPath}/flimix/settings/platform_preference/`" selected>General</option>
+      <option :value="`${previewPath}/flimix/settings/platform_preference/player_preference/`">Player Preferences</option>
+      <option :value="`${previewPath}/flimix/settings/platform_preference/integrations/`">Integrations</option>
+    </select>
+  </div>
+  <div class="hidden sm:block">
+    <div class="border-b border-gray-200">
+      <nav class="-mb-px flex space-x-8" aria-label="Tabs">
+        <a :href="`${previewPath}/flimix/settings/platform_preference/`" class="whitespace-nowrap border-b-2 border-indigo-500 px-1 py-4 text-sm font-medium text-indigo-600" aria-current="page">General</a>
+        <!-- Current: "border-indigo-500 text-indigo-600", Default: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700" -->
+        <a :href="`${previewPath}/flimix/settings/platform_preference/player_preference/`" class="whitespace-nowrap border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">Player Preferences</a>
+        <a :href="`${previewPath}/flimix/settings/platform_preference/integrations/`" class="whitespace-nowrap border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">Integrations</a>
+      
+    </div>
+  </div>
+</div>

--- a/src/flimix/settings/platform_preference/general/theme_preference.html
+++ b/src/flimix/settings/platform_preference/general/theme_preference.html
@@ -1,0 +1,89 @@
+<div
+class="grid grid-cols-1 gap-x-8  border-b border-gray-900/10 pb-12 md:grid-cols-12 gap-y-1.5 md:gap-y-0 md:gap-x-5 lg:gap-x-8">
+<div class="md:col-span-4 flex flex-col mb-3 md:mb-0">
+  <div class="space-y-2">
+    <h2 class="font-medium text-stone-800 dark:text-neutral-200">
+      Theme Preferences
+    </h2>
+    <p class="text-sm text-stone-500 dark:text-neutral-500">
+      Control the default visual mode and whether users can toggle between light and dark themes.
+    </p>
+  </div>
+</div>
+<!-- End Col -->
+
+<div class="md:col-span-8">
+  <!-- Business Vertical Settings Card -->
+  <div
+    class="p-5 space-y-5 flex flex-col bg-white border border-stone-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+    <!-- Input Grid -->
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <!-- Input -->
+      <!-- End Input -->
+
+      <!-- Input -->
+      <div>
+        <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Default Theme
+        </label>
+        <!-- Language Select -->
+        <div class="relative">
+          <select id="hs-pro-select-language" data-hs-select='{
+    "placeholder": "Select Theme",
+    "toggleTag": "<button type=\"button\" aria-expanded=\"false\"><div data-icon></div></button>",
+    "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 relative py-2 px-3 pe-7 flex items-center gap-x-2 text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm text-gray-800 hover:border-gray-300 focus:outline-hidden focus:border-gray-300 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-200 dark:hover:border-neutral-700 dark:focus:border-neutral-700",
+    "dropdownClasses": "end-0 w-full min-w-45 max-h-72 p-1 space-y-0.5 z-50 w-full overflow-hidden overflow-y-auto bg-white rounded-xl shadow-xl [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500 dark:bg-neutral-900",
+    "optionClasses": "hs-selected:bg-gray-100 dark:hs-selected:bg-neutral-800 py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800",
+    "optionTemplate": "<div><div class=\"flex items-center gap-x-2\"><div data-icon></div><div class=\"text-gray-800 dark:text-neutral-200 \" data-title></div><span class=\"hidden hs-selected:block ms-auto\"><svg class=\"shrink-0 size-3.5 text-gray-800 dark:text-neutral-200 \" xmlns=\"http:.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"20 6 9 17 4 12\"/></svg></span></div></div>"
+  }' class="hidden">
+            <option value="">Choose</option>
+            <option value="light" selected >Light</option>
+            <option value="dark">Dark</option>
+          </select>
+
+          <div class="absolute top-1/2 end-2.5 -translate-y-1/2">
+            <svg class="shrink-0 size-3.5 text-gray-500 dark:text-neutral-500"
+              xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m7 15 5 5 5-5" />
+              <path d="m7 9 5-5 5 5" />
+            </svg>
+          </div>
+          <!-- End Header -->
+        </div>
+        <!-- End Language Select -->
+      </div>
+      <!-- End Input -->
+
+      <!-- End Input -->
+    </div>
+    <!-- End Input Grid -->
+
+    <!-- Input Grid -->
+    <div class="flex gap-3">
+      <div class="flex h-6 shrink-0 items-center">
+        <div class="group grid size-4 grid-cols-1">
+          <input id="candidates" checked aria-describedby="candidates-description" name="candidates"
+            type="checkbox"
+            class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+          <svg
+            class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+            viewBox="0 0 14 14" fill="none">
+            <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round"></path>
+            <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round"></path>
+          </svg>
+        </div>
+      </div>
+      <div class="text-sm/6">
+        <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">Allow
+          Users to Switch Theme</label>
+        <p id="candidates-description" class="text-stone-500">Allows users to switch between Light and Dark
+          mode.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- End Col -->
+</div>

--- a/src/flimix/settings/platform_preference/includes/header.html
+++ b/src/flimix/settings/platform_preference/includes/header.html
@@ -1,0 +1,6 @@
+<div class="flex flex-wrap justify-between items-center gap-2">
+  <div>
+    <h1 class="text-lg md:text-xl font-semibold text-stone-800 dark:text-neutral-200">Platform Preference</h1>    
+    <p class="text-sm text-stone-500 dark:text-neutral-400">View and manage platform-wide preferences and behavior.</p>
+  </div>
+</div>

--- a/src/flimix/settings/platform_preference/integrations/accounting_and_billing.html
+++ b/src/flimix/settings/platform_preference/integrations/accounting_and_billing.html
@@ -1,0 +1,58 @@
+<div>
+  <h2 class="font-medium text-stone-800 dark:text-neutral-200">
+    Accounting & Billing
+  </h2>
+<p class="mt-1 text-sm text-stone-500 dark:text-neutral-500">
+  Integrate with third-party platforms to automate invoice generation, track payments, and manage financial records.
+</p>
+</div>
+<!-- Card -->
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+  <div
+    class="p-5 space-y-4 flex flex-col bg-white border border-gray-200 rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+    <!-- Header -->
+    <div class="flex justify-between">
+      <div
+        class="flex flex-col justify-center items-center size-9.5 border border-gray-200 rounded-lg dark:border-neutral-700 p-2">
+        <img class="shrink-0 size-5 text-gray-500 dark:text-neutral-500"
+          src="https://www.zohowebstatic.com/sites/zweb/images/favicon.ico" alt="">
+      </div>
+
+      <div>
+        <label for="hs-pro-daicn1"
+          class="relative py-2 px-3 flex items-center justify-center sm:justify-start border border-gray-200 cursor-pointer font-medium text-xs rounded-lg peer-checked:bg-gray-100 hover:border-gray-300 focus:outline-none focus:border-gray-300 dark:border-neutral-700 dark:peer-checked:bg-neutral-800 dark:hover:border-neutral-600 dark:focus:border-neutral-600">
+          <input type="checkbox" id="hs-pro-daicn1" class="peer hidden" checked>
+          <span class="relative z-10 text-gray-800 dark:text-neutral-200 peer-checked:hidden">
+            Connect
+          </span>
+          <span
+            class="relative z-10 hidden peer-checked:flex items-center gap-x-1.5 text-gray-800 dark:text-neutral-200">
+            <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+              fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M20 6 9 17l-5-5" />
+            </svg>
+            Connected
+          </span>
+        </label>
+      </div>
+    </div>
+    <!-- End Header -->
+
+    <!-- Body -->
+    <div>
+      <h3 class="font-medium text-gray-800 dark:text-neutral-200">
+        Zoho
+      </h3>
+
+      <p class="mt-1 text-sm text-gray-500 dark:text-neutral-500">
+        Integrate Zoho CRM and Books for seamless lead, contact, and invoice management.
+      </p>
+    </div>
+    <!-- End Body -->
+
+    <button type="button"
+      class="py-2 px-3 w-full inline-flex justify-center items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
+      View integration
+    </button>
+  </div>
+</div>

--- a/src/flimix/settings/platform_preference/integrations/analytics.html
+++ b/src/flimix/settings/platform_preference/integrations/analytics.html
@@ -1,0 +1,58 @@
+<div>
+  <h2 class="font-medium text-stone-800 dark:text-neutral-200">
+    Analytics & Tracking
+  </h2>
+<p class="mt-1 text-sm text-stone-500 dark:text-neutral-500">
+  Connect analytics tools to monitor user behavior, content performance, and platform metrics in real time.
+</p>
+</div>
+<!-- Card -->
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+  <div
+    class="p-5 space-y-4 flex flex-col bg-white border border-gray-200 rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+    <!-- Header -->
+    <div class="flex justify-between">
+      <div
+        class="flex flex-col justify-center items-center size-9.5 border border-gray-200 rounded-lg dark:border-neutral-700 p-2">
+        <img class="shrink-0 size-5 text-gray-500 dark:text-neutral-500"
+          src="https://www.vectorlogo.zone/logos/google/google-icon.svg" alt="">
+      </div>
+
+      <div>
+        <label for="hs-pro-daicn1"
+          class="relative py-2 px-3 flex items-center justify-center sm:justify-start border border-gray-200 cursor-pointer font-medium text-xs rounded-lg peer-checked:bg-gray-100 hover:border-gray-300 focus:outline-none focus:border-gray-300 dark:border-neutral-700 dark:peer-checked:bg-neutral-800 dark:hover:border-neutral-600 dark:focus:border-neutral-600">
+          <input type="checkbox" id="hs-pro-daicn1" class="peer hidden" checked>
+          <span class="relative z-10 text-gray-800 dark:text-neutral-200 peer-checked:hidden">
+            Connect
+          </span>
+          <span
+            class="relative z-10 hidden peer-checked:flex items-center gap-x-1.5 text-gray-800 dark:text-neutral-200">
+            <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+              fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M20 6 9 17l-5-5" />
+            </svg>
+            Connected
+          </span>
+        </label>
+      </div>
+    </div>
+    <!-- End Header -->
+
+    <!-- Body -->
+    <div>
+      <h3 class="font-medium text-gray-800 dark:text-neutral-200">
+        Google Analytics
+      </h3>
+
+      <p class="mt-1 text-sm text-gray-500 dark:text-neutral-500">
+        Track user activity, traffic sources, and behavior across your platform with detailed analytics and insights.
+      </p>
+    </div>
+    <!-- End Body -->
+
+    <button type="button"
+      class="py-2 px-3 w-full inline-flex justify-center items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
+      View integration
+    </button>
+  </div>
+</div>

--- a/src/flimix/settings/platform_preference/integrations/index.html
+++ b/src/flimix/settings/platform_preference/integrations/index.html
@@ -1,0 +1,17 @@
+{% extends "src/flimix/layouts/sidebar_layout.html" %}
+{% block main_class %}bg-stone-50 min-h-[92vh]{% endblock %}
+
+
+
+
+{% block main_content %}
+<div class="space-y-5">
+  {% include "../includes/header.html" %}
+  {% include "./tabs.html" %}
+  {% include "./payment_gateway.html" %}
+  {% include "./accounting_and_billing.html" %}
+  {% include "./analytics.html" %}
+</div>
+
+
+{% endblock main_content %}

--- a/src/flimix/settings/platform_preference/integrations/payment_gateway.html
+++ b/src/flimix/settings/platform_preference/integrations/payment_gateway.html
@@ -1,0 +1,126 @@
+<div>
+<h2 class="font-medium text-stone-800 dark:text-neutral-200">
+  Payment Gateways
+</h2>
+<p class="mt-1 text-sm text-stone-500 dark:text-neutral-500">
+  Connect and manage your own payment gateway to securely handle user subscriptions and pay-per-view purchases.
+</p>
+</div>
+<!-- Card -->
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+  <div class="p-5 space-y-4 flex flex-col bg-white border border-gray-200 rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+    <!-- Header -->
+    <div class="flex justify-between">
+      <div class="flex flex-col justify-center items-center size-9.5 border border-gray-200 rounded-lg dark:border-neutral-700 p-2">
+        <img class="shrink-0 size-5 text-gray-500 dark:text-neutral-500" src="https://www.vectorlogo.zone/logos/stripe/stripe-icon.svg" alt="">
+      </div>
+  
+      <div>
+        <label for="stripe" class="relative py-2 px-3 flex items-center justify-center sm:justify-start border border-gray-200 cursor-pointer font-medium text-xs rounded-lg peer-checked:bg-gray-100 hover:border-gray-300 focus:outline-none focus:border-gray-300 dark:border-neutral-700 dark:peer-checked:bg-neutral-800 dark:hover:border-neutral-600 dark:focus:border-neutral-600">
+          <input type="checkbox" id="stripe" class="peer hidden">
+          <span class="relative z-10 text-gray-800 dark:text-neutral-200 peer-checked:hidden">
+            Connect
+          </span>
+          <span class="relative z-10 hidden peer-checked:flex items-center gap-x-1.5 text-gray-800 dark:text-neutral-200">
+            <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+            Connected
+          </span>
+        </label>
+      </div>
+    </div>
+    <!-- End Header -->
+  
+    <!-- Body -->
+    <div class="flex-grow">
+      <h3 class="font-medium text-gray-800 dark:text-neutral-200">
+        Stripe
+      </h3>
+  
+      <p class="mt-1 text-sm text-gray-500 dark:text-neutral-500">
+        Accept global card payments and manage subscriptions.
+      </p>
+    </div>
+    <!-- End Body -->
+  
+    <button type="button" class="py-2 px-3 w-full inline-flex justify-center items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
+      View integration
+    </button>
+  </div>
+<!-- End Card -->
+<div class="p-5 space-y-4 flex flex-col bg-white border border-gray-200 rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+  <!-- Header -->
+  <div class="flex justify-between">
+    <div class="flex flex-col justify-center items-center size-9.5 border border-gray-200 rounded-lg dark:border-neutral-700 p-2">
+      <img class="shrink-0 size-5 text-gray-500 dark:text-neutral-500" src="https://www.paypalobjects.com/marketing/web/logos/paypal-mark-color.svg" alt="">
+    </div>
+
+    <div>
+      <label for="paypal" class="relative py-2 px-3 flex items-center justify-center sm:justify-start border border-gray-200 cursor-pointer font-medium text-xs rounded-lg peer-checked:bg-gray-100 hover:border-gray-300 focus:outline-none focus:border-gray-300 dark:border-neutral-700 dark:peer-checked:bg-neutral-800 dark:hover:border-neutral-600 dark:focus:border-neutral-600">
+        <input type="checkbox" id="paypal" class="peer hidden">
+        <span class="relative z-10 text-gray-800 dark:text-neutral-200 peer-checked:hidden">
+          Connect
+        </span>
+        <span class="relative z-10 hidden peer-checked:flex items-center gap-x-1.5 text-gray-800 dark:text-neutral-200">
+          <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+          Connected
+        </span>
+      </label>
+    </div>
+  </div>
+  <!-- End Header -->
+
+  <!-- Body -->
+  <div class="flex-grow">
+    <h3 class="font-medium text-gray-800 dark:text-neutral-200">
+      PayPal
+    </h3>
+
+    <p class="mt-1 text-sm text-gray-500 dark:text-neutral-500">
+      Let users pay securely using PayPal or linked cards.
+    </p>
+  </div>
+  <!-- End Body -->
+
+  <button type="button" class="py-2 px-3 w-full inline-flex justify-center items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
+    View integration
+  </button>
+</div>
+<div class="p-5 space-y-4 flex flex-col bg-white border border-gray-200 rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+  <!-- Header -->
+  <div class="flex justify-between">
+    <div class="flex flex-col justify-center items-center size-9.5 border border-gray-200 rounded-lg dark:border-neutral-700 p-2">
+     <svg viewBox="0 0 1896 401" focusable="false" class="w-16" xmlns="http://www.w3.org/2000/svg"><path fill="#3395FF" d="M122.63 105.7l-15.75 57.97 90.15-58.3-58.96 219.98 59.88.05L285.05.48"></path><path d="M25.6 232.92L.8 325.4h122.73l50.22-188.13L25.6 232.92m426.32-81.42c-3 11.15-8.78 19.34-17.4 24.57-8.6 5.22-20.67 7.84-36.25 7.84h-49.5l17.38-64.8h49.5c15.56 0 26.25 2.6 32.05 7.9 5.8 5.3 7.2 13.4 4.22 24.6m51.25-1.4c6.3-23.4 3.7-41.4-7.82-54-11.5-12.5-31.68-18.8-60.48-18.8H324.4l-66.5 248.1h53.67l26.8-100h35.2c7.9 0 14.12 1.3 18.66 3.8 4.55 2.6 7.22 7.1 8.04 13.6l9.58 82.6h57.5l-9.32-77c-1.9-17.2-9.77-27.3-23.6-30.3 17.63-5.1 32.4-13.6 44.3-25.4a92.6 92.6 0 0 0 24.44-42.5m130.46 86.4c-4.5 16.8-11.4 29.5-20.73 38.4-9.34 8.9-20.5 13.3-33.52 13.3-13.26 0-22.25-4.3-27-13-4.76-8.7-4.92-21.3-.5-37.8 4.42-16.5 11.47-29.4 21.17-38.7 9.7-9.3 21.04-13.95 34.06-13.95 13 0 21.9 4.5 26.4 13.43 4.6 8.97 4.7 21.8.2 38.5zm23.52-87.8l-6.72 25.1c-2.9-9-8.53-16.2-16.85-21.6-8.34-5.3-18.66-8-30.97-8-15.1 0-29.6 3.9-43.5 11.7-13.9 7.8-26.1 18.8-36.5 33-10.4 14.2-18 30.3-22.9 48.4-4.8 18.2-5.8 34.1-2.9 47.9 3 13.9 9.3 24.5 19 31.9 9.8 7.5 22.3 11.2 37.6 11.2a82.4 82.4 0 0 0 35.2-7.7 82.11 82.11 0 0 0 28.4-21.2l-7 26.16h51.9L709.3 149h-52zm238.65 0H744.87l-10.55 39.4h87.82l-116.1 100.3-9.92 37h155.8l10.55-39.4h-94.1l117.88-101.8m142.4 52c-4.67 17.4-11.6 30.48-20.75 39-9.15 8.6-20.23 12.9-33.24 12.9-27.2 0-36.14-17.3-26.86-51.9 4.6-17.2 11.56-30.13 20.86-38.84 9.3-8.74 20.57-13.1 33.82-13.1 13 0 21.78 4.33 26.3 13.05 4.52 8.7 4.48 21.67-.13 38.87m30.38-80.83c-11.95-7.44-27.2-11.16-45.8-11.16-18.83 0-36.26 3.7-52.3 11.1a113.09 113.09 0 0 0-41 32.06c-11.3 13.9-19.43 30.2-24.42 48.8-4.9 18.53-5.5 34.8-1.7 48.73 3.8 13.9 11.8 24.6 23.8 32 12.1 7.46 27.5 11.17 46.4 11.17 18.6 0 35.9-3.74 51.8-11.18 15.9-7.48 29.5-18.1 40.8-32.1 11.3-13.94 19.4-30.2 24.4-48.8 5-18.6 5.6-34.84 1.8-48.8-3.8-13.9-11.7-24.6-23.6-32.05m185.1 40.8l13.3-48.1c-4.5-2.3-10.4-3.5-17.8-3.5-11.9 0-23.3 2.94-34.3 8.9-9.46 5.06-17.5 12.2-24.3 21.14l6.9-25.9-15.07.06h-37l-47.7 176.7h52.63l24.75-92.37c3.6-13.43 10.08-24 19.43-31.5 9.3-7.53 20.9-11.3 34.9-11.3 8.6 0 16.6 1.97 24.2 5.9m146.5 41.1c-4.5 16.5-11.3 29.1-20.6 37.8-9.3 8.74-20.5 13.1-33.5 13.1s-21.9-4.4-26.6-13.2c-4.8-8.85-4.9-21.6-.4-38.36 4.5-16.75 11.4-29.6 20.9-38.5 9.5-8.97 20.7-13.45 33.7-13.45 12.8 0 21.4 4.6 26 13.9 4.6 9.3 4.7 22.2.28 38.7m36.8-81.4c-9.75-7.8-22.2-11.7-37.3-11.7-13.23 0-25.84 3-37.8 9.06-11.95 6.05-21.65 14.3-29.1 24.74l.18-1.2 8.83-28.1h-51.4l-13.1 48.9-.4 1.7-54 201.44h52.7l27.2-101.4c2.7 9.02 8.2 16.1 16.6 21.22 8.4 5.1 18.77 7.63 31.1 7.63 15.3 0 29.9-3.7 43.75-11.1 13.9-7.42 25.9-18.1 36.1-31.9 10.2-13.8 17.77-29.8 22.6-47.9 4.9-18.13 5.9-34.3 3.1-48.45-2.85-14.17-9.16-25.14-18.9-32.9m174.65 80.65c-4.5 16.7-11.4 29.5-20.7 38.3-9.3 8.86-20.5 13.27-33.5 13.27-13.3 0-22.3-4.3-27-13-4.8-8.7-4.9-21.3-.5-37.8 4.4-16.5 11.42-29.4 21.12-38.7 9.7-9.3 21.05-13.94 34.07-13.94 13 0 21.8 4.5 26.4 13.4 4.6 8.93 4.63 21.76.15 38.5zm23.5-87.85l-6.73 25.1c-2.9-9.05-8.5-16.25-16.8-21.6-8.4-5.34-18.7-8-31-8-15.1 0-29.68 3.9-43.6 11.7-13.9 7.8-26.1 18.74-36.5 32.9-10.4 14.16-18 30.3-22.9 48.4-4.85 18.17-5.8 34.1-2.9 47.96 2.93 13.8 9.24 24.46 19 31.9 9.74 7.4 22.3 11.14 37.6 11.14 12.3 0 24.05-2.56 35.2-7.7a82.3 82.3 0 0 0 28.33-21.23l-7 26.18h51.9l47.38-176.7h-51.9zm269.87.06l.03-.05h-31.9c-1.02 0-1.92.05-2.85.07h-16.55l-8.5 11.8-2.1 2.8-.9 1.4-67.25 93.68-13.9-109.7h-55.08l27.9 166.7-61.6 85.3h54.9l14.9-21.13c.42-.62.8-1.14 1.3-1.8l17.4-24.7.5-.7 77.93-110.5 65.7-93 .1-.06h-.03z"></path></svg>
+    </div>
+
+    <div>
+      <label for="razorpay" class="relative py-2 px-3 flex items-center justify-center sm:justify-start border border-gray-200 cursor-pointer font-medium text-xs rounded-lg peer-checked:bg-gray-100 hover:border-gray-300 focus:outline-none focus:border-gray-300 dark:border-neutral-700 dark:peer-checked:bg-neutral-800 dark:hover:border-neutral-600 dark:focus:border-neutral-600">
+        <input type="checkbox" id="razorpay" class="peer hidden">
+        <span class="relative z-10 text-gray-800 dark:text-neutral-200 peer-checked:hidden">
+          Connect
+        </span>
+        <span class="relative z-10 hidden peer-checked:flex items-center gap-x-1.5 text-gray-800 dark:text-neutral-200">
+          <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>
+          Connected
+        </span>
+      </label>
+    </div>
+  </div>
+  <!-- End Header -->
+
+  <!-- Body -->
+  <div class="flex-grow">
+    <h3 class="font-medium text-gray-800 dark:text-neutral-200">
+      Razorpay
+    </h3>
+
+    <p class="mt-1 text-sm text-gray-500 dark:text-neutral-500">
+      Accept UPI, cards, wallets & more - ideal for Indian transactions.
+    </p>
+  </div>
+  <!-- End Body -->
+
+  <button type="button" class="py-2 px-3 w-full inline-flex justify-center items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
+    View integration
+  </button>
+</div>
+</div>

--- a/src/flimix/settings/platform_preference/integrations/tabs.html
+++ b/src/flimix/settings/platform_preference/integrations/tabs.html
@@ -1,0 +1,21 @@
+<div>
+  <div class="grid grid-cols-1 sm:hidden">
+    <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
+    <select onchange="location.href=this.value"  aria-label="Select a tab" class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600">
+      <option :value="`${previewPath}/flimix/settings/platform_preference/`">General</option>
+      <option :value="`${previewPath}/flimix/settings/platform_preference/player_preference/`" >Player Preferences</option>
+      <option :value="`${previewPath}/flimix/settings/platform_preference/integrations/`" selected >Integrations</option>
+    </select>
+  </div>
+  <div class="hidden sm:block">
+    <div class="border-b border-gray-200">
+      <nav class="-mb-px flex space-x-8" aria-label="Tabs">
+
+        <!-- Current: "border-indigo-500 text-indigo-600", Default: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700" -->
+        <a :href="`${previewPath}/flimix/settings/platform_preference/`" class="whitespace-nowrap border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">General</a>
+        <a :href="`${previewPath}/flimix/settings/platform_preference/player_preference/`" class="whitespace-nowrap border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" >Player Preferences</a>
+        <a :href="`${previewPath}/flimix/settings/platform_preference/integrations/`" class="whitespace-nowrap border-b-2 border-indigo-500 px-1 py-4 text-sm font-medium text-indigo-600" aria-current="page">Integrations</a>
+      
+    </div>
+  </div>
+</div>

--- a/src/flimix/settings/platform_preference/player_preference/color_picker_script.html
+++ b/src/flimix/settings/platform_preference/player_preference/color_picker_script.html
@@ -1,0 +1,81 @@
+<script>
+  document.addEventListener('DOMContentLoaded', (event) => {
+
+    const pickers = [
+      {
+        element: '#primary_color_picker',
+        input: '#primary_color_input',
+        defaultColor: '#03a4eb'
+      },
+      {
+        element: '#icons_color_picker',
+        input: '#icons_color_input',
+        defaultColor: '#ffffff'
+      },
+      {
+        element: '#accent_color_picker',
+        input: '#accent_color_input',
+        defaultColor: '#ff5733'
+      },
+      {
+        element: '#background_color_picker',
+        input: '#background_color_input',
+        defaultColor: '#000000'
+      }
+    ];
+
+    pickers.forEach(pickerConfig => {
+
+      const colorPickerElement = document.querySelector(pickerConfig.element);
+      const colorInputElement = document.querySelector(pickerConfig.input);
+      const pickr = Pickr.create({
+        el: colorPickerElement,
+        theme: 'classic', // or 'monolith', or 'nano'
+        default: pickerConfig.defaultColor,
+        lockOpacity: true,
+        comparison: false,
+        inline: false,
+        swatches: [
+          'rgba(244, 67, 54, 1)',
+          'rgba(233, 30, 99, 1)',
+          'rgba(156, 39, 176, 1)',
+          'rgba(103, 58, 183, 1)',
+          'rgba(63, 81, 181, 1)',
+          'rgba(33, 150, 243, 1)',
+          'rgba(3, 169, 244, 1)',
+          'rgba(0, 188, 212, 1)',
+          'rgba(0, 150, 136, 1)',
+          'rgba(76, 175, 80, 1)',
+          'rgba(139, 195, 74, 1)',
+          'rgba(205, 220, 57, 1)',
+          'rgba(255, 235, 59, 1)',
+          'rgba(255, 193, 7, 1)'
+        ],
+        components: {
+          preview: true,
+          opacity: false,
+          hue: true,
+          interaction: {
+            hex: false,
+            rgba: false,
+            hsla: false,
+            hsva: false,
+            cmyk: false,
+            input: true,
+            clear: false,
+            save: false
+          }
+        }
+      });
+
+      pickr.on('change', (color, source, instance) => {
+        const hexaColor = color.toHEXA().toString();
+        console.log('rgbacolor', hexaColor);
+        //document.getElementById('primary_color_picker').style.background = rgbaColor;
+        // Store the color value in a hidden input or any other place you need
+        colorInputElement.value = hexaColor;
+      });
+
+    });
+  });
+</script>

--- a/src/flimix/settings/platform_preference/player_preference/index.html
+++ b/src/flimix/settings/platform_preference/player_preference/index.html
@@ -1,0 +1,46 @@
+
+
+{% extends "src/flimix/layouts/sidebar_layout.html" %}
+{% block main_class %}bg-stone-50 min-h-[92vh]{% endblock %}
+
+{% block extra_head %} 
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/classic.min.css" />
+<script src="https://cdn.jsdelivr.net/npm/@simonwep/pickr"></script>
+<style>
+  .pcr-button {
+    border: 1px solid #efefef;
+  }
+
+  .pickr .pcr-button::after {
+    border-radius: 0;
+  }
+</style>
+{% endblock extra_head %}
+
+
+{% block main_content %}
+<div class="space-y-5">
+  {% include "../includes/header.html" %}
+  {% include "./tabs.html" %}
+
+  <form>
+    <div class="space-y-12">
+    {% include "./playback_settings.html" %}
+    {% include "./player_controls.html" %}
+    {% include "./player_appearance.html" %}
+    {% include "./subtitle_and_audio_preference.html" %}
+    </div>
+
+    <div class="mt-6 flex items-center justify-end gap-x-6">
+      <button type="button" class="text-sm/6 font-semibold text-gray-900">Cancel</button>
+      <button type="submit"
+        class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Save</button>
+    </div>
+  </form>
+</div>
+
+{% endblock main_content %}
+
+{% block script %}
+{% include "./color_picker_script.html" %}
+{% endblock script %}

--- a/src/flimix/settings/platform_preference/player_preference/playback_settings.html
+++ b/src/flimix/settings/platform_preference/player_preference/playback_settings.html
@@ -1,0 +1,194 @@
+<div
+class="grid grid-cols-1 gap-x-8  pt-4 border-b border-gray-900/10 pb-12 md:grid-cols-12 gap-y-1.5 md:gap-y-0 md:gap-x-5 lg:gap-x-8">
+<div class="md:col-span-4 flex flex-col mb-3 md:mb-0">
+  <div class="space-y-2">
+    <h2 class="font-medium text-stone-800 dark:text-neutral-200">
+      Playback Settings
+    </h2>
+    <p class="text-sm text-stone-500 dark:text-neutral-500">
+      Control how videos behave during playback.
+    </p>
+  </div>
+</div>
+<!-- End Col -->
+
+<div class="md:col-span-8">
+  <!-- Business Vertical Settings Card -->
+  <div
+    class="p-5 space-y-5 flex flex-col bg-white border border-stone-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+    <!-- Input Grid -->
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">
+            Enable subtitles</label>
+          <p id="candidates-description" class="text-stone-500">Show subtitles for the video.</p>
+        </div>
+      </div>
+      
+      
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">Enable autoplay</label>
+          <p id="candidates-description" class="text-stone-500">Automatically start playback on video load.</p>
+        </div>
+      </div><!-- Input -->
+    </div>
+
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">
+            Enable loop playback</label>
+          <p id="candidates-description" class="text-stone-500">Automatically replay the video when it ends.</p>
+        </div>
+      </div>
+      
+      
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">Mute video on start</label>
+          <p id="candidates-description" class="text-stone-500">Start the video with the sound muted.</p>
+        </div>
+      </div><!-- Input -->
+    </div>
+    <!-- End Input Grid -->
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">
+            Enable picture-in-picture mode</label>
+          <p id="candidates-description" class="text-stone-500">Allow video playback in a small overlay.
+          </p>
+        </div>
+      </div>
+      
+    </div>
+
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <!-- Input -->
+      <!-- End Input -->
+
+      <!-- Input -->
+      <div>
+        <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Default Video Quality
+        </label>
+        <!-- Language Select -->
+        <div class="relative">
+          <select id="hs-pro-select-quality" data-hs-select='{
+    "placeholder": "Select video quality",
+    "toggleTag": "<button type=\"button\" aria-expanded=\"false\"><div data-icon></div></button>",
+    "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 relative py-2 px-3 pe-7 flex items-center gap-x-2 text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm text-gray-800 hover:border-gray-300 focus:outline-hidden focus:border-gray-300 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-200 dark:hover:border-neutral-700 dark:focus:border-neutral-700",
+    "dropdownClasses": "end-0 w-full min-w-45 max-h-72 p-1 space-y-0.5 z-50 w-full overflow-hidden overflow-y-auto bg-white rounded-xl shadow-xl [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500 dark:bg-neutral-900",
+    "optionClasses": "hs-selected:bg-gray-100 dark:hs-selected:bg-neutral-800 py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800",
+    "optionTemplate": "<div><div class=\"flex items-center gap-x-2\"><div data-icon></div><div class=\"text-gray-800 dark:text-neutral-200 \" data-title></div><span class=\"hidden hs-selected:block ms-auto\"><svg class=\"shrink-0 size-3.5 text-gray-800 dark:text-neutral-200 \" xmlns=\"http:.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"20 6 9 17 4 12\"/></svg></span></div></div>"
+  }' class="hidden">
+            <option value="">Choose</option>
+            <option value="auto" selected >Auto</option>
+            <option value="144">144p</option>
+            <option value="240">240p</option>
+            <option value="360">360p</option>
+            <option value="480">480p (SD)</option>
+            <option value="720">720p (HD)</option>
+            <option value="1080">1080p (Full HD)</option>
+            <option value="1440">1440p (2K)</option>
+            <option value="2160">2160p (4K)</option>
+          </select>
+
+          <div class="absolute top-1/2 end-2.5 -translate-y-1/2">
+            <svg class="shrink-0 size-3.5 text-gray-500 dark:text-neutral-500"
+              xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m7 15 5 5 5-5" />
+              <path d="m7 9 5-5 5 5" />
+            </svg>
+          </div>
+          <!-- End Header -->
+        </div>
+        <!-- End Language Select -->
+      </div>
+
+      
+      <!-- End Input -->
+      <!-- End Input -->
+    </div>
+  </div>
+</div>
+<!-- End Col -->
+</div>

--- a/src/flimix/settings/platform_preference/player_preference/player_appearance.html
+++ b/src/flimix/settings/platform_preference/player_preference/player_appearance.html
@@ -1,0 +1,85 @@
+<div
+class="grid grid-cols-1 gap-x-8  border-b border-gray-900/10 pb-12 md:grid-cols-12 gap-y-1.5 md:gap-y-0 md:gap-x-5 lg:gap-x-8">
+<div class="md:col-span-4 flex flex-col mb-3 md:mb-0">
+  <div class="space-y-2">
+    <h2 class="font-medium text-stone-800 dark:text-neutral-200">
+      Player Appearance                 
+    </h2>
+    <p class="text-sm text-stone-500 dark:text-neutral-500">
+      Set the look and layout of the player to match your brand and viewing style.
+    </p>
+  </div>
+</div>
+<!-- End Col -->
+
+<div class="md:col-span-8">
+  <!-- Business Vertical Settings Card -->
+  <div
+    class="p-5 space-y-5 flex flex-col bg-white border border-stone-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+    <!-- Input Grid -->
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+
+    <div>
+        <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+         Primary Color
+        </label>
+                  <div class="mt-2">
+            <div id="primary_color_picker"
+              class="w-full rounded-md border border-gray-300 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 sm:text-sm sm:leading-6">
+            </div>
+          </div>
+          <input type="hidden" id="primary_color_input" name="primary_color" value="#03a4eb">
+    </div>
+
+    <div>
+      <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+       Icon Color
+      </label> <!-- End Language Select -->
+      <div class="mt-2">
+        <div id="icons_color_picker"
+          class="w-full rounded-md border border-gray-300 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 sm:text-sm sm:leading-6">
+        </div>
+      </div>
+      <input type="hidden" id="icons_color_input" name="icons_color" value="#ffffff">
+  </div> 
+
+      <!-- End Input -->
+
+      <!-- End Input -->
+    </div>
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+
+      <div>
+          <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+           Accent Color
+          </label> <!-- End Language Select -->
+          <div class="mt-2">
+            <div id="accent_color_picker"
+              class="w-full rounded-md border border-gray-300 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 sm:text-sm sm:leading-6">
+            </div>
+          </div>
+          <input type="hidden" id="accent_color_input" name="accent_color" value="#ff5733">
+      </div>
+  
+      <div>
+        <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Background Color
+        </label> <!-- End Language Select -->
+        <div class="mt-2">
+          <div id="background_color_picker"
+            class="w-full rounded-md border border-gray-300 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 sm:text-sm sm:leading-6">
+          </div>
+        </div>
+        <input type="hidden" id="background_color_input" name="background_color" value="#000000">
+    </div> 
+  
+        <!-- End Input -->
+  
+        <!-- End Input -->
+      </div>
+  </div>
+</div>
+<!-- End Col -->
+</div>
+
+

--- a/src/flimix/settings/platform_preference/player_preference/player_controls.html
+++ b/src/flimix/settings/platform_preference/player_preference/player_controls.html
@@ -1,0 +1,144 @@
+<div
+class="grid grid-cols-1 gap-x-8  border-b border-gray-900/10 pb-12 md:grid-cols-12 gap-y-1.5 md:gap-y-0 md:gap-x-5 lg:gap-x-8">
+<div class="md:col-span-4 flex flex-col mb-3 md:mb-0">
+  <div class="space-y-2">
+    <h2 class="font-medium text-stone-800 dark:text-neutral-200">
+      Player Controls
+    </h2>
+    <p class="text-sm text-stone-500 dark:text-neutral-500">
+      Configure which controls and UI elements are visible on the video player.
+    </p>
+  </div>
+</div>
+<!-- End Col -->
+
+<div class="md:col-span-8">
+  <!-- Business Vertical Settings Card -->
+  <div
+    class="p-5 space-y-5 flex flex-col bg-white border border-stone-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+    <!-- Input Grid -->
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">
+            Enable player controls</label>
+          <p id="candidates-description" class="text-stone-500">Show the player controls for video playback.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">
+            Show video title</label>
+          <p id="candidates-description" class="text-stone-500">Display the title of the video on the player.</p>
+        </div>
+      </div>
+      
+      
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">Enable play icon</label>
+          <p id="candidates-description" class="text-stone-500">Show the play icon on the video player.</p>
+        </div>
+      </div><!-- Input -->
+    </div>
+    <!-- End Input Grid -->
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">
+            Enable progress bar</label>
+          <p id="candidates-description" class="text-stone-500">Show the progress bar on the video player.
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">
+            Enable speed controls</label>
+          <p id="candidates-description" class="text-stone-500">Allow viewers to change the playback speed.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- End Col -->
+</div>

--- a/src/flimix/settings/platform_preference/player_preference/subtitle_and_audio_preference.html
+++ b/src/flimix/settings/platform_preference/player_preference/subtitle_and_audio_preference.html
@@ -1,0 +1,157 @@
+<div
+class="grid grid-cols-1 gap-x-8  border-b border-gray-900/10 pb-12 md:grid-cols-12 gap-y-1.5 md:gap-y-0 md:gap-x-5 lg:gap-x-8">
+<div class="md:col-span-4 flex flex-col mb-3 md:mb-0">
+  <div class="space-y-2">
+    <h2 class="font-medium text-stone-800 dark:text-neutral-200">
+      Subtitle & Audio Preferences
+    </h2>
+    <p class="text-sm text-stone-500 dark:text-neutral-500">
+      Manage default languages and subtitle settings for a personalized experience.
+    </p>
+  </div>
+</div>
+<!-- End Col -->
+
+<div class="md:col-span-8">
+  <!-- Business Vertical Settings Card -->
+  <div
+    class="p-5 space-y-5 flex flex-col bg-white border border-stone-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+    <!-- Input Grid -->
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <div class="flex gap-3">
+        <div class="flex h-6 shrink-0 items-center">
+          <div class="group grid size-4 grid-cols-1">
+            <input id="candidates"  aria-describedby="candidates-description" name="candidates"
+              type="checkbox"
+              class="col-start-1 row-start-1 appearance-none rounded-sm text-indigo-600 focus:ring-indigo-600 border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto">
+            <svg
+              class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25"
+              viewBox="0 0 14 14" fill="none">
+              <path class="opacity-0 group-has-checked:opacity-100" d="M3 8L6 11L11 3.5" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+              <path class="opacity-0 group-has-indeterminate:opacity-100" d="M3 7H11" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="text-sm/6">
+          <label for="candidates" class="block text-sm font-medium text-stone-800 dark:text-neutral-200">
+            Enable subtitles</label>
+          <p id="candidates-description" class="text-stone-500">Show subtitles for the video.</p>
+        </div>
+      </div>
+
+    </div>
+
+
+    <div class="grid sm:grid-cols-2 gap-3 sm:gap-5">
+      <!-- Input -->
+      <!-- End Input -->
+
+      <!-- Input -->
+      <div>
+        <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Default Subtitle Language
+        </label>
+        <!-- Language Select -->
+        <div class="relative">
+          <select id="hs-pro-select-quality" data-hs-select='{
+    "placeholder": "Select video quality",
+    "toggleTag": "<button type=\"button\" aria-expanded=\"false\"><div data-icon></div></button>",
+    "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 relative py-2 px-3 pe-7 flex items-center gap-x-2 text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm text-gray-800 hover:border-gray-300 focus:outline-hidden focus:border-gray-300 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-200 dark:hover:border-neutral-700 dark:focus:border-neutral-700",
+    "dropdownClasses": "end-0 w-full min-w-45 max-h-72 p-1 space-y-0.5 z-50 w-full overflow-hidden overflow-y-auto bg-white rounded-xl shadow-xl [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500 dark:bg-neutral-900",
+    "optionClasses": "hs-selected:bg-gray-100 dark:hs-selected:bg-neutral-800 py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800",
+    "optionTemplate": "<div><div class=\"flex items-center gap-x-2\"><div data-icon></div><div class=\"text-gray-800 dark:text-neutral-200 \" data-title></div><span class=\"hidden hs-selected:block ms-auto\"><svg class=\"shrink-0 size-3.5 text-gray-800 dark:text-neutral-200 \" xmlns=\"http:.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"20 6 9 17 4 12\"/></svg></span></div></div>"
+  }' class="hidden">
+            <option value="">Choose</option>
+            <option value="en" selected>English</option>
+            <option value="hi">Hindi</option>
+            <option value="ta">Tamil</option>
+            <option value="te">Telugu</option>
+            <option value="ml">Malayalam</option>
+            <option value="kn">Kannada</option>
+            <option value="mr">Marathi</option>
+            <option value="gu">Gujarati</option>
+            <option value="bn">Bengali</option>
+            <option value="pa">Punjabi</option>
+            <option value="ur">Urdu</option>
+            <option value="as">Assamese</option>
+            <option value="or">Odia</option>
+            <option value="fr">French</option>
+            <option value="es">Spanish</option>
+            <option value="de">German</option>
+            <option value="zh">Chinese</option>
+            <option value="ja">Japanese</option>
+            <option value="ko">Korean</option>
+            <option value="ar">Arabic</option>
+          </select>
+
+          <div class="absolute top-1/2 end-2.5 -translate-y-1/2">
+            <svg class="shrink-0 size-3.5 text-gray-500 dark:text-neutral-500"
+              xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m7 15 5 5 5-5" />
+              <path d="m7 9 5-5 5 5" />
+            </svg>
+          </div>
+          <!-- End Header -->
+        </div>
+        <!-- End Language Select -->
+      </div>
+
+      <div>
+        <label for="hs-pro-esscp" class="block mb-2 text-sm font-medium text-stone-800 dark:text-neutral-200">
+          Default Audio Language
+        </label>
+        <!-- Language Select -->
+        <div class="relative">
+          <select id="hs-pro-select-quality" data-hs-select='{
+    "placeholder": "Select video quality",
+    "toggleTag": "<button type=\"button\" aria-expanded=\"false\"><div data-icon></div></button>",
+    "toggleClasses": "hs-select-disabled:pointer-events-none hs-select-disabled:opacity-50 relative py-2 px-3 pe-7 flex items-center gap-x-2 text-nowrap w-full cursor-pointer bg-white border border-gray-200 rounded-lg text-start text-sm text-gray-800 hover:border-gray-300 focus:outline-hidden focus:border-gray-300 dark:bg-neutral-900 dark:border-neutral-800 dark:text-neutral-200 dark:hover:border-neutral-700 dark:focus:border-neutral-700",
+    "dropdownClasses": "end-0 w-full min-w-45 max-h-72 p-1 space-y-0.5 z-50 w-full overflow-hidden overflow-y-auto bg-white rounded-xl shadow-xl [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500 dark:bg-neutral-900",
+    "optionClasses": "hs-selected:bg-gray-100 dark:hs-selected:bg-neutral-800 py-2 px-4 w-full text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800",
+    "optionTemplate": "<div><div class=\"flex items-center gap-x-2\"><div data-icon></div><div class=\"text-gray-800 dark:text-neutral-200 \" data-title></div><span class=\"hidden hs-selected:block ms-auto\"><svg class=\"shrink-0 size-3.5 text-gray-800 dark:text-neutral-200 \" xmlns=\"http:.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"20 6 9 17 4 12\"/></svg></span></div></div>"
+  }' class="hidden">
+            <option value="">Choose</option>
+            <option value="en">English</option>
+            <option value="hi">Hindi</option>
+            <option value="ta" selected>Tamil</option>
+            <option value="te">Telugu</option>
+            <option value="ml">Malayalam</option>
+            <option value="kn">Kannada</option>
+            <option value="mr">Marathi</option>
+            <option value="gu">Gujarati</option>
+            <option value="bn">Bengali</option>
+            <option value="pa">Punjabi</option>
+            <option value="ur">Urdu</option>
+            <option value="as">Assamese</option>
+            <option value="or">Odia</option>
+            <option value="fr">French</option>
+            <option value="es">Spanish</option>
+            <option value="de">German</option>
+            <option value="zh">Chinese</option>
+            <option value="ja">Japanese</option>
+            <option value="ko">Korean</option>
+            <option value="ar">Arabic</option>
+          </select>
+
+          <div class="absolute top-1/2 end-2.5 -translate-y-1/2">
+            <svg class="shrink-0 size-3.5 text-gray-500 dark:text-neutral-500"
+              xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m7 15 5 5 5-5" />
+              <path d="m7 9 5-5 5 5" />
+            </svg>
+          </div>
+          <!-- End Header -->
+        </div>
+        <!-- End Language Select -->
+      </div>
+      <!-- End Input -->
+      <!-- End Input -->
+    </div>
+  </div>
+</div>
+<!-- End Col -->
+</div>

--- a/src/flimix/settings/platform_preference/player_preference/tabs.html
+++ b/src/flimix/settings/platform_preference/player_preference/tabs.html
@@ -1,0 +1,21 @@
+<div>
+  <div class="grid grid-cols-1 sm:hidden">
+    <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
+    <select onchange="location.href=this.value"  aria-label="Select a tab" class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600">
+      <option :value="`${previewPath}/flimix/settings/platform_preference/`">General</option>
+      <option :value="`${previewPath}/flimix/settings/platform_preference/player_preference/`" selected>Player Preferences</option>
+      <option :value="`${previewPath}/flimix/settings/platform_preference/integrations/`">Integrations</option>
+    </select>
+  </div>
+  <div class="hidden sm:block">
+    <div class="border-b border-gray-200">
+      <nav class="-mb-px flex space-x-8" aria-label="Tabs">
+
+        <!-- Current: "border-indigo-500 text-indigo-600", Default: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700" -->
+        <a :href="`${previewPath}/flimix/settings/platform_preference/`" class="whitespace-nowrap border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">General</a>
+        <a :href="`${previewPath}/flimix/settings/platform_preference/player_preference/`" class="whitespace-nowrap border-b-2 border-indigo-500 px-1 py-4 text-sm font-medium text-indigo-600" aria-current="page">Player Preferences</a>
+        <a :href="`${previewPath}/flimix/settings/platform_preference/integrations/`" class="whitespace-nowrap border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">Integrations</a>
+      
+    </div>
+  </div>
+</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a comprehensive "Platform Preference" section under Settings, accessible via the sidebar with active state highlighting.
  - Added dedicated pages and navigation tabs for General, Player Preferences, and Integrations within Platform Preferences.
  - Implemented detailed forms for organization info, localization (languages and timezones), and theme preferences (including light/dark mode and user toggle).
  - Enabled player preference customization, including playback settings, player controls, appearance (with color pickers), and subtitle/audio options.
  - Provided integration management interfaces for payment gateways (Stripe, PayPal, Razorpay), accounting and billing (Zoho), and analytics (Google Analytics), each with connect/disconnect toggles and integration details.
- **Style**
  - Enhanced responsive design and dark mode support across all new settings pages and components for improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->