### PR TITLE
Add tooltip to show supported platforms for course access

### DIFF
--- a/src/_data/products.json
+++ b/src/_data/products.json
@@ -140,6 +140,6 @@
     "completed_percent": 58,
     "valid_till": "10/01/26",
     "valid_till_readable": "Jan 10",
-    "available_on": ["web", "desktop"]
+    "available_on": ["web", "desktop_app"]
   }
 ]

--- a/src/_data/products.json
+++ b/src/_data/products.json
@@ -140,6 +140,6 @@
     "completed_percent": 58,
     "valid_till": "10/01/26",
     "valid_till_readable": "Jan 10",
-    "available_on": ["web", "desktop_app"]
+    "available_on": ["web", "desktop"]
   }
 ]

--- a/src/testpress/my_courses/list.html
+++ b/src/testpress/my_courses/list.html
@@ -113,13 +113,13 @@
       {% set desktop_and_android = is_desktop and is_android and not is_web %}
 
       {% set show_info_icon = android_only or desktop_only or desktop_and_android %}
-      {% set tooltip_text = android_only and "This course can be accessed only from mobile app." 
-                        or desktop_only and "This course can be accessed only from desktop app." 
-                        or desktop_and_android and "This course can be accessed only from mobile app and desktop app." %}
+      {% set tooltip_text = "This course can be accessed only from mobile app." if android_only else
+                            "This course can be accessed only from desktop app." if desktop_only else
+                            "This course can be accessed only from mobile app and desktop app." if desktop_and_android else "" %}
 
       <a href="/flimix/library/products/detail/"
         class="flex items-center space-x-2 text-sm underline underline-offset-4
-                {{ android_only and 'text-gray-400' or 'text-gray-800 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400' }}"
+        {{ 'text-gray-400' if android_only else 'text-gray-800 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400' }}"
         {% if android_only %} aria-disabled="true" onclick="return false;" {% endif %}>
         
         <span>

--- a/src/testpress/my_courses/list.html
+++ b/src/testpress/my_courses/list.html
@@ -113,7 +113,7 @@
       {% set desktop_and_android = is_desktop and is_android and not is_web %}
 
       {% set show_info_icon = android_only or desktop_only or desktop_and_android %}
-      {% set is_disabled = desktop_and_android %}
+      {% set is_disabled = android_only or desktop_only or desktop_and_android %}
       <div class="flex items-center space-x-2 text-sm">
         <a href="#"
           class="flex items-center gap-x-1 text-sm underline underline-offset-4
@@ -145,25 +145,29 @@
           {% endif %}
       </a>
         {% if show_info_icon %}
-          <div class="hs-tooltip [--trigger:click] [--placement:bottom] inline-block">
-            <button type="button" class="hs-tooltip-toggle inline" tabindex="-1">
-              <!-- Info Icon -->
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                  stroke-width="1.5" stroke="currentColor" class="w-4 h-4 text-gray-400 inline">
+
+        <div class="hs-dropdown relative inline-flex [--placement:bottom] [--trigger:click] [--strategy:absolute]">
+          <button type="button" class="hs-dropdown-toggle inline items-center justify-center">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                stroke="currentColor" class="w-4 h-4 text-gray-400 hover:cursor-pointer inline">
                 <path stroke-linecap="round" stroke-linejoin="round"
-                      d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
-              </svg>
-              <span class="hs-tooltip-content hidden absolute z-50 w-80 py-2 px-3 bg-gray-900 text-sm text-white rounded-md shadow-md dark:text-white dark:bg-neutral-700">
+                  d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+            </svg>
+          </button>
+
+          <div class="hs-dropdown-menu hidden z-50 w-80 bg-gray-900 text-white text-sm rounded-md shadow-md dark:bg-neutral-700 p-3">
+              <span>
                 {% if android_only %}
-                  This course can be accessed only from the mobile app.
+                  This course can be accessed only from the <a href="https://play.google.com/store/apps/details?id=your.android.app" class="underline text-blue-400">mobile app.</a>
                 {% elif desktop_only %}
-                  This course can be accessed only from the desktop app.
+                  This course can be accessed only from the <a href="https://yourdomain.com/download/desktop-app" class="underline text-blue-400">desktop app.</a>
                 {% elif desktop_and_android %}
                   This course can be accessed only from the <a href="https://yourdomain.com/download/desktop-app" class="underline text-blue-400">desktop app</a> and <a href="https://play.google.com/store/apps/details?id=your.android.app" class="underline text-blue-400">mobile app</a>
                 {% endif %}
               </span>
-            </button>
           </div>
+        </div>
+
         {% endif %}
       </div>
     </div>

--- a/src/testpress/my_courses/list.html
+++ b/src/testpress/my_courses/list.html
@@ -113,27 +113,28 @@
       {% set desktop_and_android = is_desktop and is_android and not is_web %}
 
       {% set show_info_icon = android_only or desktop_only or desktop_and_android %}
-
-      {% set tooltip_text = android_only and "This course can be accessed only from the mobile app." 
-        or desktop_only and "This course can be accessed only from the desktop app." 
-        or desktop_and_android and "This course can be accessed only from the desktop app and mobile app." %}
+      {% set is_disabled = desktop_and_android %}
       <div class="flex items-center space-x-2 text-sm">
