### PR TITLE
Add PDF Download Link Design to Content Pages

### DIFF
--- a/src/content_detail_page/attachment.html
+++ b/src/content_detail_page/attachment.html
@@ -12,7 +12,7 @@
   {% include "./includes/desktop_sidebar.html" %}
   <main class="lg:pl-96">
     {% include "./includes/navigate_content.html" %}
-    <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false}">
+    <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
       {% include "./includes/content_heading.html" %}
       <div class="mt-6 py-2 px-4 sm:px-6 lg:px-0 max-w-5xl mx-auto flex justify-center">
         <div>

--- a/src/content_detail_page/exam.html
+++ b/src/content_detail_page/exam.html
@@ -12,7 +12,7 @@
 	{% include "./includes/desktop_sidebar.html" %}  
 	<main class="lg:pl-96" x-data="GenerateorDownloadCertificate">
     {% include "./includes/navigate_content.html" %}
-    <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false}">
+    <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
         <div class="mt-6 p-4 sm:px-6 lg:px-0 flex items-center justify-between">
           <div class="min-w-0 flex-1">
             <h1 class="text-lg lg:text-2xl font-bold text-gray-900">What is Markup language?</h1>

--- a/src/content_detail_page/includes/content_heading.html
+++ b/src/content_detail_page/includes/content_heading.html
@@ -1,6 +1,11 @@
 <div class="mt-6 px-4 sm:px-6 lg:px-0 flex justify-between items-center">
   <h1 class="text-lg lg:text-2xl font-bold text-gray-900">What is Markup language?</h1>
   <div class="flex items-center justify-center space-x-2">
+    <a class="cursor-pointer" title="Download" x-show="is_renderable" x-cloak>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-6 h-6 text-emerald-600" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/>
+      </svg>                
+    </a>
     <a class="cursor-pointer" x-on:click="toggleSVG = !toggleSVG" title="Bookmark" x-show="!isBookmarked" x-cloak>
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600">
         <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
@@ -9,11 +14,6 @@
     <a class="cursor-pointer" x-on:click="isBookmarked = false" title="Remove Bookmark" x-show="isBookmarked" x-cloak> 
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l1.664 1.664M21 21l-1.5-1.5m-5.485-1.242L12 17.25 4.5 21V8.742m.164-4.078a2.15 2.15 0 011.743-1.342 48.507 48.507 0 0111.186 0c1.1.128 1.907 1.077 1.907 2.185V19.5M4.664 4.664L19.5 19.5" />
-      </svg>                
-    </a>
-    <a class="cursor-pointer" title="Download" x-show="is_renderable" x-cloak>
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-6 h-6 text-emerald-600" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/>
       </svg>                
     </a>
   </div>

--- a/src/content_detail_page/includes/content_heading.html
+++ b/src/content_detail_page/includes/content_heading.html
@@ -1,14 +1,19 @@
 <div class="mt-6 px-4 sm:px-6 lg:px-0 flex justify-between items-center">
   <h1 class="text-lg lg:text-2xl font-bold text-gray-900">What is Markup language?</h1>
-  <div>
-    <a class="cursor-pointer" x-on:click="toggleSVG = !toggleSVG">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600" x-show="!isBookmarked" x-cloak>
+  <div class="flex items-center justify-center space-x-2">
+    <a class="cursor-pointer" x-on:click="toggleSVG = !toggleSVG" title="Bookmark" x-show="!isBookmarked" x-cloak>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600">
         <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
       </svg>  
     </a>
-    <a class="cursor-pointer" x-on:click="isBookmarked = false"> 
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600" x-show="isBookmarked" x-cloak>
+    <a class="cursor-pointer" x-on:click="isBookmarked = false" title="Remove Bookmark" x-show="isBookmarked" x-cloak> 
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l1.664 1.664M21 21l-1.5-1.5m-5.485-1.242L12 17.25 4.5 21V8.742m.164-4.078a2.15 2.15 0 011.743-1.342 48.507 48.507 0 0111.186 0c1.1.128 1.907 1.077 1.907 2.185V19.5M4.664 4.664L19.5 19.5" />
+      </svg>                
+    </a>
+    <a class="cursor-pointer" title="Download" x-show="is_renderable" x-cloak>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-6 h-6 text-emerald-600" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/>
       </svg>                
     </a>
   </div>

