### PR TITLE
Add album detail page for flimix

### DIFF
--- a/src/_data/audio_tracks.json
+++ b/src/_data/audio_tracks.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": 1,
+    "title": "Lepak Kudenggeh",
+    "description": "Summer naale namma yellarukkum niyabagam varadhu Veyil mattum-tha la. Apram Veyil-ah thandi vera ennada niyabagam varum indha season-la nu kekringla?. Namma yellarum school padikrapo Annual leave viduvanga we mean that \"Summer Holidays\". Appo andha Time-la naama Veyil-ah thaandi sila settaigal,sambhavangala pannirupom. Andha Memories-ah recollect pandrathukku-tha indha Episode. So Summer Holidays-ah pathi \"Ennena Solranga Parunga!\". Learn more about your ad choices. Visit podcastchoices.com/adchoices",
+    "thumbnail": "https://i.scdn.co/image/ab67616d0000b27340dd41ad27cc4185f6631d62",
+    "duration": "24:18"
+  },
+  {
+    "id": 2,
+    "title": "Angry Bird",
+    "description": "Life-la Tour naale Namma yellarukkum oru nalla marakka mudiyatha Good Memories irukkum!. Athuvum Clg Friends-ooda pona tour-na sollava venum!. So Andha Maari Gopi pona oru Tour-la ulla Fun, Comedy, Galatta's matrum sila Sambhavangala pathi Indha episode-la Ennena Solranga Parunga!. Learn more about your ad choices. Visit podcastchoices.com/adchoices",
+    "thumbnail": "https://i.scdn.co/image/ab67616d0000b27340dd41ad27cc4185f6631d62",
+    "duration": "18:42"
+  },
+  {
+    "id": 3,
+    "title": "Nanben Daa",
+    "description": "Gopi Sudhakar-ooda Combo Namakku yevlo pidikkum, Apdi patta oru Combo Enga Start aachunu Therinjukanuma?, Appo udane indha Episode-ah kelunga Makkale!. Indha Episode-la avanga Rendu Perum First Time-ah enga meet pannikitangandratha pathi \"Ennena Solranga Parunga!\".",
+    "thumbnail": "https://i.scdn.co/image/ab67616d0000b27340dd41ad27cc4185f6631d62",
+    "duration": "21:05"
+  },
+  {
+    "id": 4,
+    "title": "Pirantha Naal",
+    "description": "Gopi-yum Sudhakar-um avanga First Year College Life-la nadantha Sila Vishayangala, matrum Pala Sambavangala Pathi indha Episode-la \"Ennena Solranga Parunga\" Learn more about your ad choices. Visit podcastchoices.com/adchoices",
+    "thumbnail": "https://i.scdn.co/image/ab67616d0000b27340dd41ad27cc4185f6631d62",
+    "duration": "19:11"
+  },
+  {
+    "id": 5,
+    "title": "Cintaku Buta 1.0",
+    "description": "Maanavargale! Public Examai Kandu Bayama! Appo Udane indha Episode-ah Kelunga, idhula Gopi Avaru Public Exam Yeluthumbodhu irundha Bayatha!",
+    "thumbnail": "https://i.scdn.co/image/ab67616d0000b27340dd41ad27cc4185f6631d62",
+    "duration": "16:27"
+  }
+]

--- a/src/flimix/layouts/sidebar_layout.html
+++ b/src/flimix/layouts/sidebar_layout.html
@@ -15,6 +15,8 @@
         {% endblock main_content %}
       </div>
     </main>
+    {% block footer_content %}
+    {% endblock footer_content %}
   </div>
 </div>
 {% endblock content %}