-      <a href="#"
-        class="flex items-center gap-x-1 text-sm underline underline-offset-4 text-gray-400 text-gray-800 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400">
+        <a href="#"
+          class="flex items-center gap-x-1 text-sm underline underline-offset-4
+                {{ is_disabled
+                    and 'pointer-events-none text-gray-400'
+                    or 'text-gray-800 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400' }}"
+          {% if is_disabled %}aria-disabled="true"{% endif %}>
 
-        <span>
-          {% if is_web %}
-            Go to Course
-          {% elif desktop_only %}
-            Desktop Only
-          {% elif android_only %}
-            Mobile Only
-          {% elif desktop_and_android %}
-            Mobile/Desktop Only
-          {% else %}
-            Go to Course
-          {% endif %}
-        </span>
+          <span>
+            {% if is_web %}
+              Go to Course
+            {% elif desktop_only %}
+              Desktop Only
+            {% elif android_only %}
+              Mobile Only
+            {% elif desktop_and_android %}
+              Mobile/Desktop Only
+            {% else %}
+              Go to Course
+            {% endif %}
+          </span>
 
           {% if is_web %}
             <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24"
@@ -152,8 +153,14 @@
                 <path stroke-linecap="round" stroke-linejoin="round"
                       d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
               </svg>
-              <span class="hs-tooltip-content hidden absolute z-50 w-80 py-2 px-3 bg-gray-900 text-sm text-white rounded-md shadow-md dark:text-white dark:bg-neutral-700 leading-snug">
-                {{ tooltip_text | safe }}
+              <span class="hs-tooltip-content hidden absolute z-50 w-80 py-2 px-3 bg-gray-900 text-sm text-white rounded-md shadow-md dark:text-white dark:bg-neutral-700">
+                {% if android_only %}
+                  This course can be accessed only from the mobile app.
+                {% elif desktop_only %}
+                  This course can be accessed only from the desktop app.
+                {% elif desktop_and_android %}
+                  This course can be accessed only from the <a href="https://yourdomain.com/download/desktop-app" class="underline text-blue-400">desktop app</a> and <a href="https://play.google.com/store/apps/details?id=your.android.app" class="underline text-blue-400">mobile app</a>
+                {% endif %}
               </span>
             </button>
           </div>

--- a/src/testpress/my_courses/list.html
+++ b/src/testpress/my_courses/list.html
@@ -62,7 +62,7 @@
           </div>
           {% if product.description %}
 
-          <div class="hs-tooltip [--placement:bottom] hover:cursor-pointer inline-block">
+          <div class="hs-tooltip [--trigger:click] [--placement:bottom] hover:cursor-pointer inline-block">
             <button type="button" class="hs-tooltip-toggle inline">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                 stroke="currentColor" class="w-4 h-4 text-gray-400 hover:cursor-pointer inline">
@@ -113,48 +113,52 @@
       {% set desktop_and_android = is_desktop and is_android and not is_web %}
 
       {% set show_info_icon = android_only or desktop_only or desktop_and_android %}
-      {% set tooltip_text = android_only and "This course can be accessed only from mobile app." 
-                        or desktop_only and "This course can be accessed only from desktop app." 
-                        or desktop_and_android and "This course can be accessed only from mobile app and desktop app." %}
 
-      <a href="/flimix/library/products/detail/"
-        class="flex items-center space-x-2 text-sm underline underline-offset-4
-                {{ android_only and 'text-gray-400' or 'text-gray-800 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400' }}"
-        {% if android_only %} aria-disabled="true" onclick="return false;" {% endif %}>
-        
+      {% set tooltip_text = android_only and "This course can be accessed only from the mobile app." 
+        or desktop_only and "This course can be accessed only from the desktop app." 
+        or desktop_and_android and "This course can be accessed only from the desktop app and mobile app." %}
+      <div class="flex items-center space-x-2 text-sm">
+      <a href="#"
+        class="flex items-center gap-x-1 text-sm underline underline-offset-4 text-gray-400 text-gray-800 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400">
+
         <span>
           {% if is_web %}
             Go to Course
-          {% elif desktop_only or desktop_and_android %}
-            Get Desktop App
+          {% elif desktop_only %}
+            Desktop Only
           {% elif android_only %}
-            Go to Course
+            Mobile Only
+          {% elif desktop_and_android %}
+            Mobile/Desktop Only
           {% else %}
             Go to Course
           {% endif %}
         </span>
 
+          {% if is_web %}
+            <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round">
+              <path d="m9 18 6-6-6-6"></path>
+            </svg>
+          {% endif %}
+      </a>
         {% if show_info_icon %}
-          <div class="hs-tooltip [--placement:bottom] inline-block">
+          <div class="hs-tooltip [--trigger:click] [--placement:bottom] inline-block">
             <button type="button" class="hs-tooltip-toggle inline" tabindex="-1">
