### PR TITLE
Add content detail page header

### DIFF
--- a/src/content_detail_page/attachment.html
+++ b/src/content_detail_page/attachment.html
@@ -42,5 +42,6 @@
     </div>
     {% include "./includes/comment_section.html" %}
   </main>
+  {% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}

--- a/src/content_detail_page/discussions.html
+++ b/src/content_detail_page/discussions.html
@@ -18,5 +18,6 @@ tab: "discussions"
     {% include "./includes/course_tabs.html" %}
     {% include "./includes/discussions_list.html" %}
   </main>
+  {% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}

--- a/src/content_detail_page/exam.html
+++ b/src/content_detail_page/exam.html
@@ -35,6 +35,7 @@
     </div>
     {% include "./includes/exam_footer.html" %}
   </main>
+  {% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}
 

--- a/src/content_detail_page/history.html
+++ b/src/content_detail_page/history.html
@@ -19,5 +19,6 @@ tab: "history"
     {% include "./includes/history.html" %}
     {% include "./includes/pagination.html" %}
   </main>
+  {% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}

--- a/src/content_detail_page/includes/ai_pdf_chat.html
+++ b/src/content_detail_page/includes/ai_pdf_chat.html
@@ -1,4 +1,4 @@
-<div class="lg:mt-16 h-full flex flex-col lg:pl-[23.5rem] xl:pl-0">
+<div class="lg:[height:calc(100vh-4rem)] xl:mt-16 flex flex-col lg:pl-[23.5rem] xl:pl-0">
   <!-- Header -->
   <div class="py-3 px-5 flex justify-between items-center border-b border-gray-200 dark:border-neutral-800">
     <span id="hs-pro-chtsdid1-label" class="block font-semibold text-gray-800 dark:text-neutral-200">

--- a/src/content_detail_page/includes/ai_pdf_chat.html
+++ b/src/content_detail_page/includes/ai_pdf_chat.html
@@ -25,7 +25,7 @@
       <!-- Title Input -->
       <div class="xl:h-screen h-[70vh] overflow-y-auto p-4 overflow-y-auto overflow-x-hidden [&amp;::-webkit-scrollbar]:w-2 [&amp;::-webkit-scrollbar-thumb]:rounded-full [&amp;::-webkit-scrollbar-track]:bg-gray-100 [&amp;::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&amp;::-webkit-scrollbar-track]:bg-neutral-700 dark:[&amp;::-webkit-scrollbar-thumb]:bg-neutral-500">
 
-        <div class="relative">
+        <div class="relative pb-20 lg:pb-[10rem]">
 
           <!-- List -->
           <div class="w-full space-y-5">

--- a/src/content_detail_page/includes/ai_pdf_chat.html
+++ b/src/content_detail_page/includes/ai_pdf_chat.html
@@ -1,4 +1,4 @@
-<div class="h-full flex flex-col lg:pl-[23.5rem] xl:pl-0">
+<div class="lg:mt-16 h-full flex flex-col lg:pl-[23.5rem] xl:pl-0">
   <!-- Header -->
   <div class="py-3 px-5 flex justify-between items-center border-b border-gray-200 dark:border-neutral-800">
     <span id="hs-pro-chtsdid1-label" class="block font-semibold text-gray-800 dark:text-neutral-200">

--- a/src/content_detail_page/includes/course_tabs.html
+++ b/src/content_detail_page/includes/course_tabs.html
@@ -1,4 +1,5 @@
-<div>
+{% include "./viewer_header.html" %}
+<div class="mt-16">
   <div class="xl:hidden px-4 mt-6">
     <label for="tabs" class="sr-only">Select a tab</label>
     <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->

--- a/src/content_detail_page/includes/course_tabs.html
+++ b/src/content_detail_page/includes/course_tabs.html
@@ -1,5 +1,5 @@
 {% include "./viewer_header.html" %}
-<div class="mt-16">
+<div class="lg:mt-20 xl:mt-16">
   <div class="xl:hidden px-4 mt-6">
     <label for="tabs" class="sr-only">Select a tab</label>
     <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->

