### PR TITLE
feat: Add responsive close button for AI chat overlay for small screens

### DIFF
--- a/src/content_detail_page/includes/ai_pdf_chat.html
+++ b/src/content_detail_page/includes/ai_pdf_chat.html
@@ -34,7 +34,7 @@
       </div>
 
        <!-- Close button (at the end) - only visible when PDF viewer is hidden -->
-       <div class="hs-tooltip [--pbottom] show">
+       <div class="hs-tooltip [--pbottom]">
          <button type="button"
                  data-hs-overlay="#hs-pro-chtsdid1"
                  class="py-1.5 mb-2 relative inline-flex justify-center items-center gap-x-2 hover:bg-gray-100 text-gray-500 hover:text-gray-700 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-neutral-500 dark:hover:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700 xl:hidden" 
@@ -43,7 +43,7 @@
                   <path stroke-linecap="round" stroke-linejoin="round" d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                 </svg>
          </button>
-         <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 inline-block absolute invisible z-20 py-1.5 px-2.5 bg-gray-900 text-xs text-white rounded-lg whitespace-nowrap dark:bg-neutral-700" role="tooltip" data-placement="bottom" style="position: fixed; inset: auto auto 0px 0px; margin: 0px; transform: translate3d(1698.29px, -840px, 0px);" data-popper-placement="top">
+         <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 inline-block absolute invisible z-20 py-1.5 px-2.5 bg-gray-900 text-xs text-white rounded-lg whitespace-nowrap dark:bg-neutral-700" role="tooltip">
            Close AI
          </span>
        </div>

--- a/src/content_detail_page/includes/ai_pdf_chat.html
+++ b/src/content_detail_page/includes/ai_pdf_chat.html
@@ -1,33 +1,52 @@
 <div class="lg:[height:calc(100vh-4rem)] xl:mt-16 flex flex-col lg:pl-[23.5rem] xl:pl-0">
   <!-- Tab Navigation -->
   <div class="px-4 pt-3">