--- a/src/flimix/library/album/detail/add_audio_track.html
+++ b/src/flimix/library/album/detail/add_audio_track.html
@@ -1,0 +1,82 @@
+<!-- Add Event Modal -->
+<div id="create-episode" class="hs-overlay hidden size-full fixed top-0 start-0 z-[80] overflow-x-hidden overflow-y-auto [--close-when-click-inside:true] pointer-events-none" role="dialog" tabindex="-1" aria-labelledby="create-episode-label">
+  <div class="hs-overlay-open:mt-7 hs-overlay-open:opacity-100 hs-overlay-open:duration-500 mt-0 opacity-0 ease-out transition-all sm:max-w-xl sm:w-full m-3 sm:mx-auto h-[calc(100%-3.5rem)] min-h-[calc(100%-3.5rem)] flex items-center">
+    <div class="w-full max-h-full flex flex-col bg-white rounded-xl pointer-events-auto shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)]">
+      <!-- Header -->
+      <div class="py-2.5 px-4 flex justify-between items-center border-b">
+        <h3 id="create-episode-label" class="font-medium text-gray-800">
+          Add New episode
+        </h3>
+        <button type="button" class="size-8 inline-flex justify-center items-center gap-x-2 rounded-full border border-transparent bg-gray-100 text-gray-800 hover:bg-gray-200 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-200" aria-label="Close" data-hs-overlay="#create-episode">
+          <span class="sr-only">Close</span>
+          <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+        </button>
+      </div>
+      <!-- End Header -->
+
+      <!-- Body -->
+      <div class="overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300">
+        <div class="p-4 space-y-5 ">
+
+          <div>
+            <label for="hs-pro-dalpn" class="block mb-2 text-sm font-medium text-gray-800 dark:text-white">
+              Title
+            </label>
+
+            <input type="text" id="hs-pro-dalpn"
+              class="py-2.5 px-3 block w-full border-gray-200 rounded-lg text-sm placeholder:text-gray-400 focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-transparent dark:border-neutral-700 dark:text-neutral-300 dark:placeholder:text-white/60 dark:focus:ring-neutral-600"
+              >
+          </div>
+
+          <div class="space-y-2">
+            <label class="block block mb-2 text-sm font-medium text-gray-800 dark:text-neutral-200">
+              Upload Audio
+            </label>
+            <div class="p-12 flex justify-center bg-white border border-dashed border-gray-300 rounded-xl dark:bg-neutral-800 dark:border-neutral-600">
+              <div class="text-center">
+                <svg class="w-16 text-gray-400 mx-auto dark:text-neutral-400" width="70" height="46" viewBox="0 0 70 46" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M6.05172 9.36853L17.2131 7.5083V41.3608L12.3018 42.3947C9.01306 43.0871 5.79705 40.9434 5.17081 37.6414L1.14319 16.4049C0.515988 13.0978 2.73148 9.92191 6.05172 9.36853Z" fill="currentColor" stroke="currentColor" stroke-width="2" class="fill-white stroke-gray-400 dark:fill-neutral-800 dark:stroke-neutral-500"/>
+                  <path d="M63.9483 9.36853L52.7869 7.5083V41.3608L57.6982 42.3947C60.9869 43.0871 64.203 40.9434 64.8292 37.6414L68.8568 16.4049C69.484 13.0978 67.2685 9.92191 63.9483 9.36853Z" fill="currentColor" stroke="currentColor" stroke-width="2" class="fill-white stroke-gray-400 dark:fill-neutral-800 dark:stroke-neutral-500"/>
+                  <rect x="17.0656" y="1.62305" width="35.8689" height="42.7541" rx="5" fill="currentColor" stroke="currentColor" stroke-width="2" class="fill-white stroke-gray-400 dark:fill-neutral-800 dark:stroke-neutral-500"/>
+                  <path d="M47.9344 44.3772H22.0655C19.3041 44.3772 17.0656 42.1386 17.0656 39.3772L17.0656 35.9161L29.4724 22.7682L38.9825 33.7121C39.7832 34.6335 41.2154 34.629 42.0102 33.7025L47.2456 27.5996L52.9344 33.7209V39.3772C52.9344 42.1386 50.6958 44.3772 47.9344 44.3772Z" stroke="currentColor" stroke-width="2" class="stroke-gray-400 dark:stroke-neutral-500"/>
+                  <circle cx="39.5902" cy="14.9672" r="4.16393" stroke="currentColor" stroke-width="2" class="stroke-gray-400 dark:stroke-neutral-500"/>
+                </svg>
+
+                <div class="mt-4 flex flex-wrap justify-center text-sm leading-6 text-gray-600">
+                  <span class="pe-1 font-medium text-gray-800 dark:text-neutral-200">
+                    Drop your files here or
+                  </span>
+                  <label for="hs-pro-upcebb" class="relative cursor-pointer bg-white font-semibold text-blue-600 hover:text-blue-700 rounded-lg decoration-2 hover:underline focus-within:outline-none focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2 dark:bg-neutral-800 dark:text-blue-500 dark:hover:text-blue-600">
+                    <span>browse</span>
+                    <input id="hs-pro-upcebb" type="file" class="sr-only">
+                  </label>
+                </div>
+
+                <p class="mt-1 text-xs text-gray-400 dark:text-neutral-400">
+                 MP4, AVI, MOV
+                </p>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+      <!-- End Body -->
+
+      <!-- Footer -->
+      <div class="p-4 flex justify-end gap-x-2">
+        <div class="flex-1 flex justify-end items-center gap-2">
+          <button type="button" class="py-2 px-3 text-nowrap inline-flex justify-center items-center text-start bg-white border border-gray-200 text-gray-800 text-sm font-medium rounded-lg shadow-sm align-middle hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none" data-hs-overlay="#create-episode">
+            Save as draft
+          </button>
+
+          <button type="button" class="py-2 px-3 text-nowrap inline-flex justify-center items-center gap-x-2 text-start bg-blue-600 border border-blue-600 text-white text-sm font-medium rounded-lg shadow-sm align-middle hover:bg-blue-700 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:ring-1 focus:ring-blue-300" data-hs-overlay="#create-episode">
+            Publish
+          </button>
+        </div>
+      </div>
+      <!-- End Footer -->
+    </div>
+  </div>
+</div>
+<!-- End Add Event Modal -->