--- a/src/content_detail_page/includes/video_content.html
+++ b/src/content_detail_page/includes/video_content.html
@@ -1,5 +1,5 @@
 
-<div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false}">
+<div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
   {% include "./content_heading.html" %}
   <div class="mt-6">
     <div style="padding-top:56.25%;position:relative;">

--- a/src/content_detail_page/notes.html
+++ b/src/content_detail_page/notes.html
@@ -14,7 +14,7 @@
 	{% include "./includes/desktop_sidebar.html" %}  
 	<main class="lg:pl-96">
 		{% include "./includes/navigate_content.html" %}
-    <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false}">
+    <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
 
       <div>
         {% include "./includes/content_heading.html" %}

--- a/src/content_detail_page/pdf.html
+++ b/src/content_detail_page/pdf.html
@@ -14,7 +14,7 @@
 	{% include "./includes/desktop_sidebar.html" %}  
 	<main class="lg:pl-96">
 		{% include "./includes/navigate_content.html" %}
-		<div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false}">
+		<div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:true}">
 		  {% include "./includes/content_heading.html" %}
 			<div class="mt-6">
 				<iframe allowfullscreen="" webkitallowfullscreen="" src="https://media.testpress.in/static/js/pdf_js_v3_10_111/web/viewer.html?file=https%3A%2F%2Fd36vpug2b5drql.cloudfront.net%2Finstitute%2Flmsdemo%2Fprivate%2Fcourses%2F720%2Fattachments%2F307698b93678438b936998dc7cc18ace.pdf%3FExpires%3D1698831263%26Signature%3DYnSG2UOig~UFMWBxsnLl1-e4-ewMcLoZX-Ge65AJoj7G-HD3atOcgP8BEorqBxJDJs037mkvRehKrn6gT1rIeKC-ZusvxS~4zJYReTY3lH5LquzUkBrCzIHSNND4qgirGjnse7om9fRG9awBJHoqlyDdcxyjRXk3Et8qgQriJiIIJXgWByM2wL0K9ovD~UMrvinvUqedpJ01~PcDeomnEGh81jv77Sui3TqxqpyZWFConbM7fMRpgAgxZRBmuxhUyvuWWpSwT66oL3PQMF5oGxz0ORo2ncQZdrL0gPfSve2ST6vamf0-i8HXiSHtHRQnKmW1YH3pNNRpukWj1ArRyw__%26Key-Pair-Id%3DK2XWKDWM065EGO" height="800px" id="admin-pdf-viewer" runat="server" width="100%"></iframe>

--- a/src/content_detail_page/video_conf_start.html
+++ b/src/content_detail_page/video_conf_start.html
@@ -14,7 +14,7 @@
 	{% include "./includes/desktop_sidebar.html" %}  
 	<main class="lg:pl-96">
 		{% include "./includes/navigate_content.html" %}
-    <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false}">
+    <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
       {% include "./includes/content_heading.html" %}    
       <div class="sm:block px-4 sm:px-6 lg:px-0 mt-6">
         <section aria-labelledby="quick-links-title" class="p-0 sm:p-6 2xl:p-8 space-y-6 mx-auto max-w-xl sm:border rounded-md">


### PR DESCRIPTION
This pull request introduces a new PDF download icon across PDF content pages, providing a visual cue for downloadable content. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a download icon next to the bookmark icon for content items, allowing users to access downloads when available.
- **Accessibility**
	- Added descriptive tooltips to bookmark and download icons for improved accessibility.
- **Style**
	- Updated icon layout for better spacing and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->