--- a/src/content_detail_page/includes/global_search_modal.html
+++ b/src/content_detail_page/includes/global_search_modal.html
@@ -1,0 +1,110 @@
+  <div id="hs-pro-dnsm" class="hs-overlay hs-overlay-backdrop-open:backdrop-blur-md hidden size-full fixed top-0 start-0 z-[80] overflow-x-hidden overflow-y-auto pointer-events-none" role="dialog" tabindex="-1" aria-label="Search">
+    <div class="hs-overlay-open:opacity-100 hs-overlay-open:duration-500 opacity-0 ease-out transition-all sm:max-w-lg sm:w-full m-3 sm:mx-auto h-[calc(100%-56px)] min-h-[calc(100%-56px)] flex items-center">
+      <div class="max-h-full relative w-full flex flex-col bg-white rounded-xl pointer-events-auto shadow-xl dark:bg-neutral-800">
+        <!-- Input -->
+        <div class="relative">
+          <div class="absolute inset-y-0 start-0 flex items-center pointer-events-none z-[20] ps-3.5">
+            <svg class="shrink-0 size-4 text-gray-400 dark:text-white/60" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+          </div>
+          <div class="border-b border-gray-200 dark:border-neutral-700">
+              <input type="text" class="py-2.5 sm:py-3 ps-10 pe-8 block w-full bg-white border-transparent rounded-t-lg sm:text-sm focus:outline-hidden focus:ring-0 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-800 dark:text-neutral-400 dark:placeholder:text-neutral-400 focus:border-transparent focus:outline-none focus:ring-0" placeholder="Search or type a command" autofocus>
+          </div>
+          <div class="hidden absolute inset-y-0 end-0 flex items-center z-[20] pe-1">
+            <button type="button" class="inline-flex shrink-0 justify-center items-center size-6 rounded-full text-gray-500 hover:text-emerald-600 focus:outline-hidden focus:text-emerald-600 dark:text-neutral-500 dark:hover:text-emerald-500 dark:focus:text-emerald-500" aria-label="Close">
+              <span class="sr-only">Close</span>
+              <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <path d="m15 9-6 6" />
+                <path d="m9 9 6 6" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <!-- End Input -->
+
+        <!-- Body -->
+        <div class="h-125 p-4 overflow-y-auto overflow-hidden [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500">
+          <!-- List Group -->
+          <div class="pb-4 mb-4 last:pb-0 last:mb-0 last:border-0 border-b border-gray-200 dark:border-neutral-700">
+            <span class="block text-xs text-gray-500 mb-2 dark:text-neutral-500">
+              Filter
+            </span>
+
+            <!-- Label Button Group -->
+            <div class="flex flex-wrap  gap-1 sm:gap-2">
+              <a class="inline-flex items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-hidden focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#">
+                Course
+              </a>
+              <a class="inline-flex items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-hidden focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#">
+                Chapter
+              </a>
+              <a class="inline-flex items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-hidden focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#">
+                Exam
+              </a>
+              <a class="inline-flex items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-hidden focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#">
+                Video
+              </a>
+              <a class="inline-flex items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-hidden focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#">
+                Posts
+              </a>
+              <a class="inline-flex items-center gap-x-1.5 text-xs text-gray-800 bg-white border border-gray-200 hover:bg-gray-100 py-1.5 px-2.5 rounded-full focus:outline-hidden focus:bg-gray-100 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#">
+                Notes
+              </a>
+            </div>
+            <!-- End Label Button Group -->
+          </div>
+        </div>
+        <!-- End Body -->
+
+        <!-- Footer -->
+        <div class="py-3 px-4 flex flex-wrap justify-between items-center gap-2 border-t border-gray-200 dark:border-neutral-700">
+          <div class="inline-flex items-center gap-x-2">
+            <div class="size-5 flex flex-col justify-center items-center bg-white border border-gray-200 text-xs uppercase text-gray-400 shadow-2xs rounded-sm dark:bg-neutral-800 dark:border-neutral-700">
+              <svg class="shrink-0 size-3 text-gray-400 dark:text-neutral-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="9 10 4 15 9 20" />
+                <path d="M20 4v7a4 4 0 0 1-4 4H4" />
+              </svg>
+            </div>
+            <span class="text-xs text-gray-400 dark:text-neutral-500">
+              to close
+            </span>
+          </div>
+
+          <div class="inline-flex items-center gap-x-4">
+            <div class="inline-flex items-center gap-x-2">
+              <div class="size-5 flex flex-col justify-center items-center bg-white border border-gray-200 text-xs uppercase text-gray-400 shadow-2xs rounded-sm dark:bg-neutral-800 dark:border-neutral-700">
+                <svg class="shrink-0 size-3.5 text-gray-400 dark:text-neutral-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M22 14.596C21.828 15.1189 20.888 16 19.5969 16C18.3057 16 16.9265 14.6624 16.9265 12.8974V12.0687C16.9265 10.2373 18.2022 9.00142 19.5969 9.00142C20.9918 9.00142 21.7942 9.69876 22 10.5666M14.5417 10.3109C14.3233 9.6198 13.3292 8.96537 12.1831 9.00142C11.0374 9.03732 10.0119 9.83333 10.0119 10.777C10.0119 11.7208 10.6901 12.0632 12.1839 12.2081C13.6774 12.353 14.49 13.1331 14.5417 13.9596C14.5934 14.7861 13.8083 16 12.1839 16C10.7604 16 9.69525 14.6894 9.63548 13.9379M7.25295 14.7213C6.82726 15.5884 5.94455 15.9999 4.75814 15.9999C3.57172 15.9999 2 15.088 2 12.7831V12.1113C2 10.5911 3.16477 9.00113 4.75814 9.00113C6.35166 9.00113 7.41158 10.5059 7.25295 12.2838H2.47754" />
+                </svg>
+              </div>
+              <span class="text-xs text-gray-400 dark:text-neutral-500">
+                to select
+              </span>
+            </div>
+
+            <div class="inline-flex items-center gap-x-2">
+              <div class="size-5 flex flex-col justify-center items-center bg-white border border-gray-200 text-xs uppercase text-gray-400 shadow-2xs rounded-sm dark:bg-neutral-800 dark:border-neutral-700">
+                <svg class="shrink-0 size-3 text-gray-400 dark:text-neutral-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 5v14" />
+                  <path d="m19 12-7 7-7-7" />
+                </svg>
+              </div>
+              <div class="size-5 flex flex-col justify-center items-center bg-white border border-gray-200 text-xs uppercase text-gray-400 shadow-2xs rounded-sm dark:bg-neutral-800 dark:border-neutral-700">
+                <svg class="shrink-0 size-3 text-gray-400 dark:text-neutral-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="m5 12 7-7 7 7" />
+                  <path d="M12 19V5" />
+                </svg>
+              </div>
+              <span class="text-xs text-gray-400 dark:text-neutral-500">
+                to navigate
+              </span>
+            </div>
+          </div>
+        </div>
+        <!-- End Footer -->
+      </div>
+    </div>
+  </div>

