### PR TITLE
fix: Add proper padding for doubt button on content detail page

### DIFF
--- a/src/content_detail_page/attachment.html
+++ b/src/content_detail_page/attachment.html
@@ -37,7 +37,7 @@
         </div>
       </div>
     </div>
-    <div class="sm:px-4 lg:px-8">
+    <div class="px-4 lg:px-8">
       {% include "./includes/doubt_button.html" %}
     </div>
     {% include "./includes/comment_section.html" %}

--- a/src/content_detail_page/attachment.html
+++ b/src/content_detail_page/attachment.html
@@ -37,7 +37,7 @@
         </div>
       </div>
     </div>
-    <div class="lg:px-8">
+    <div class="sm:px-4 lg:px-8">
       {% include "./includes/doubt_button.html" %}
     </div>
     {% include "./includes/comment_section.html" %}

--- a/src/content_detail_page/exam.html
+++ b/src/content_detail_page/exam.html
@@ -27,7 +27,7 @@
           </div>
         </div>
       {% include "./includes/exam_details.html" %}
-      <div class="sm:px-4 lg:px-0">
+      <div class="px-4 lg:px-0">
         {% include "./includes/doubt_button.html" %}
       </div>
       {% include "./includes/exam_tabs.html" %}

--- a/src/content_detail_page/exam.html
+++ b/src/content_detail_page/exam.html
@@ -27,7 +27,7 @@
           </div>
         </div>
       {% include "./includes/exam_details.html" %}
-      <div class="lg:px-8">
+      <div class="sm:px-4 lg:px-8">
         {% include "./includes/doubt_button.html" %}
       </div>
       {% include "./includes/exam_tabs.html" %}

--- a/src/content_detail_page/exam.html
+++ b/src/content_detail_page/exam.html
@@ -27,7 +27,7 @@
           </div>
         </div>
       {% include "./includes/exam_details.html" %}
-      <div class="sm:px-4 lg:px-8">
+      <div class="sm:px-4 lg:px-0">
         {% include "./includes/doubt_button.html" %}
       </div>
       {% include "./includes/exam_tabs.html" %}

--- a/src/content_detail_page/includes/video_content.html
+++ b/src/content_detail_page/includes/video_content.html
@@ -6,7 +6,7 @@
       <iframe src="https://lmsdemo.testpress.in/embed/iFTEoF7PzJe/?access_token=ea3de778-37e2-41af-b8a2-e96dda33f662" style="border:0;max-width:100%;position:absolute;top:0;left:0;height:100%;width:100%;" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope picture-in-picture" allowfullscreen="" frameborder="0"></iframe>
     </div>
   </div>
-  <div class="sm:px-4">
+  <div class="sm:px-4 lg:px-0">
   {% include "./doubt_button.html" %}
   <div class="mt-6 text-sm text-gray-900 description" x-data="{ showFullDescription: false }">
     <div x-cloak x-show="!showFullDescription">

--- a/src/content_detail_page/includes/video_content.html
+++ b/src/content_detail_page/includes/video_content.html
@@ -6,7 +6,7 @@
       <iframe src="https://lmsdemo.testpress.in/embed/iFTEoF7PzJe/?access_token=ea3de778-37e2-41af-b8a2-e96dda33f662" style="border:0;max-width:100%;position:absolute;top:0;left:0;height:100%;width:100%;" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope picture-in-picture" allowfullscreen="" frameborder="0"></iframe>
     </div>
   </div>
-  <div class="sm:px-4 lg:px-0">
+  <div class="px-4 lg:px-0">
   {% include "./doubt_button.html" %}
   <div class="mt-6 text-sm text-gray-900 description" x-data="{ showFullDescription: false }">
     <div x-cloak x-show="!showFullDescription">

--- a/src/content_detail_page/includes/video_content.html
+++ b/src/content_detail_page/includes/video_content.html
@@ -6,6 +6,7 @@
       <iframe src="https://lmsdemo.testpress.in/embed/iFTEoF7PzJe/?access_token=ea3de778-37e2-41af-b8a2-e96dda33f662" style="border:0;max-width:100%;position:absolute;top:0;left:0;height:100%;width:100%;" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope picture-in-picture" allowfullscreen="" frameborder="0"></iframe>
     </div>
   </div>
+  <div class="sm:px-4">
   {% include "./doubt_button.html" %}
   <div class="mt-6 text-sm text-gray-900 description" x-data="{ showFullDescription: false }">
     <div x-cloak x-show="!showFullDescription">
@@ -21,4 +22,5 @@
         <span @click="showFullDescription = false" class="text-emerald-600 text-bold cursor-pointer">Show Less</span>
     </div>
   </div>
+</div>
 </div>

--- a/src/content_detail_page/notes.html
+++ b/src/content_detail_page/notes.html
@@ -50,7 +50,7 @@
         </div>
       </div>
     </div>
-    <div class="sm:px-4 lg:px-8">
+    <div class="px-4 lg:px-8">
     {% include "./includes/doubt_button.html" %}
     </div>
     {% include "./includes/comment_section.html" %}

--- a/src/content_detail_page/notes.html
+++ b/src/content_detail_page/notes.html
@@ -50,7 +50,7 @@
         </div>
       </div>
     </div>