-    <nav class="relative flex space-x-1 after:absolute after:bottom-0 after:inset-x-0 after:border-b-2 after:border-gray-200 dark:after:border-neutral-700" aria-label="Tabs" role="tablist" aria-orientation="horizontal">
-      <button type="button" 
-              class="hs-tab-active:after:bg-emerald-600 hs-tab-active:text-emerald-600 px-2.5 py-1.5 mb-2 relative inline-flex justify-center items-center gap-x-2 hover:bg-gray-100 text-gray-500 hover:text-gray-700 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 after:absolute after:-bottom-2 after:inset-x-0 after:z-10 after:h-0.5 after:pointer-events-none dark:hs-tab-active:text-emerald-400 dark:hs-tab-active:after:bg-emerald-400 dark:text-neutral-500 dark:hover:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700 active" 
-              id="ai-chat-tab" 
-              aria-selected="true" 
-              data-hs-tab="#ai-chat-content" 
-              aria-controls="ai-chat-content" 
-              role="tab">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />
-        </svg>
-        Chat
-      </button>
-      <button type="button" 
-              class="hs-tab-active:after:bg-emerald-600 hs-tab-active:text-emerald-600 px-2.5 py-1.5 mb-2 relative inline-flex justify-center items-center gap-x-2 hover:bg-gray-100 text-gray-500 hover:text-gray-700 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 after:absolute after:-bottom-2 after:inset-x-0 after:z-10 after:h-0.5 after:pointer-events-none dark:hs-tab-active:text-emerald-400 dark:hs-tab-active:after:bg-emerald-400 dark:text-neutral-500 dark:hover:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" 
-              id="ai-quiz-tab" 
-              aria-selected="false" 
-              data-hs-tab="#ai-quiz-content" 
-              aria-controls="ai-quiz-content" 
-              role="tab">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
-                <path d="M12 17h.01"/>
-              </svg>
-        Quiz
-      </button>
+    <nav class="relative flex justify-between items-center after:absolute after:bottom-0 after:inset-x-0 after:border-b-2 after:border-gray-200 dark:after:border-neutral-700" aria-label="Tabs" role="tablist" aria-orientation="horizontal">
+      
+      <!-- Tabs container -->
+      <div class="flex space-x-1">
+        <button type="button" 
+                class="hs-tab-active:after:bg-emerald-600 hs-tab-active:text-emerald-600 px-2.5 py-1.5 mb-2 relative inline-flex justify-center items-center gap-x-2 hover:bg-gray-100 text-gray-500 hover:text-gray-700 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 after:absolute after:-bottom-2 after:inset-x-0 after:z-10 after:h-0.5 after:pointer-events-none dark:hs-tab-active:text-emerald-400 dark:hs-tab-active:after:bg-emerald-400 dark:text-neutral-500 dark:hover:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700 active" 
+                id="ai-chat-tab" 
+                aria-selected="true" 
+                data-hs-tab="#ai-chat-content" 
+                aria-controls="ai-chat-content" 
+                role="tab">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />
+          </svg>
+          Chat
+        </button>
+        <button type="button" 
+                class="hs-tab-active:after:bg-emerald-600 hs-tab-active:text-emerald-600 px-2.5 py-1.5 mb-2 relative inline-flex justify-center items-center gap-x-2 hover:bg-gray-100 text-gray-500 hover:text-gray-700 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 after:absolute after:-bottom-2 after:inset-x-0 after:z-10 after:h-0.5 after:pointer-events-none dark:hs-tab-active:text-emerald-400 dark:hs-tab-active:after:bg-emerald-400 dark:text-neutral-500 dark:hover:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" 
+                id="ai-quiz-tab" 
+                aria-selected="false" 
+                data-hs-tab="#ai-quiz-content" 
+                aria-controls="ai-quiz-content" 
+                role="tab">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4">
+            <circle cx="12" cy="12" r="10"/>
+            <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
+            <path d="M12 17h.01"/>
+          </svg>
+          Quiz
+        </button>
+      </div>
+
+       <!-- Close button (at the end) - only visible when PDF viewer is hidden -->
+       <div class="hs-tooltip [--pbottom] show">
+         <button type="button"
+                 data-hs-overlay="#hs-pro-chtsdid1"
+                 class="py-1.5 mb-2 relative inline-flex justify-center items-center gap-x-2 hover:bg-gray-100 text-gray-500 hover:text-gray-700 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-neutral-500 dark:hover:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700 xl:hidden" 
+                 aria-label="Close chat">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                </svg>
+         </button>
+         <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 inline-block absolute invisible z-20 py-1.5 px-2.5 bg-gray-900 text-xs text-white rounded-lg whitespace-nowrap dark:bg-neutral-700" role="tooltip" data-placement="bottom" style="position: fixed; inset: auto auto 0px 0px; margin: 0px; transform: translate3d(1698.29px, -840px, 0px);" data-popper-placement="top">
+           Close AI
+         </span>
+       </div>
     </nav>
   </div>
   <!-- End Tab Navigation -->

--- a/src/content_detail_page/pdf_with_chat.html
+++ b/src/content_detail_page/pdf_with_chat.html
@@ -31,7 +31,7 @@
                 </svg>
                 <span class="sr-only">AI</span>
               </button>
-              <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 inline-block absolute invisible z-20 py-1.5 px-2.5 bg-gray-900 text-xs text-white rounded-lg whitespace-nowrap dark:bg-neutral-700" role="tooltip" data-placement="bottom" style="position: fixed; left: 1333.25px; top: 45px;">
+              <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 inline-block absolute invisible z-20 py-1.5 px-2.5 bg-gray-900 text-xs text-white rounded-lg whitespace-nowrap dark:bg-neutral-700" role="tooltip">
                 AI
               </span>
             </div>


### PR DESCRIPTION
**Issue**: Users on smaller screens couldn't easily close the AI chat interface when the PDF viewer was hidden, as there was no clear way to return to the main content.

**Reason**: The AI chat overlay was designed to be side-by-side with the PDF viewer on larger screens, but on smaller screens the PDF viewer gets hidden and users need a way to close the chat interface to return to the main content.

**Solution**: Added a close button that only appears on screens smaller than XL (when PDF viewer is hidden) with a hover tooltip for better UX. The button uses Preline's overlay functionality to close just the chat interface without affecting browser history.