--- a/src/flimix/library/album/detail/audio_player.html
+++ b/src/flimix/library/album/detail/audio_player.html
@@ -1,0 +1,230 @@
+<div class="">
+  <h2 id="activity-title" class="text-lg font-medium text-gray-900 text-left mb-3" x-text="currentaudiotitle"></h2>
+  <div id="waveform" class="mb-10"></div>
+  <svg class="hidden">
+    <symbol id="backward" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M8 5L5 8M5 8L8 11M5 8H13.5C16.5376 8 19 10.4624 19 13.5C19 15.4826 18.148 17.2202 17 18.188"></path>
+      <path d="M5 15V19"></path>
+      <path d="M8 18V16C8 15.4477 8.44772 15 9 15H10C10.5523 15 11 15.4477 11 16V18C11 18.5523
+          10.5523 19 10 19H9C8.44772 19 8 18.5523 8 18Z"></path>
+    </symbol>
+  
+    <symbol id="play" viewBox="0 0 24 24">
+      <path fill-rule="evenodd" d="M4.5 5.653c0-1.426 1.529-2.33 2.779-1.643l11.54 6.348c1.295.712 1.295 2.573 0
+          3.285L7.28 19.991c-1.25.687-2.779-.217-2.779-1.643V5.653z" clip-rule="evenodd" />
+    </symbol>
+  
+    <symbol id="pause" viewBox="0 0 24 24">
+      <path fill-rule="evenodd" d="M6.75 5.25a.75.75 0 01.75-.75H9a.75.75 0 01.75.75v13.5a.75.75 0
+        01-.75.75H7.5a.75.75 0 01-.75-.75V5.25zm7.5 0A.75.75 0 0115 4.5h1.5a.75.75 0 01.75.75v13.5a.75.75 0
+        01-.75.75H15a.75.75 0 01-.75-.75V5.25z" clip-rule="evenodd" />
+    </symbol>
+  
+    <symbol id="forward" viewBox="0 0 24 24">
+      <path d="M16 5L19 8M19 8L16 11M19 8H10.5C7.46243 8 5 10.4624 5 13.5C5 15.4826 5.85204 17.2202 7 18.188"
+        stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+      <path d="M13 15V19" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+      <path d="M16 18V16C16 15.4477 16.4477 15 17 15H18C18.5523 15 19 15.4477 19 16V18C19 18.5523 18.5523 19 18
+        19H17C16.4477 19 16 18.5523 16 18Z" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+    </symbol>
+  
+    <symbol id="high" viewBox="0 0 24 24">
+      <path d="M13.5 4.06c0-1.336-1.616-2.005-2.56-1.06l-4.5 4.5H4.508c-1.141 0-2.318.664-2.66 1.905A9.76 9.76 0
+        001.5 12c0 .898.121 1.768.35 2.595.341 1.24 1.518 1.905 2.659 1.905h1.93l4.5 4.5c.945.945 2.561.276
+        2.561-1.06V4.06zM18.584 5.106a.75.75 0 011.06 0c3.808 3.807 3.808 9.98 0 13.788a.75.75 0 11-1.06-1.06
+        8.25 8.25 0 000-11.668.75.75 0 010-1.06z"></path>
+      <path d="M15.932 7.757a.75.75 0 011.061 0 6 6 0 010 8.486.75.75 0 01-1.06-1.061 4.5 4.5 0 000-6.364.75.75 0
+        010-1.06z"></path>
+    </symbol>
+  
+    <symbol id="off" viewBox="0 0 24 24">
+      <path d="M13.5 4.06c0-1.336-1.616-2.005-2.56-1.06l-4.5 4.5H4.508c-1.141 0-2.318.664-2.66 1.905A9.76 9.76 0
+        001.5 12c0 .898.121 1.768.35 2.595.341 1.24 1.518 1.905 2.659 1.905h1.93l4.5 4.5c.945.945 2.561.276
+        2.561-1.06V4.06zM17.78 9.22a.75.75 0 10-1.06 1.06L18.44 12l-1.72 1.72a.75.75 0 001.06 1.06l1.72-1.72 1.72
+        1.72a.75.75 0 101.06-1.06L20.56 12l1.72-1.72a.75.75 0 00-1.06-1.06l-1.72 1.72-1.72-1.72z" />
+    </symbol>
+  </svg>
+  
+  <media-controller
+class="w-full"
+audio
+style="
+  --media-background-color: transparent;
+  --media-control-background: transparent;
+  --media-control-hover-background: transparent;
+"
+>
+<audio
+  id="audio"
+  slot="media"
+  x-ref="audioPlayer"
+  src="https://stream.mux.com/O4h5z00885HEucNNa1rV02wZapcGp01FXXoJd35AHmGX7g/audio.m4a"
+  crossorigin
+></audio>
+
+<media-control-bar
+class="hidden md:flex w-full items-center h-16 px-4 bg-white rounded-md ring-1 ring-slate-700/10"
+>
+  <media-seek-backward-button seekoffset="10" class="p-0">
+    <svg
+      slot="icon"
+      aria-hidden="true"
+      class="w-7 h-7 fill-none stroke-slate-500"
+    >
+      <use href="#backward" />
+    </svg>
+  </media-seek-backward-button>
+  <media-play-button  id="play-btn" class="h-10 w-10 p-2 mx-3 rounded-full bg-slate-700">
+    <svg slot="play" aria-hidden="true" class="relative left-px">
+      <use href="#play" />
+    </svg>
+    <svg slot="pause" aria-hidden="true">
+      <use href="#pause" />
+    </svg>
+  </media-play-button>
+  <media-seek-forward-button seekoffset="10" class="p-0">
+    <svg
+      slot="icon"
+      aria-hidden="true"
+      class="w-7 h-7 fill-none stroke-slate-500"
+    >
+      <use href="#forward" />
+    </svg>
+  </media-seek-forward-button>
+  <media-time-display class="text-slate-500 text-sm"></media-time-display>
+  <media-time-range
+    class="block h-2 min-h-0 p-0 m-2 rounded-md bg-slate-50"
+    style="
+      --media-range-track-background: transparent;
+      --media-time-range-buffered-color: rgb(0 0 0 / 0.02);
+      --media-range-bar-color: rgb(79 70 229);
+      --media-range-track-border-radius: 4px;
+      --media-range-track-height: 0.5rem;
+      --media-range-thumb-background: rgb(79 70 229);
+      --media-range-thumb-box-shadow: 0 0 0 2px rgb(255 255 255 / 0.9);
+      --media-range-thumb-width: 0.25rem;
+      --media-range-thumb-height: 1rem;
+      --media-preview-time-text-shadow: transparent;
+    "
+  >
+    <media-preview-time-display
+      slot="preview"
+      class="text-slate-600 text-xs"
+    ></media-preview-time-display>
+  </media-time-range>
+  <media-duration-display
+    class="text-slate-500 text-sm"
+  ></media-duration-display>
+  <media-mute-button>
+    <svg slot="high" aria-hidden="true" class="h-5 w-5 fill-slate-500">
+      <use href="#high" />
+    </svg>
+    <svg slot="medium" aria-hidden="true" class="h-5 w-5 fill-slate-500">
+      <use href="#high" />
+    </svg>
+    <svg slot="low" aria-hidden="true" class="h-5 w-5 fill-slate-500">
+      <use href="#high" />
+    </svg>
+    <svg slot="off" aria-hidden="true" class="h-5 w-5 fill-slate-500">
+      <use href="#off" />
+    </svg>
+  </media-mute-button>
+</media-control-bar>
+<media-time-range
+class="md:hidden block  w-full h-2 min-h-0 p-0 bg-slate-50 focus-visible:ring-slate-700 focus-visible:ring-2"
+style="
+  --media-range-track-background: transparent;
+  --media-time-range-buffered-color: rgb(0 0 0 / 0.02);
+  --media-range-bar-color: rgb(79 70 229);
+  --media-range-track-height: 0.5rem;
+  --media-range-thumb-background: rgb(79 70 229);
+  --media-range-thumb-box-shadow: 0 0 0 2px rgb(255 255 255 / 0.9);
+  --media-range-thumb-width: 0.25rem;
+  --media-range-thumb-height: 1rem;
+  --media-preview-time-text-shadow: transparent;
+"
+>
+<media-preview-time-display
+  slot="preview"
+  class="text-slate-600 text-xs"
+></media-preview-time-display>
+</media-time-range>
+<media-control-bar
+class="flex md:hidden w-full h-20 bg-white items-center justify-between"
+>
+<media-seek-backward-button seekoffset="10" class="p-0">
+  <svg
+    slot="icon"
+    aria-hidden="true"
+    class="w-7 h-7 fill-none stroke-slate-500"
+  >
+    <use href="#backward" />
+  </svg>
+</media-seek-backward-button>
+<media-play-button class="h-10 w-10 p-2 mx-3 rounded-full bg-slate-700">
+  <svg slot="play" aria-hidden="true" class="relative left-px">
+    <use href="#play" />
+  </svg>
+  <svg slot="pause" aria-hidden="true">
+    <use href="#pause" />
+  </svg>
+</media-play-button>
+<media-seek-forward-button seekoffset="10" class="p-0">
+  <svg
+    slot="icon"
+    aria-hidden="true"
+    class="w-7 h-7 fill-none stroke-slate-500"
+  >
+    <use href="#forward" />
+  </svg>
+</media-seek-forward-button>
+
+<div
+  class="hidden @md:block h-full border-l border-slate-700/10 mx-4"
+></div>
+
+<media-time-display
+  class="order-last @md:order-none text-slate-500 text-sm"
+></media-time-display>
+
+<media-time-range
+  class="hidden @md:block h-2 min-h-0 p-0 m-2 rounded-md bg-slate-50"
+  style="
+    --media-range-track-background: transparent;
+    --media-time-range-buffered-color: rgb(0 0 0 / 0.02);
+    --media-range-bar-color: rgb(79 70 229);
+    --media-range-track-border-radius: 4px;
+    --media-range-track-height: 0.5rem;
+    --media-range-thumb-background: rgb(79 70 229);
+    --media-range-thumb-box-shadow: 0 0 0 2px rgb(255 255 255 / 0.9);
+    --media-range-thumb-width: 0.25rem;
+    --media-range-thumb-height: 1rem;
+    --media-preview-time-text-shadow: transparent;
+  "
+>
+  <media-preview-time-display
+    slot="preview"
+    class="text-slate-600 text-xs"
+  ></media-preview-time-display>
+</media-time-range>
+
+<media-duration-display
+  class="hidden @md:block text-slate-500 text-sm"
+></media-duration-display>
+
+<media-mute-button class="order-first @md:order-none">
+  <svg slot="high" aria-hidden="true" class="h-5 w-5 fill-slate-500">
+    <use href="#high" />
+  </svg>
+  <svg slot="medium" aria-hidden="true" class="h-5 w-5 fill-slate-500">
+    <use href="#high" />
+  </svg>
+  <svg slot="low" aria-hidden="true" class="h-5 w-5 fill-slate-500">
+    <use href="#high" />
+  </svg>
+  <svg slot="off" aria-hidden="true" class="h-5 w-5 fill-slate-500">
+    <use href="#off" />
+  </svg>
+</media-mute-button>
+</media-control-bar>
+</media-controller>

