### PR TITLE
fix: Add Mark as Completed button and improve navigation 

### DIFF
--- a/src/content_detail_page/includes/content_heading.html
+++ b/src/content_detail_page/includes/content_heading.html
@@ -1,23 +1,61 @@
-<div class="mt-6 px-4 sm:px-6 lg:px-0 flex justify-between items-center">
+<div x-data="{ is_completed: false}" class="pt-4 mt-6 px-4 sm:px-6 lg:px-0 flex flex-wrap items-center justify-between gap-4">
   <h1 class="text-lg lg:text-2xl font-bold text-gray-900">What is Markup language?</h1>
-  <div class="flex items-center justify-center space-x-2">
+  <div class="flex items-center space-x-2">
     <a class="cursor-pointer" title="Download" x-show="is_renderable" x-cloak>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-6 h-6 text-emerald-600" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/>
-      </svg>                
+      </svg>
     </a>
     <a class="cursor-pointer" x-on:click="toggleSVG = !toggleSVG" title="Bookmark" x-show="!isBookmarked" x-cloak>
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600">
         <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
-      </svg>  
+      </svg>
     </a>
-    <a class="cursor-pointer" x-on:click="isBookmarked = false" title="Remove Bookmark" x-show="isBookmarked" x-cloak> 
+    <a class="cursor-pointer" x-on:click="isBookmarked = false" title="Remove Bookmark" x-show="isBookmarked" x-cloak>
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l1.664 1.664M21 21l-1.5-1.5m-5.485-1.242L12 17.25 4.5 21V8.742m.164-4.078a2.15 2.15 0 011.743-1.342 48.507 48.507 0 0111.186 0c1.1.128 1.907 1.077 1.907 2.185V19.5M4.664 4.664L19.5 19.5" />
-      </svg>                
+      </svg>
     </a>
+    <button
+      on:click="!is_completed && (is_completed = true)"
+      :class="is_completed ? 'cursor-not-allowed opacity-50' : 'hover:bg-emerald-500'"
+      type="button"
+      class="hidden md:flex w-auto relative inline-flex items-center gap-x-1.5 rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 transition-colors duration-200"
+      :disabled="is_completed"
+    >
+      <span x-text="is_completed ? 'Completed' : 'Mark as Completed'">Mark as Completed</span>
+      <svg class="-mr-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd"></path>
+      </svg>
+    </button>
+    <div class="hidden md:flex space-x-3 ml-4">
+      <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+        </svg>
+        Previous
+      </a>
+      <a href="{{ pagination.nextPageHref|url }}" class="relative ml-3 inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0">
+        Next
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+        </svg>
+      </a>
+    </div>
   </div>
 </div>
+<button
+      on:click="!is_completed && (is_completed = true)"
+      :class="is_completed ? 'cursor-not-allowed opacity-50' : 'hover:bg-emerald-500'"
+      type="button"
+      class="md:hidden w-auto relative inline-flex items-center ml-4 mt-3 gap-x-1.5 rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 transition-colors duration-200"
+      :disabled="is_completed"
+    >
+      <span x-text="is_completed ? 'Completed' : 'Mark as Completed'">Mark as Completed</span>
+      <svg class="-mr-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd"></path>
+      </svg>
+</button>
 <div class="flex justify-end" x-show="!toggleSVG" x-cloak>
   <div class="absolute z-10">
     <input id="combobox" type="text" class="w-full rounded-md border-0 bg-white py-1.5 pl-3 pr-12 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-emerald-600 text-sm leading-6" role="combobox" aria-controls="options" aria-expanded="false" placeholder="Search folder...">

--- a/src/content_detail_page/includes/content_heading.html
+++ b/src/content_detail_page/includes/content_heading.html
@@ -4,17 +4,17 @@
     <a class="cursor-pointer" title="Download" x-show="is_renderable" x-cloak>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-6 h-6 text-emerald-600" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/>