+              <!-- Info Icon -->
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                   stroke-width="1.5" stroke="currentColor" class="w-4 h-4 text-gray-400 inline">
                 <path stroke-linecap="round" stroke-linejoin="round"
                       d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
               </svg>
-              <span class="hs-tooltip-content hidden absolute z-50 w-72 py-1 px-2 bg-gray-900 text-sm text-white rounded-md shadow-md dark:text-white dark:bg-neutral-700">
-                {{ tooltip_text }}
+              <span class="hs-tooltip-content hidden absolute z-50 w-80 py-2 px-3 bg-gray-900 text-sm text-white rounded-md shadow-md dark:text-white dark:bg-neutral-700 leading-snug">
+                {{ tooltip_text | safe }}
               </span>
             </button>
           </div>
-        {% elif is_web %}
-          <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-              viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-              stroke-linecap="round" stroke-linejoin="round">
-            <path d="m9 18 6-6-6-6"></path>
-          </svg>
         {% endif %}
-      </a>
+      </div>
     </div>
   </div>
   {% endfor %}

--- a/src/testpress/my_courses/list.html
+++ b/src/testpress/my_courses/list.html
@@ -113,13 +113,13 @@
       {% set desktop_and_android = is_desktop and is_android and not is_web %}
 
       {% set show_info_icon = android_only or desktop_only or desktop_and_android %}
-      {% set tooltip_text = "This course can be accessed only from mobile app." if android_only else
-                            "This course can be accessed only from desktop app." if desktop_only else
-                            "This course can be accessed only from mobile app and desktop app." if desktop_and_android else "" %}
+      {% set tooltip_text = android_only and "This course can be accessed only from mobile app." 
+                        or desktop_only and "This course can be accessed only from desktop app." 
+                        or desktop_and_android and "This course can be accessed only from mobile app and desktop app." %}
 
       <a href="/flimix/library/products/detail/"
         class="flex items-center space-x-2 text-sm underline underline-offset-4
-        {{ 'text-gray-400' if android_only else 'text-gray-800 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400' }}"
+                {{ android_only and 'text-gray-400' or 'text-gray-800 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400' }}"
         {% if android_only %} aria-disabled="true" onclick="return false;" {% endif %}>
         
         <span>

--- a/src/testpress/my_courses/list.html
+++ b/src/testpress/my_courses/list.html
@@ -104,25 +104,58 @@
       </div>
       </div>
       </div>
+      {% set is_web = "web" in product.available_on %}
+      {% set is_desktop = "desktop_app" in product.available_on %}
+      {% set is_android = "android" in product.available_on %}
+
+      {% set android_only = is_android and not is_web and not is_desktop %}
+      {% set desktop_only = is_desktop and not is_web and not is_android %}
+      {% set desktop_and_android = is_desktop and is_android and not is_web %}
+
+      {% set show_info_icon = android_only or desktop_only or desktop_and_android %}
+      {% set tooltip_text = android_only and "This course can be accessed only from mobile app." 
+                        or desktop_only and "This course can be accessed only from desktop app." 
+                        or desktop_and_android and "This course can be accessed only from mobile app and desktop app." %}
+
       <a href="/flimix/library/products/detail/"
-        class="inline-flex items-center gap-x-1 text-sm text-gray-800 underline underline-offset-4 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400">
-        {% if "web" in product.available_on %}
-        <span>Go to Course</span>
-        {% elif "desktop_app" in product.available_on %}
-        <span>Open in Desktop App</span>
-        {% elif "android" in product.available_on %}
-        <span>Open in Android App</span>
-        {% else %}
-        <span>Go to Course</span>
+        class="flex items-center space-x-2 text-sm underline underline-offset-4
+                {{ android_only and 'text-gray-400' or 'text-gray-800 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400' }}"
+        {% if android_only %} aria-disabled="true" onclick="return false;" {% endif %}>
+        
+        <span>
+          {% if is_web %}
+            Go to Course
+          {% elif desktop_only or desktop_and_android %}
+            Get Desktop App
+          {% elif android_only %}
+            Go to Course
+          {% else %}
+            Go to Course
+          {% endif %}
+        </span>
+
+        {% if show_info_icon %}
+          <div class="hs-tooltip [--placement:bottom] inline-block">
+            <button type="button" class="hs-tooltip-toggle inline" tabindex="-1">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                  stroke-width="1.5" stroke="currentColor" class="w-4 h-4 text-gray-400 inline">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                      d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+              </svg>
+              <span class="hs-tooltip-content hidden absolute z-50 w-72 py-1 px-2 bg-gray-900 text-sm text-white rounded-md shadow-md dark:text-white dark:bg-neutral-700">
+                {{ tooltip_text }}
+              </span>
+            </button>
+          </div>
+        {% elif is_web %}
+          <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+              viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round">
+            <path d="m9 18 6-6-6-6"></path>
+          </svg>
         {% endif %}
-        <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
-          fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="m9 18 6-6-6-6"></path>
-        </svg>
       </a>
     </div>
-
-
   </div>
   {% endfor %}
   {% include "./loader.html" %}


### PR DESCRIPTION
This PR improves user clarity when a course is not accessible on the current platform by displaying an info tooltip that lists the platforms where the course is available.