--- a/src/flimix/library/album/detail/audio_player.html
+++ b/src/flimix/library/album/detail/audio_player.html
@@ -3,10 +3,7 @@
   <div id="waveform" class="mb-10"></div>
   <svg class="hidden">
     <symbol id="backward" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M8 5L5 8M5 8L8 11M5 8H13.5C16.5376 8 19 10.4624 19 13.5C19 15.4826 18.148 17.2202 17 18.188"></path>
-      <path d="M5 15V19"></path>
-      <path d="M8 18V16C8 15.4477 8.44772 15 9 15H10C10.5523 15 11 15.4477 11 16V18C11 18.5523
-          10.5523 19 10 19H9C8.44772 19 8 18.5523 8 18Z"></path>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-500"><polygon points="19 20 9 12 19 4 19 20"/><line x1="5" x2="5" y1="19" y2="5"/></svg>
     </symbol>
   
     <symbol id="play" viewBox="0 0 24 24">
@@ -21,11 +18,7 @@
     </symbol>
   
     <symbol id="forward" viewBox="0 0 24 24">
-      <path d="M16 5L19 8M19 8L16 11M19 8H10.5C7.46243 8 5 10.4624 5 13.5C5 15.4826 5.85204 17.2202 7 18.188"
-        stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M13 15V19" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M16 18V16C16 15.4477 16.4477 15 17 15H18C18.5523 15 19 15.4477 19 16V18C19 18.5523 18.5523 19 18
-        19H17C16.4477 19 16 18.5523 16 18Z" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-500"><polygon points="5 4 15 12 5 20 5 4"/><line x1="19" x2="19" y1="5" y2="19"/></svg>
     </symbol>
   
     <symbol id="high" viewBox="0 0 24 24">
@@ -65,14 +58,10 @@ style="
 <media-control-bar
 class="hidden md:flex w-full items-center h-16 px-4 bg-white rounded-md ring-1 ring-slate-700/10"
 >
-  <media-seek-backward-button seekoffset="10" class="p-0">
-    <svg
-      slot="icon"
-      aria-hidden="true"
-      class="w-7 h-7 fill-none stroke-slate-500"
-    >
-      <use href="#backward" />
-    </svg>
+<button @click="$refs.audioPlayer.currentTime = 0;
+$refs.audioPlayer.play();prev()">
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-7 h-7 text-slate-500"><polygon points="19 20 9 12 19 4 19 20"/><line x1="5" x2="5" y1="19" y2="5"/></svg>
+ </button>
   </media-seek-backward-button>
   <media-play-button  id="play-btn" class="h-10 w-10 p-2 mx-3 rounded-full bg-slate-700">
     <svg slot="play" aria-hidden="true" class="relative left-px">
@@ -82,15 +71,10 @@ class="hidden md:flex w-full items-center h-16 px-4 bg-white rounded-md ring-1 r
       <use href="#pause" />
     </svg>
   </media-play-button>
-  <media-seek-forward-button seekoffset="10" class="p-0">
-    <svg
-      slot="icon"
-      aria-hidden="true"
-      class="w-7 h-7 fill-none stroke-slate-500"
-    >
-      <use href="#forward" />
-    </svg>
-  </media-seek-forward-button>
+  <button @click="$refs.audioPlayer.currentTime = 0;
+  $refs.audioPlayer.play();next()">
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-7 h-7 text-slate-500"><polygon points="5 4 15 12 5 20 5 4"/><line x1="19" x2="19" y1="5" y2="19"/></svg>
+   </button>
   <media-time-display class="text-slate-500 text-sm"></media-time-display>
   <media-time-range
     class="block h-2 min-h-0 p-0 m-2 rounded-md bg-slate-50"
@@ -152,15 +136,10 @@ style="
 <media-control-bar
 class="flex md:hidden w-full h-20 bg-white items-center justify-between"
 >