-      </svg>
+      </svg>                
     </a>
     <a class="cursor-pointer" x-on:click="toggleSVG = !toggleSVG" title="Bookmark" x-show="!isBookmarked" x-cloak>
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600">
         <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
-      </svg>
+      </svg>  
     </a>
-    <a class="cursor-pointer" x-on:click="isBookmarked = false" title="Remove Bookmark" x-show="isBookmarked" x-cloak>
+    <a class="cursor-pointer" x-on:click="isBookmarked = false" title="Remove Bookmark" x-show="isBookmarked" x-cloak> 
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l1.664 1.664M21 21l-1.5-1.5m-5.485-1.242L12 17.25 4.5 21V8.742m.164-4.078a2.15 2.15 0 011.743-1.342 48.507 48.507 0 0111.186 0c1.1.128 1.907 1.077 1.907 2.185V19.5M4.664 4.664L19.5 19.5" />
-      </svg>
+      </svg>                
     </a>
     <button
       x-on:click="!is_completed && (is_completed = true)"

--- a/src/content_detail_page/includes/content_heading.html
+++ b/src/content_detail_page/includes/content_heading.html
@@ -1,4 +1,4 @@
-<div x-data="{ is_completed: false}" class="pt-4 mt-6 px-4 sm:px-6 lg:px-0 flex flex-wrap items-center justify-between gap-4">
+<div x-data="{ is_completed: false}" class="pt-4 mt-6 px-4 lg:px-0 flex flex-wrap items-center justify-between gap-4">
   <h1 class="text-lg lg:text-2xl font-bold text-gray-900">What is Markup language?</h1>
   <div class="flex items-center space-x-2">
     <a class="cursor-pointer" title="Download" x-show="is_renderable" x-cloak>

--- a/src/content_detail_page/includes/content_heading.html
+++ b/src/content_detail_page/includes/content_heading.html
@@ -17,7 +17,7 @@
       </svg>
     </a>
     <button
-      on:click="!is_completed && (is_completed = true)"
+      x-on:click="!is_completed && (is_completed = true)"
       :class="is_completed ? 'cursor-not-allowed opacity-50' : 'hover:bg-emerald-500'"
       type="button"
       class="hidden md:flex w-auto relative inline-flex items-center gap-x-1.5 rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 transition-colors duration-200"
@@ -45,7 +45,8 @@
   </div>
 </div>
 <button
-      on:click="!is_completed && (is_completed = true)"
+      x-data="{ is_completed: false}"
+      x-on:click="!is_completed && (is_completed = true)"
       :class="is_completed ? 'cursor-not-allowed opacity-50' : 'hover:bg-emerald-500'"
       type="button"
       class="md:hidden w-auto relative inline-flex items-center ml-4 mt-3 gap-x-1.5 rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 transition-colors duration-200"

--- a/src/content_detail_page/includes/navigate_content.html
+++ b/src/content_detail_page/includes/navigate_content.html
@@ -1,7 +1,7 @@
 {% include "./viewer_header.html" %}
-<nav class="mt-16 h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-gray-200 bg-white px-4 py-3 sm:px-6">
+<nav class="h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-gray-200 bg-white px-4 py-3 sm:px-6">
 
-  <div class="flex flex-1 justify-between sm:justify-end">
+  <div class="md:hidden flex flex-1 justify-between sm:justify-end">
     <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
         <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />

--- a/src/content_detail_page/includes/navigate_content.html
+++ b/src/content_detail_page/includes/navigate_content.html
@@ -1,5 +1,5 @@
 {% include "./viewer_header.html" %}
-<nav class="h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-gray-200 bg-white px-4 py-3 sm:px-6">
+<nav class="h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-gray-200 bg-white px-4 py-3 ">
 
   <div class="md:hidden flex flex-1 justify-between sm:justify-end">
     <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0">


### PR DESCRIPTION
- The navigation bar is now visible only on small devices at the bottom; on large devices, navigation buttons are placed beside the bookmark.

- On small devices, the "Mark as Completed" button is shown in a dropdown, and marking an item displays a tick icon beside the heading.