--- a/src/content_detail_page/includes/mobile_sidebar.html
+++ b/src/content_detail_page/includes/mobile_sidebar.html
@@ -1,4 +1,4 @@
-<div class="relative z-50 lg:hidden" role="dialog" aria-modal="true">
+<div class="relative z-50 lg:hidden mt-16" role="dialog" aria-modal="true">
   <!--
     Off-canvas menu backdrop, show/hide based on off-canvas menu state.
 

--- a/src/content_detail_page/includes/mobile_sidebar.html
+++ b/src/content_detail_page/includes/mobile_sidebar.html
@@ -91,7 +91,7 @@
   </div>
 </div>
 
-<div class="sticky top-0 z-40 flex items-center gap-x-6 bg-white px-4 py-3 shadow-sm sm:px-6 xl:hidden">
+<div class="sticky top-16 z-5 flex items-center gap-x-6 bg-white px-4 py-3 shadow-sm sm:px-6 xl:hidden">
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
     <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
   </svg>

--- a/src/content_detail_page/includes/navigate_content.html
+++ b/src/content_detail_page/includes/navigate_content.html
@@ -1,4 +1,5 @@
-<nav class="h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 sm:px-6">
+{% include "./viewer_header.html" %}
+<nav class="mt-16 h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-gray-200 bg-white px-4 py-3 sm:px-6">
 
   <div class="flex flex-1 justify-between sm:justify-end">
     <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0">