-<media-seek-backward-button seekoffset="10" class="p-0">
-  <svg
-    slot="icon"
-    aria-hidden="true"
-    class="w-7 h-7 fill-none stroke-slate-500"
-  >
-    <use href="#backward" />
-  </svg>
-</media-seek-backward-button>
+ <button @click="$refs.audioPlayer.currentTime = 0;
+ $refs.audioPlayer.play();prev()">
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-7 h-7 text-slate-500"><polygon points="19 20 9 12 19 4 19 20"/><line x1="5" x2="5" y1="19" y2="5"/></svg>
+ </button>
 <media-play-button class="h-10 w-10 p-2 mx-3 rounded-full bg-slate-700">
   <svg slot="play" aria-hidden="true" class="relative left-px">
     <use href="#play" />
@@ -169,15 +148,10 @@ class="flex md:hidden w-full h-20 bg-white items-center justify-between"
     <use href="#pause" />
   </svg>
 </media-play-button>
-<media-seek-forward-button seekoffset="10" class="p-0">
-  <svg
-    slot="icon"
-    aria-hidden="true"
-    class="w-7 h-7 fill-none stroke-slate-500"
-  >
-    <use href="#forward" />
-  </svg>
-</media-seek-forward-button>
+<button @click="$refs.audioPlayer.currentTime = 0;
+$refs.audioPlayer.play();next()">
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-7 h-7 text-slate-500"><polygon points="5 4 15 12 5 20 5 4"/><line x1="19" x2="19" y1="5" y2="19"/></svg>
+ </button>
 
 <div
   class="hidden @md:block h-full border-l border-slate-700/10 mx-4"

--- a/src/flimix/library/album/detail/audio_track_component.html
+++ b/src/flimix/library/album/detail/audio_track_component.html
@@ -1,0 +1,32 @@
+<script>
+  function audioTrackComponent() {
+    return {
+      currentaudiotitle: 'Lepak Kudenggeh',
+      showPlayer: false,
+      player_id: null,
+      titles: [
+        'Lepak Kudenggeh',
+        'Angry Bird',
+        'Nanben Daa',
+        'Pirantha Naal',
+        'Cintaku Buta 1.0'
+      ],
+
+      next() {
+        const index = this.titles.indexOf(this.currentaudiotitle);
+        if (index < this.titles.length - 1) {
+          this.currentaudiotitle = this.titles[index + 1];
+         
+        }
+      },
+
+      prev() {
+        const index = this.titles.indexOf(this.currentaudiotitle);
+        if (index > 0) {
+          this.currentaudiotitle = this.titles[index - 1];
+         
+        }
+      }
+    }
+  }
+</script>

--- a/src/flimix/library/album/detail/audio_tracks.html
+++ b/src/flimix/library/album/detail/audio_tracks.html
@@ -28,7 +28,7 @@
             </span>
           </th>
 
-          <th scope="col" class="min-w-full">
+          <th scope="col" class="w-2/3">
             <!-- Sort Dropdown -->
             <div class="hs-dropdown relative inline-flex w-full cursor-pointer">
               <button id="hs-pro-eptnms" type="button" class="px-4 py-2.5 text-start w-full flex items-center gap-x-1 text-sm font-normal text-stone-500 focus:outline-hidden focus:bg-stone-100 dark:text-neutral-500 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">