-    <div class="lg:px-8">
+    <div class="sm:px-4 lg:px-8">
     {% include "./includes/doubt_button.html" %}
     </div>
     {% include "./includes/comment_section.html" %}

--- a/src/content_detail_page/notes.html
+++ b/src/content_detail_page/notes.html
@@ -16,7 +16,7 @@
 		{% include "./includes/navigate_content.html" %}
     <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false}">
 
-      <div class="max-w-5xl mx-auto">
+      <div>
         {% include "./includes/content_heading.html" %}
         <div class="mt-6 prose prose-slate px-4 sm:px-6 lg:px-0 lg:prose-md max-w-none">
           <h4><strong>Mentor Links </strong></h4>

--- a/src/content_detail_page/pdf.html
+++ b/src/content_detail_page/pdf.html
@@ -20,7 +20,7 @@
 				<iframe allowfullscreen="" webkitallowfullscreen="" src="https://media.testpress.in/static/js/pdf_js_v3_10_111/web/viewer.html?file=https%3A%2F%2Fd36vpug2b5drql.cloudfront.net%2Finstitute%2Flmsdemo%2Fprivate%2Fcourses%2F720%2Fattachments%2F307698b93678438b936998dc7cc18ace.pdf%3FExpires%3D1698831263%26Signature%3DYnSG2UOig~UFMWBxsnLl1-e4-ewMcLoZX-Ge65AJoj7G-HD3atOcgP8BEorqBxJDJs037mkvRehKrn6gT1rIeKC-ZusvxS~4zJYReTY3lH5LquzUkBrCzIHSNND4qgirGjnse7om9fRG9awBJHoqlyDdcxyjRXk3Et8qgQriJiIIJXgWByM2wL0K9ovD~UMrvinvUqedpJ01~PcDeomnEGh81jv77Sui3TqxqpyZWFConbM7fMRpgAgxZRBmuxhUyvuWWpSwT66oL3PQMF5oGxz0ORo2ncQZdrL0gPfSve2ST6vamf0-i8HXiSHtHRQnKmW1YH3pNNRpukWj1ArRyw__%26Key-Pair-Id%3DK2XWKDWM065EGO" height="800px" id="admin-pdf-viewer" runat="server" width="100%"></iframe>
 			</div>
 		</div>
-		<div class="lg:px-8">
+		<div class="sm:px-4 lg:px-8">
 			{% include "./includes/doubt_button.html" %}
 		</div>
 		{% include "./includes/comment_section.html" %}

--- a/src/content_detail_page/pdf.html
+++ b/src/content_detail_page/pdf.html
@@ -20,7 +20,7 @@
 				<iframe allowfullscreen="" webkitallowfullscreen="" src="https://media.testpress.in/static/js/pdf_js_v3_10_111/web/viewer.html?file=https%3A%2F%2Fd36vpug2b5drql.cloudfront.net%2Finstitute%2Flmsdemo%2Fprivate%2Fcourses%2F720%2Fattachments%2F307698b93678438b936998dc7cc18ace.pdf%3FExpires%3D1698831263%26Signature%3DYnSG2UOig~UFMWBxsnLl1-e4-ewMcLoZX-Ge65AJoj7G-HD3atOcgP8BEorqBxJDJs037mkvRehKrn6gT1rIeKC-ZusvxS~4zJYReTY3lH5LquzUkBrCzIHSNND4qgirGjnse7om9fRG9awBJHoqlyDdcxyjRXk3Et8qgQriJiIIJXgWByM2wL0K9ovD~UMrvinvUqedpJ01~PcDeomnEGh81jv77Sui3TqxqpyZWFConbM7fMRpgAgxZRBmuxhUyvuWWpSwT66oL3PQMF5oGxz0ORo2ncQZdrL0gPfSve2ST6vamf0-i8HXiSHtHRQnKmW1YH3pNNRpukWj1ArRyw__%26Key-Pair-Id%3DK2XWKDWM065EGO" height="800px" id="admin-pdf-viewer" runat="server" width="100%"></iframe>
 			</div>
 		</div>
-		<div class="sm:px-4 lg:px-8">
+		<div class="px-4 lg:px-8">
 			{% include "./includes/doubt_button.html" %}
 		</div>
 		{% include "./includes/comment_section.html" %}

--- a/src/content_detail_page/video_conf_start.html
+++ b/src/content_detail_page/video_conf_start.html
@@ -53,7 +53,7 @@
         <button type="button" class="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600">Attend Class</button>
       </div>
     </div>
-    <div class="lg:px-8">
+    <div class="sm:px-4 lg:px-8">
       {% include "./includes/doubt_button.html" %}
     </div>
     {% include "./includes/comment_section.html" %}

--- a/src/content_detail_page/video_conf_start.html
+++ b/src/content_detail_page/video_conf_start.html
@@ -53,7 +53,7 @@
         <button type="button" class="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600">Attend Class</button>
       </div>
     </div>
-    <div class="sm:px-4 lg:px-8">
+    <div class="px-4 lg:px-8">
       {% include "./includes/doubt_button.html" %}
     </div>
     {% include "./includes/comment_section.html" %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Improved horizontal padding around the doubt button for better appearance and usability on small screens, ensuring consistent spacing across all device sizes.
	- Added additional padding around the video content section for enhanced layout consistency on small screens.
	- Removed maximum width constraint and horizontal centering from the notes heading and mentor links section for a more fluid layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->