--- a/src/content_detail_page/includes/viewer_header.html
+++ b/src/content_detail_page/includes/viewer_header.html
@@ -1,0 +1,144 @@
+  <header class="lg:ms-[24rem] fixed top-0 inset-x-0 flex flex-wrap md:justify-start md:flex-nowrap z-[50] bg-white border-b border-gray-200 dark:bg-neutral-800 dark:border-neutral-700">
+    <div class="flex justify-between xl:grid xl:grid-cols-3 basis-full items-center w-full py-3 px-2 sm:px-5">
+      <div class="xl:col-span-1 flex items-center md:gap-x-3">
+
+        <div class="hidden lg:block min-w-80 xl:w-full">
+          <!-- Search Input -->
+          <div class="relative">
+            <div class="absolute inset-y-0 start-0 flex items-center pointer-events-none z-[20] ps-3.5">
+              <svg class="shrink-0 size-4 text-gray-400 dark:text-white/60" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="8" />
+                <path d="m21 21-4.3-4.3" />
+              </svg>
+            </div>
+            <input type="text" class="py-2 ps-10 pe-16 block w-full bg-white border-gray-200 rounded-lg text-sm focus:border-transparent focus:border-b-stone-200 focus:outline-none focus:ring-0 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-400 dark:placeholder:text-neutral-400 dark:focus:ring-neutral-600" placeholder="Search" data-hs-overlay="#hs-pro-dnsm">
+            <div class="hidden absolute inset-y-0 end-0 flex items-center z-[20] pe-1">
+              <button type="button" class="inline-flex shrink-0 justify-center items-center size-6 rounded-full text-gray-500 hover:text-primary-600 focus:outline-hidden focus:text-primary-600 dark:text-neutral-500 dark:hover:text-primary-500 dark:focus:text-primary-500" aria-label="Close">
+                <span class="sr-only">Close</span>
+                <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="m15 9-6 6" />
+                  <path d="m9 9 6 6" />
+                </svg>
+              </button>
+            </div>
+            <div class="absolute inset-y-0 end-0 flex items-center pointer-events-none z-[20] pe-3 text-gray-400">
+              <svg class="shrink-0 size-3 text-gray-400 dark:text-white/60" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
+              </svg>
+              <span class="mx-1">
+                <svg class="shrink-0 size-3 text-gray-400 dark:text-white/60" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M5 12h14" />
+                  <path d="M12 5v14" />
+                </svg>
+              </span>
+              <span class="text-xs">/</span>
+            </div>
+          </div>
+          <!-- End Search Input -->
+        </div>
+      </div>
+
+      <div class="xl:col-span-2 flex justify-end items-center gap-x-2">
+        <div class="h-9.5">
+          <!-- Account Dropdown -->
+        <div class="hs-dropdown [--placement:top-right] [--strategy:absolute] [--auto-close:inside] relative inline-flex">
+          <!-- Account Avatar -->
+          <button id="hs-pro-fadm" type="button" class="px-1.5 py-[5px] min-h-9.5 hs-dropdown-toggle flex shrink-0 items-center gap-x-1 text-start text-gray-800 hover:bg-gray-100 rounded-lg focus:outline-hidden focus:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+            <img class="shrink-0 size-7 rounded-full" src="https://images.unsplash.com/photo-1568602471122-7832951cc4c5?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=facearea&amp;facepad=2.5&amp;w=320&amp;h=320&amp;q=80" alt="Avatar">
+            <span class="grow hidden sm:block mx-1 max-w-32 truncate">
+              <span class="block truncate text-sm font-medium">
+                James Collison
+              </span>
+            </span>
+            <svg class="shrink-0 size-4 text-gray-500 dark:text-neutral-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m6 9 6 6 6-6" />
+            </svg>
+          </button>
+          <!-- End Account Avatar -->
+
+          <!-- Account Dropdown -->
+          <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 start-2.5 w-56 transition-[opacity,margin] duration opacity-0 hidden z-[10] bg-white rounded-xl shadow-xl dark:bg-neutral-950" role="menu" aria-orientation="vertical" aria-labelledby="hs-pro-fadm">
+          <div class="p-1 border-b border-gray-200 dark:border-neutral-800">
+            <a class="py-2 px-3 flex items-center gap-x-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+              href="">
+              <img class="shrink-0 size-8 rounded-full"
+                src="https://images.unsplash.com/photo-1568602471122-7832951cc4c5?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=facearea&amp;facepad=2.5&amp;w=320&amp;h=320&amp;q=80"
+                alt="Avatar">
+
+              <div class="grow">
+                <span class="text-sm font-semibold text-gray-800 dark:text-neutral-300">
+                  James Collison
+                </span>
+                <p class="text-xs text-gray-500 dark:text-neutral-500">
+                  James@testpress.in
+                </p>
+              </div>
+            </a>
+          </div>
+          <div class="p-1">
+            <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+              href="#">
+              <svg class="shrink-0 mt-0.5 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                stroke-linejoin="round">
+                <rect width="20" height="14" x="2" y="5" rx="2" />
+                <line x1="2" x2="22" y1="10" y2="10" />
+              </svg>
+              Order & Billing
+            </a>
+            <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+            href="#">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 mt-0.5 size-4"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M8 18v-2"/><path d="M12 18v-4"/><path d="M16 18v-6"/></svg>
+            My Report
+          </a>
+            <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+            href="#">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 mt-0.5 size-4"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M7 16c.5-2 1.5-7 4-7 2 0 2 3 4 3 2.5 0 4.5-5 5-7"/></svg>
+            Analytics
+          </a>
+          <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+          href="#">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 mt-0.5 size-4"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"/></svg>
+          Bookmarks
+        </a>
+        <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+        href="#">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 mt-0.5 size-4"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></svg>
+        Certificates
+      </a>
+
+          </div>
+          <div class="px-4 py-3.5 border-y border-gray-200 dark:border-neutral-800">
+            <!-- Switch/Toggle -->
+            <div class="flex flex-wrap justify-between items-center gap-2">
+              <label for="hs-pro-dnaddm" class="flex-1 cursor-pointer text-sm text-gray-800 dark:text-neutral-300">Dark
+                mode</label>
+              <label for="hs-pro-dnaddm" class="relative inline-block w-11 h-6 cursor-pointer">
+                <input data-hs-theme-switch type="checkbox" id="hs-pro-dnaddm" class="peer sr-only">
+                <span
+                  class="absolute inset-0 bg-gray-200 rounded-full transition-colors duration-200 ease-in-out peer-checked:bg-primary-600 dark:bg-neutral-700 dark:peer-checked:bg-primary-500 peer-disabled:opacity-50 peer-disabled:pointer-events-none"></span>
+                <span
+                  class="absolute top-1/2 start-0.5 -translate-y-1/2 size-5 bg-white rounded-full shadow-sm !transition-transform duration-200 ease-in-out peer-checked:translate-x-full dark:bg-neutral-400 dark:peer-checked:bg-white"></span>
+              </label>
+            </div>
+            <!-- End Switch/Toggle -->
+          </div>
+          <div class="p-1">
+            <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+              href="#">
+              Login Activity
+            </a>
+            <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+              href="#">
+              Log out
+            </a>
+          </div>
+          </div>
+          <!-- End Account Dropdown -->
+        </div>
+          <!-- End Account Dropdown -->
+        </div>
+      </div>
+    </div>
+  </header>