--- a/src/flimix/library/album/detail/audio_tracks.html
+++ b/src/flimix/library/album/detail/audio_tracks.html
@@ -1,0 +1,158 @@
+<div>
+  <div>
+    <div class="divide-y divide-gray-200 mb-10">
+      <div class="flex justify-between pb-4 mt-8">
+        <h2 id="activity-title" class="text-lg font-medium text-gray-900">Audio Tracks</h2>
+        <div class="flex items-center space-x-2">
+          <button type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="create-episode" data-hs-overlay="#create-episode" class="inline-flex items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-none focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700"
+            href="#" target="_parent">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+              stroke="currentColor" class="shrink-0 size-3.5">
+              <path stroke-linecap="round" stroke-linejoin="round"
+                d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+            </svg>
+            Add New Audio
+          </button>
+        </div>
+      </div>
+<div class="">
+<div class="overflow-x-auto [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-stone-100 [&::-webkit-scrollbar-thumb]:bg-stone-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500">
+  <div class="min-w-full inline-block align-middle">
+    <!-- Table -->
+    <table class="min-w-full divide-y divide-stone-200 dark:divide-neutral-700">
+      <thead>
+        <tr class="">
+          <th scope="col" class="px-3 py-2.5 text-start">
+            <span class="text-sm text-stone-500 dark:text-neutral-400 mr-4 font-normal">
+              #
+            </span>
+          </th>
+
+          <th scope="col" class="min-w-full">
+            <!-- Sort Dropdown -->
+            <div class="hs-dropdown relative inline-flex w-full cursor-pointer">
+              <button id="hs-pro-eptnms" type="button" class="px-4 py-2.5 text-start w-full flex items-center gap-x-1 text-sm font-normal text-stone-500 focus:outline-hidden focus:bg-stone-100 dark:text-neutral-500 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+                Title
+              </button>
+            </div>
+            <!-- End Sort Dropdown -->
+          </th>
+          <th scope="col" class="min-w-48">
+            <!-- Sort Dropdown -->
+            <div class="hs-dropdown relative inline-flex w-full cursor-pointer">
+              <button id="hs-pro-eptnms" type="button" class="px-4 py-2.5 text-start w-full flex items-center gap-x-1 text-sm font-normal text-stone-500 focus:outline-hidden focus:bg-stone-100 dark:text-neutral-500 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+                Duration
+              </button>
+            </div>
+            <!-- End Sort Dropdown -->
+          </th>
+          <th scope="col">              <!-- End Sort Dropdown -->
+          </th>
+        </tr>
+      </thead>
+
+      <tbody class="divide-y divide-stone-200 dark:divide-neutral-700">
+        {% for audio in audio_tracks %}
+        <tr x-data="{showplaybutton:'ontouchstart' in window, isplaying:false}"
+        
+        @mouseenter="showplaybutton = true"
+        @mouseleave="showplaybutton = 'ontouchstart' in window"
+        >
+          <td class="size-px whitespace-nowrap px-3 py-4">
+            <span class="text-sm  text-stone-800 dark:text-neutral-400 mr-4" >
+              {{ audio.id }}
+            </span>              
+            </td>
+          </td>
+          <td class="size-px whitespace-nowrap px-4 py-1">
+            <span class="text-sm font-medium  dark:text-neutral-200"  :class="currentaudiotitle === '{{ audio.title }}' && showPlayer ? 'text-indigo-800' : 'text-stone-600'"
+            ">
+              {{ audio.title }}
+            </span>
+            <span x-cloak x-show="showplaybutton  && player_id !== '{{ audio.id }}'" 
+            @click="
+            currentaudiotitle='{{ audio.title }}';
+            $refs.audioPlayer.currentTime = 0;
+            $refs.audioPlayer.play();
+            isplaying=true;
+            showPlayer=true;
+            player_id='{{ audio.id }}';
+          "
+          class="hover:cursor-pointer inline-flex ml-2 items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-hidden focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#">
+              play
+            </span>
+            <span x-cloak x-show="showplaybutton  && player_id=='{{ audio.id }}'" 
+            @click="
+            currentaudiotitle='{{ audio.title }}';
+            $refs.audioPlayer.currentTime = 0;
+            $refs.audioPlayer.pause();
+            isplaying=false;
+            player_id=null;
+            showPlayer=true;
+          "
+          class="hover:cursor-pointer inline-flex ml-2 items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-hidden focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#">
+              pause
+            </span>
+          </td> 
+          <td class="size-px whitespace-nowrap px-4 py-1">
+            <span class="text-sm text-stone-600 dark:text-neutral-400 mr-4">
+              {{ audio.duration }}
+            </span>
+          </td> 
+          <td class="h-px w-nowrap px-4 py-1 text-end">
+
+            <div class="hs-dropdown [--auto-close:inside] [--placement:bottom-right] relative inline-flex">
+              <button id="hs-pro-errtmd1" type="button" class="size-7 inline-flex justify-center items-center gap-x-2 rounded-lg border border-stone-200 bg-white text-stone-800 shadow-2xs hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-stone-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+                <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+              </button>
+
+              <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 w-auto border border-gray-200 [opacity,margin] duration opacity-0 hidden z-10 bg-white rounded-xl shadow-xl dark:bg-neutral-900" role="menu" aria-orientation="vertical" aria-labelledby="hs-pro-errtmd1">
+                <div class="p-1">
+                  <button type="button"
+                    class="w-full flex items-center gap-x-3 py-1.5 px-2 rounded-lg text-[13px] text-gray-800 hover:bg-gray-100 disabled:opacity-50 focus:outline-none focus:bg-gray-100 disabled:pointer-events-none dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                      stroke="currentColor" class="shrink-0 size-3.5">
+                      <path stroke-linecap="round" stroke-linejoin="round"
+                        d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+                    </svg>
+                    Edit
+                  </button>
+                  <button type="button"
+                    class="w-full flex items-center gap-x-3 py-1.5 px-2 rounded-lg text-[13px] text-gray-800 hover:bg-gray-100 disabled:opacity-50 focus:outline-none focus:bg-gray-100 disabled:pointer-events-none dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                      stroke="currentColor" class="shrink-0 size-3.5">
+                      <path stroke-linecap="round" stroke-linejoin="round"
+                        d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                    Delete
+                  </button>
+    
+                  <div class="my-1 border-t border-gray-200 dark:border-neutral-700"></div>
+                  <button type="button"
+                    class="w-full flex items-center gap-x-3 py-1.5 px-2 rounded-lg text-[13px] text-gray-800 hover:bg-gray-100 disabled:opacity-50 focus:outline-none focus:bg-gray-100 disabled:pointer-events-none dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                      stroke="currentColor" class="shrink-0 size-3.5">
+                      <path stroke-linecap="round" stroke-linejoin="round"
+                        d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                    </svg>
+                    Download Audio
+                  </button>
+                </div>
+              </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <!-- End Table -->
+  </div>
+</div>
+<!-- End Table Section -->
+</div>
+<!-- End Discounts Table Card -->
+<!-- End Table Content -->
+    </div>
+  </div>
+  

--- a/src/flimix/library/album/detail/audio_tracks.html
+++ b/src/flimix/library/album/detail/audio_tracks.html
@@ -81,7 +81,7 @@
           class="hover:cursor-pointer inline-flex ml-2 items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-hidden focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#">
               play
             </span>
-            <span x-cloak x-show="showplaybutton  && player_id=='{{ audio.id }}'" 
+            <span x-cloak x-show="showplaybutton  && player_id =='{{ audio.id }}'" 
             @click="
             currentaudiotitle='{{ audio.title }}';
             $refs.audioPlayer.currentTime = 0;

