### PR TITLE
ui: Add Zoom recording icon for assets

### DIFF
--- a/src/_data/assets.json
+++ b/src/_data/assets.json
@@ -61,7 +61,8 @@
         "created_at": "Feb. 28, 2023, 10:32 AM",
         "status": "Error",
         "live_duration": "2 Hrs 23 Mins",
-        "type": "video"
+        "type": "video",
+        "is_zoom_recording": true
     },
     {
         "id": "8z5NQyXmcpu",
@@ -69,7 +70,8 @@
         "created_at": "Feb. 27, 2023, 05:52 AM",
         "status": "Completed",
         "live_duration": "1 Hr 5 Mins",
-        "type": "video"
+        "type": "video",
+        "is_zoom_recording": true
     },
     {
         "id": "C6taNjHTTEr",
@@ -77,7 +79,8 @@
         "created_at": "Feb. 27, 2023, 05:49 AM",
         "status": "Uploading",
         "live_duration": "2 Hrs 18 Mins",
-        "type": "video"
+        "type": "video",
+        "is_zoom_recording": true
     },
     {
         "id": "7dIvydxf5hm",

--- a/src/tpstreams/assets/asset_item.html
+++ b/src/tpstreams/assets/asset_item.html
@@ -1,9 +1,15 @@
 <tr>
   <td class="whitespace-nowrap pl-4 sm:pl-6 pr-3 py-4 text-sm font-medium text-gray-900">
     <div class="flex space-x-3 items-center">
+      {% if asset.is_zoom_recording %}
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8 text-red-400">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z" />
+      </svg>        
+      {% else %}
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-8 h-8 text-red-400">
         <path fill-rule="evenodd" d="M1.5 5.625c0-1.036.84-1.875 1.875-1.875h17.25c1.035 0 1.875.84 1.875 1.875v12.75c0 1.035-.84 1.875-1.875 1.875H3.375A1.875 1.875 0 011.5 18.375V5.625zm1.5 0v1.5c0 .207.168.375.375.375h1.5a.375.375 0 00.375-.375v-1.5a.375.375 0 00-.375-.375h-1.5A.375.375 0 003 5.625zm16.125-.375a.375.375 0 00-.375.375v1.5c0 .207.168.375.375.375h1.5A.375.375 0 0021 7.125v-1.5a.375.375 0 00-.375-.375h-1.5zM21 9.375A.375.375 0 0020.625 9h-1.5a.375.375 0 00-.375.375v1.5c0 .207.168.375.375.375h1.5a.375.375 0 00.375-.375v-1.5zm0 3.75a.375.375 0 00-.375-.375h-1.5a.375.375 0 00-.375.375v1.5c0 .207.168.375.375.375h1.5a.375.375 0 00.375-.375v-1.5zm0 3.75a.375.375 0 00-.375-.375h-1.5a.375.375 0 00-.375.375v1.5c0 .207.168.375.375.375h1.5a.375.375 0 00.375-.375v-1.5zM4.875 18.75a.375.375 0 00.375-.375v-1.5a.375.375 0 00-.375-.375h-1.5a.375.375 0 00-.375.375v1.5c0 .207.168.375.375.375h1.5zM3.375 15h1.5a.375.375 0 00.375-.375v-1.5a.375.375 0 00-.375-.375h-1.5a.375.375 0 00-.375.375v1.5c0 .207.168.375.375.375zm0-3.75h1.5a.375.375 0 00.375-.375v-1.5A.375.375 0 004.875 9h-1.5A.375.375 0 003 9.375v1.5c0 .207.168.375.375.375zm4.125 0a.75.75 0 000 1.5h9a.75.75 0 000-1.5h-9z" clip-rule="evenodd" />
       </svg>
+      {% endif %}
       <a href="{{ '/tpstreams/assets/detail'|url }}" title="{{ asset.title }}">{{ asset.name }}</a>
       {% if asset.status == 'Uploading' %}
         <span class="inline-flex items-center rounded-full bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700">{{ asset.status }}</span>


### PR DESCRIPTION
- Display a Zoom-specific icon for assets identified as Zoom recordings
- Improves visual distinction between Zoom and non-Zoom content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual indicator for Zoom recordings in the asset list. Assets identified as Zoom recordings now display a distinct icon for easier identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->