--- a/src/content_detail_page/leaderboard.html
+++ b/src/content_detail_page/leaderboard.html
@@ -18,5 +18,6 @@ tab: "leaderboard"
     {% include "./includes/course_tabs.html" %}
     {% include "./includes/course_leaderboard.html" %}
   </main>
+  {% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}

--- a/src/content_detail_page/notes.html
+++ b/src/content_detail_page/notes.html
@@ -55,5 +55,6 @@
     </div>
     {% include "./includes/comment_section.html" %}
   </main>
+  {% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}

--- a/src/content_detail_page/pdf.html
+++ b/src/content_detail_page/pdf.html
@@ -25,5 +25,6 @@
 		</div>
 		{% include "./includes/comment_section.html" %}
 	</main>
+	{% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}

--- a/src/content_detail_page/pdf_with_chat.html
+++ b/src/content_detail_page/pdf_with_chat.html
@@ -14,7 +14,7 @@
 	{% include "./includes/desktop_sidebar.html" %}  
   <main id="content" class="lg:pl-96 hs-overlay-layout-open:pe-96 transition-all duration-300"> 
     {% include "./includes/viewer_header.html" %} 
-    <div id="hs-pro-tabs-chtcpt-1" role="tabpanel" aria-labelledby="hs-pro-tabs-chtcpt-item-1" class="h-screen mt-16">
+    <div id="hs-pro-tabs-chtcpt-1" role="tabpanel" aria-labelledby="hs-pro-tabs-chtcpt-item-1" class="h-screen lg:mt-16">
       <div class="relative flex flex-col justify-end">
         <header class="inset-x-0 z-10 p-4 flex justify-between items-center gap-x-2 bg-white dark:bg-neutral-800 dark:border-neutral-700">
           <!-- Update Ticket Status Dropdown -->