--- a/src/flimix/library/album/detail/content.html
+++ b/src/flimix/library/album/detail/content.html
@@ -1,0 +1,61 @@
+<div class="grid grid-cols-1 text-sm sm:grid-cols-12 sm:grid-rows-1 sm:gap-x-6 md:gap-x-8 lg:gap-x-8 mt-4">
+  <div class="sm:col-span-4 md:col-span-3 md:row-span-2 md:row-end-2">
+    <img src="https://i.scdn.co/image/ab67616d0000b27340dd41ad27cc4185f6631d62" alt="Off-white t-shirt with circular dot illustration on the front of mountain ridges that fade." class="aspect-square w-full rounded-lg bg-gray-50 object-cover">
+  </div>
+  <div class="mt-6 sm:col-span-7 sm:mt-0 md:row-end-1">
+    <h3 class="text-lg font-medium text-gray-900">
+      <a href="#">About Album</a>
+    </h3>
+    <p class="mt-3 text-gray-500">Best of Havoc Brothers is a collection of their most iconic and fan-favorite tracks, celebrating their journey in Tamil independent music. Perfect for both loyal fans and new listeners.</p>
+    <div class="flex flex-wrap  gap-1 sm:gap-2 mt-3">
+      <a class="inline-flex items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-none focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#">
+        Comedy
+      </a>
+    </div>
+    <dl class="grid grid-cols-1 mt-6 md:grid-cols-2 xl:grid-cols-1 gap-y-4">
+      <div class="flex flex-none w-full gap-x-4">
+        <dt class="flex-none">
+          <span class="sr-only">Released date</span>
+          <svg class="w-5 h-6 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M5.25 12a.75.75 0 01.75-.75h.01a.75.75 0 01.75.75v.01a.75.75 0 01-.75.75H6a.75.75 0 01-.75-.75V12zM6 13.25a.75.75 0 00-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 00.75-.75V14a.75.75 0 00-.75-.75H6zM7.25 12a.75.75 0 01.75-.75h.01a.75.75 0 01.75.75v.01a.75.75 0 01-.75.75H8a.75.75 0 01-.75-.75V12zM8 13.25a.75.75 0 00-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 00.75-.75V14a.75.75 0 00-.75-.75H8zM9.25 10a.75.75 0 01.75-.75h.01a.75.75 0 01.75.75v.01a.75.75 0 01-.75.75H10a.75.75 0 01-.75-.75V10zM10 11.25a.75.75 0 00-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 00.75-.75V12a.75.75 0 00-.75-.75H10zM9.25 14a.75.75 0 01.75-.75h.01a.75.75 0 01.75.75v.01a.75.75 0 01-.75.75H10a.75.75 0 01-.75-.75V14zM12 9.25a.75.75 0 00-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 00.75-.75V10a.75.75 0 00-.75-.75H12zM11.25 12a.75.75 0 01.75-.75h.01a.75.75 0 01.75.75v.01a.75.75 0 01-.75.75H12a.75.75 0 01-.75-.75V12zM12 13.25a.75.75 0 00-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 00.75-.75V14a.75.75 0 00-.75-.75H12zM13.25 10a.75.75 0 01.75-.75h.01a.75.75 0 01.75.75v.01a.75.75 0 01-.75.75H14a.75.75 0 01-.75-.75V10zM14 11.25a.75.75 0 00-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 00.75-.75V12a.75.75 0 00-.75-.75H14z">
+            </path>
+            <path fill-rule="evenodd" d="M5.75 2a.75.75 0 01.75.75V4h7V2.75a.75.75 0 011.5 0V4h.25A2.75 2.75 0 0118 6.75v8.5A2.75 2.75 0 0115.25 18H4.75A2.75 2.75 0 012 15.25v-8.5A2.75 2.75 0 014.75 4H5V2.75A.75.75 0 015.75 2zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75z" clip-rule="evenodd"></path>
+          </svg>
+        </dt>
+        <dd class="text-sm leading-6 text-gray-500">
+          <time datetime="2023-01-31">Released on 2023</time>
+        </dd>
+      </div>
+      <div class="flex flex-none w-full gap-x-4">
+        <dt class="flex-none">
+          <span class="sr-only">Season and episodes</span>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-6 text-gray-400">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 0 1-1.125-1.125M3.375 19.5h1.5C5.496 19.5 6 18.996 6 18.375m-3.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-1.5A1.125 1.125 0 0 1 18 18.375M20.625 4.5H3.375m17.25 0c.621 0 1.125.504 1.125 1.125M20.625 4.5h-1.5C18.504 4.5 18 5.004 18 5.625m3.75 0v1.5c0 .621-.504 1.125-1.125 1.125M3.375 4.5c-.621 0-1.125.504-1.125 1.125M3.375 4.5h1.5C5.496 4.5 6 5.004 6 5.625m-3.75 0v1.5c0 .621.504 1.125 1.125 1.125m0 0h1.5m-1.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m1.5-3.75C5.496 8.25 6 7.746 6 7.125v-1.5M4.875 8.25C5.496 8.25 6 8.754 6 9.375v1.5m0-5.25v5.25m0-5.25C6 5.004 6.504 4.5 7.125 4.5h9.75c.621 0 1.125.504 1.125 1.125m1.125 2.625h1.5m-1.5 0A1.125 1.125 0 0 1 18 7.125v-1.5m1.125 2.625c-.621 0-1.125.504-1.125 1.125v1.5m2.625-2.625c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125M18 5.625v5.25M7.125 12h9.75m-9.75 0A1.125 1.125 0 0 1 6 10.875M7.125 12C6.504 12 6 12.504 6 13.125m0-2.25C6 11.496 5.496 12 4.875 12M18 10.875c0 .621-.504 1.125-1.125 1.125M18 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m-12 5.25v-5.25m0 5.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125m-12 0v-1.5c0-.621-.504-1.125-1.125-1.125M18 18.375v-5.25m0 5.25v-1.5c0-.621.504-1.125 1.125-1.125M18 13.125v1.5c0 .621.504 1.125 1.125 1.125M18 13.125c0-.621.504-1.125 1.125-1.125M6 13.125v1.5c0 .621-.504 1.125-1.125 1.125M6 13.125C6 12.504 5.496 12 4.875 12m-1.5 0h1.5m-1.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M19.125 12h1.5m0 0c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h1.5m14.25 0h1.5"></path>
+          </svg>        
+        </dt>
+        <dd class="text-sm leading-6 text-gray-500">
+          25 Audio Tracks
+        </dd>
+      </div>
+        <div class="flex flex-none w-full gap-x-4">
+          <dt class="flex-none">
+            <span class="sr-only">Size</span>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-6 text-gray-400">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"></path>
+            </svg>                
+          </dt>
+          <dd class="text-sm leading-6 text-gray-500">Content Rated as U/A</dd>
+        </div>
+        <div class="flex flex-none w-full gap-x-4">
+          <dt class="flex-none">
+            <span class="sr-only">Size</span>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-6 text-gray-400">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"></path>
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"></path>
+            </svg>                     
+          </dt>
+          <dd class="text-sm leading-6 text-gray-500">500k views</dd>
+        </div>
+    </dl>
+  </div>
+</div>