--- a/src/content_detail_page/pdf_with_chat.html
+++ b/src/content_detail_page/pdf_with_chat.html
@@ -12,8 +12,9 @@
 <div x-data="contents">
 	{% include "./includes/mobile_sidebar.html" %}  
 	{% include "./includes/desktop_sidebar.html" %}  
-  <main id="content" class="lg:pl-96 hs-overlay-layout-open:pe-96 transition-all duration-300">  
-    <div id="hs-pro-tabs-chtcpt-1" role="tabpanel" aria-labelledby="hs-pro-tabs-chtcpt-item-1" class="h-screen">
+  <main id="content" class="lg:pl-96 hs-overlay-layout-open:pe-96 transition-all duration-300"> 
+    {% include "./includes/viewer_header.html" %} 
+    <div id="hs-pro-tabs-chtcpt-1" role="tabpanel" aria-labelledby="hs-pro-tabs-chtcpt-item-1" class="h-screen mt-16">
       <div class="relative flex flex-col justify-end">
         <header class="inset-x-0 z-10 p-4 flex justify-between items-center gap-x-2 bg-white dark:bg-neutral-800 dark:border-neutral-700">
           <!-- Update Ticket Status Dropdown -->
@@ -42,5 +43,6 @@
     </div>
 
   </main>
+  {% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}

--- a/src/content_detail_page/running.html
+++ b/src/content_detail_page/running.html
@@ -22,5 +22,6 @@ tab: "running"
     {% include "./includes/running.html" %}
     {% include "./includes/pagination.html" %}
   </main>
+  {% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}

--- a/src/content_detail_page/upcoming.html
+++ b/src/content_detail_page/upcoming.html
@@ -20,5 +20,6 @@ tab: "upcoming"
     {% include "./includes/upcoming.html" %}
     {% include "./includes/pagination.html" %}
   </main>
+  {% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}

--- a/src/content_detail_page/video.html
+++ b/src/content_detail_page/video.html
@@ -22,5 +22,6 @@ date: 2023-05-30
 		{% include "./includes/video_content.html" %}
 		{% include "./includes/comment_section.html" %}
 	</main>
+	{% include "./includes/global_search_modal.html"%}
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR introduces a new header component on the content detail page. It includes:
- A search input (with modal trigger)
- Profile dropdown with user options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a global search modal with filter options and keyboard shortcuts for enhanced navigation.
  * Added a fixed header to the content detail page, featuring a search input and an account dropdown menu with profile, navigation links, and dark mode toggle.

* **Style**
  * Updated page layout by incorporating the new header and adjusting spacing around the main content tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->