--- a/src/flimix/library/album/detail/header.html
+++ b/src/flimix/library/album/detail/header.html
@@ -1,0 +1,69 @@
+<p class="inline-flex justify-between items-center gap-x-1">
+  <a href="/flimix/asset/all/" class="text-sm text-indigo-600 decoration-2 hover:underline font-medium focus:outline-hidden focus:underline dark:text-indigo-400 dark:hover:text-indigo-500">
+    Albums
+  </a>
+</p>
+<div class="lg:flex lg:items-center lg:justify-between py-2">
+  
+  <div class="min-w-0 flex-1">
+    <h2 class="text-2xl/7 font-bold text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">Best of Havoc Brothers</h2>  
+  </div>
+  <div class="mt-5 flex lg:ml-4 lg:mt-0">
+    <span class="hidden sm:block">
+      <button type="button" class="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+        <svg class="-ml-0.5 mr-1.5 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+          <path d="m2.695 14.762-1.262 3.155a.5.5 0 0 0 .65.65l3.155-1.262a4 4 0 0 0 1.343-.886L17.5 5.501a2.121 2.121 0 0 0-3-3L3.58 13.419a4 4 0 0 0-.885 1.343Z" />
+        </svg>
+        Edit
+      </button>
+    </span>
+
+    <span class="ml-3 hidden sm:block">
+      <button type="button" class="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="-ml-0.5 mr-1.5 size-5 text-red-400">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+        </svg> 
+        Delete
+      </button>
+    </span>
+
+    <span class="sm:ml-3">
+      <button type="button" class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+        <svg class="-ml-0.5 mr-1.5 size-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+          <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />
+        </svg>
+        Publish
+      </button>
+    </span>
+
+    <!-- Dropdown -->
+    <div class="relative ml-3 sm:hidden" x-data="{ open: false }">
+      <!-- Button to toggle the dropdown -->
+      <button type="button" class="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:ring-gray-400" @click="open = !open" aria-expanded="false" aria-haspopup="true">
+        More
+        <svg class="-mr-1 ml-1.5 size-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+          <path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+        </svg>
+      </button>
+
+      <!-- Dropdown menu -->
+      <div x-show="open" 
+           @click.outside="open = false" 
+           x-transition:enter="transition ease-out duration-200" 
+           x-transition:enter-start="transform opacity-0 scale-95" 
+           x-transition:enter-end="transform opacity-100 scale-100" 
+           x-transition:leave="transition ease-in duration-75" 
+           x-transition:leave-start="transform opacity-100 scale-100" 
+           x-transition:leave-end="transform opacity-0 scale-95"
+           class="absolute right-0 z-10 -mr-1 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-none" 
+           role="menu" 
+           aria-orientation="vertical" 
+           aria-labelledby="mobile-menu-button" 
+           tabindex="-1">
+        <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="mobile-menu-item-0">Edit</a>
+        <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="mobile-menu-item-1">Delete</a>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/src/flimix/library/album/detail/index.html
+++ b/src/flimix/library/album/detail/index.html
@@ -7,7 +7,7 @@
 {% endblock extra_head %}
 
 {% block main_content %}
-<div x-data="{currentaudiotitle:'Lepak Kudenggeh',showPlayer:false,player_id:null}">
+<div x-data="audioTrackComponent()">
   {% include "./header.html" %}
   {% include "./content.html" %}
   {% include "./audio_tracks.html" %}
@@ -24,6 +24,7 @@
 
 {% block script %}
 {% include "src/flimix/utils/alpine_multiselect.html" %}
+{% include "./audio_track_component.html" %}
 <script>
   // Get Media Chrome elements
   const audio = document.getElementById('audio');

--- a/src/flimix/library/album/detail/index.html
+++ b/src/flimix/library/album/detail/index.html
@@ -1,0 +1,52 @@
+{% extends "src/flimix/layouts/sidebar_layout.html" %}
+{% block extra_head %}
+<script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome@4/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome/menu/+esm"></script>
+<script src="https://cdn.jsdelivr.net/npm/wavesurfer.js"></script>
+
+{% endblock extra_head %}
+
+{% block main_content %}
+<div x-data="{currentaudiotitle:'Lepak Kudenggeh',showPlayer:false,player_id:null}">
+  {% include "./header.html" %}
+  {% include "./content.html" %}
+  {% include "./audio_tracks.html" %}
+
+  </div>
+  {% include "./add_audio_track.html" %}
+  <footer x-cloak x-transition x-show="showPlayer" class="sticky bottom-0 bg-white border-t p-4 text-center text-sm text-gray-600 shadow-md z-50 -mb-10 -mx-4 sm:-mx-6 lg:-mx-8">
+    {% include "./audio_player.html" %}
+   </footer>
+</div>
+
+{% endblock main_content %}
+
+
+{% block script %}
+{% include "src/flimix/utils/alpine_multiselect.html" %}
+<script>
+  // Get Media Chrome elements
+  const audio = document.getElementById('audio');
+
+  // Initialize Wavesurfer (DISABLE AUDIO)
+  const wavesurfer = WaveSurfer.create({
+    container: '#waveform',
+    waveColor: 'blue',
+    progressColor: 'darkblue',
+    barWidth: 2,
+    height: 50,
+    responsive: true,
+    interact: true,
+    backend: 'MediaElement',
+    media: audio,  
+  });
+  
+  wavesurfer.on('seek', (progress) => {
+    audio.currentTime = progress * audio.duration;
+  });
+
+  audio.addEventListener('loadeddata', () => {
+    wavesurfer.setTime(audio.currentTime);
+  });
+</script>
+{% endblock script %}

--- a/src/flimix/library/album/list/contents.html
+++ b/src/flimix/library/album/list/contents.html
@@ -42,7 +42,7 @@
         </ul>
       </div>
     </div>
-    <a href="/flimix/library/albums/detail/"
+    <a href="/flimix/library/album/detail/"
       class="px-4 pb-4 mt-auto inline-flex items-center gap-x-1 text-sm text-gray-800 underline underline-offset-4 hover:text-indigo-600 focus:outline-none focus:text-indigo-600 dark:text-neutral-200 dark:hover:text-indigo-400 dark:focus:text-indigo-400">
       View Details
       <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an album detail page with a responsive layout, including album information, metadata, and a "Comedy" tag.
  - Added a header section with breadcrumb navigation and action buttons for editing, deleting, and publishing albums.
  - Implemented an interactive audio tracks list with play/pause controls, action menus, and responsive design.
  - Added a modal dialog for uploading and adding new audio tracks.
  - Integrated a full-featured audio player with waveform visualization, playback controls, and responsive layouts.
  - Enabled navigation between audio tracks with next/previous controls.
  - Added a structured data source for audio tracks.

- **Bug Fixes**
  - Corrected the "View Details" link URL in the album list for accurate navigation.

- **Chores**
  - Added a new template block for footer content in the sidebar layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->