### PR TITLE
fix: Update custom player styles to display video timestamp in mobiles

### DIFF
--- a/css/videojs-tps.css
+++ b/css/videojs-tps.css
@@ -1,49 +1,12 @@
 .vjs-theme-plyr {
-    --vjs-theme-plyr--primary: #03a4eb;
-    --vjs-theme-plyr--secondary: #fff;
-    --vjs-theme-plyr--hover: #2fb6f0;
-    --vjs-theme-plyr-tooltip-color: #4a5464;
+    --vjs-theme-plyr-tooltip-color: #131314;
     --vjs-theme-plyr-tooltip-radius: 5px;
     --vjs-theme-plyr-control-spacing: 10px;
 }
-@font-face {
-    font-display: swap;
-    font-family: Gordita;
-    font-style: normal;
-    font-weight: 300;
-    src: url(https://static.tpstreams.com/static/fonts/player/gordita-light.woff2) format("woff2"), url(https://static.tpstreams.com/static/fonts/player/gordita-light.woff) format("woff");
-}
-@font-face {
-    font-display: swap;
-    font-family: Gordita;
-    font-style: normal;
-    font-weight: 400;
-    src: url(https://static.tpstreams.com/static/fonts/player/gordita-regular.woff2) format("woff2"), url(https://static.tpstreams.com/static/fonts/player/gordita-regular.woff) format("woff");
-}
-@font-face {
-    font-display: swap;
-    font-family: Gordita;
-    font-style: normal;
-    font-weight: 500;
-    src: url(https://static.tpstreams.com/static/fonts/player/gordita-medium.woff2) format("woff2"), url(https://static.tpstreams.com/static/fonts/player/gordita-medium.woff) format("woff");
-}
-@font-face {
-    font-display: swap;
-    font-family: Gordita;
-    font-style: normal;
-    font-weight: 600;
-    src: url(https://static.tpstreams.com/static/fonts/player/gordita-bold.woff2) format("woff2"), url(https://static.tpstreams.com/static/fonts/player/gordita-bold.woff) format("woff");
-}
-@font-face {
-    font-display: swap;
-    font-family: Gordita;
-    font-style: normal;
-    font-weight: 900;
-    src: url(https://static.tpstreams.com/static/fonts/player/gordita-black.woff2) format("woff2"), url(https://static.tpstreams.com/static/fonts/player/gordita-black.woff) format("woff");
-}
 .vjs-control:hover .vjs-icon-placeholder:before,
-.vjs-theme-plyr .vjs-play-progress {
-    background-color: var(--vjs-theme-plyr--primary);
+.vjs-theme-plyr .vjs-play-progress,
+.vjs-title:hover {
+    background-color: var(--vjs-theme-plyr--accent);
 }
 .vjs-theme-plyr .vjs-big-play-button,
 .vjs-theme-plyr.vjs-big-play-button:focus,
@@ -59,11 +22,14 @@
     left: 50%;
     margin-top: -30px;
     margin-left: -30px;
-    color: var(--vjs-theme-plyr--secondary);
-    transition: background 0.4s 0.2s, box-shadow 0.4s;
+    color: var(--vjs-theme-plyr--icons);
+    transition:
+        background 0.4s 0.2s,
+        box-shadow 0.4s;
+    position: fixed !important;
 }
 .vjs-theme-plyr:hover .vjs-big-play-button {
-    background: var(--vjs-theme-plyr--hover);
+    background: var(--vjs-theme-plyr--primary);
 }
 .vjs-theme-plyr .vjs-progress-control:hover .vjs-progress-holder {
     font-size: 1em;
@@ -81,17 +47,24 @@
 .vjs-theme-plyr .vjs-play-progress {
     border-radius: 0.2em;
 }
+.video-js .vjs-control {
+    width: 5em;
+}
 .video-js .vjs-control-bar {
     transform: translateY(100%);
     opacity: 0;
-    transition: transform 0.3s, opacity 0.3s;
+    transition:
+        transform 0.3s,
+        opacity 0.3s;
     background-color: #fff0;
 }
 .video-js.pause .vjs-control-bar,
 .video-js:hover .vjs-control-bar {
     transform: translateY(-35%);
     opacity: 1;
-    transition: transform 0.3s, opacity 0.3s;
+    transition:
+        transform 0.3s,
+        opacity 0.3s;
     background-color: #fff0;
 }
 .video-js .vjs-settings-menu::after,
@@ -102,7 +75,7 @@
     position: absolute;
     width: 10px;
     height: 10px;
-    background-color: var(--vjs-theme-plyr--secondary);
+    background-color: var(--vjs-theme-plyr--icons);
     border-radius: 50%;
     top: 50%;
     transform: translateY(-50%);
@@ -115,18 +88,26 @@
 }
 .vjs-theme-plyr .vjs-play-control .vjs-icon-placeholder:before,
 .vjs-theme-plyr .vjs-play-control:hover .vjs-icon-placeholder:before {
-    width: 1.5em;
+    width: 2.875em;
     height: 1.5em;
     margin-top: -0.2em;
-    color: var(--vjs-theme-plyr--secondary);
+    color: var(--vjs-theme-plyr--icons);
     margin-left: 9px;
-    transition: background-color 0.3s, color 0.3s;
+    transition:
+        background-color 0.3s,
+        color 0.3s;
     line-height: 1.55;
+}
+.vjs-theme-plyr .vjs-icon-placeholder:before {
+    width: 2em;
 }
 .vjs-theme-plyr .vjs-mute-control .vjs-icon-placeholder:before,
 .vjs-theme-plyr .vjs-mute-control:hover .vjs-icon-placeholder:before {
-    color: var(--vjs-theme-plyr--secondary);
-    transition: background-color 0.3s, color 0.3s;
+    color: var(--vjs-theme-plyr--icons);
+    transition:
+        background-color 0.3s,
+        color 0.3s;
+    left: 20px;
 }
 .video-js .vjs-mute-control::before,
 .video-js .vjs-settings-menu::before,
@@ -137,7 +118,7 @@
     top: -2.75em;
     left: 50%;
     transform: translateX(-50%);
-    background-color: var(--vjs-theme-plyr--secondary);
+    background-color: #fff;
     color: var(--vjs-theme-plyr-tooltip-color);
     padding: 0.5em;
     padding: calc(var(--vjs-theme-plyr-control-spacing) / 2) calc(var(--vjs-theme-plyr-control-spacing) / 2 * 1.5);
@@ -145,7 +126,6 @@
     opacity: 0;
     transition: opacity 0.3s;
     white-space: nowrap;
-    font-family: Gordita, Avenir, Helvetica Neue, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
 }
 .vjs-theme-plyr .vjs-play-control::before {
     content: "Pause";
@@ -163,12 +143,15 @@
 }
 .video-js .vjs-mute-control::before {
     content: "Mute";
+    margin-left: auto;
 }
 .video-js.mute .vjs-mute-control::before {
     content: "Unmute";
+    margin-left: auto;
 }
 .vjs-theme-plyr .vjs-picture-in-picture-control::before {
     content: "PIP";
+    margin-left: -15px;
 }
 .video-js .vjs-mute-control::after,
 .vjs-theme-plyr .vjs-fullscreen-control::after,
@@ -181,10 +164,13 @@
     margin-left: -5px;
     border-width: 5px;
     border-style: solid;
-    border-color: #fff0 #fff0 var(--vjs-theme-plyr--secondary) #fff0;
+    border-color: #fff0 #fff0 #fff;
     transition: opacity 0.3s;
     opacity: 0;
     transform: rotate(180deg);
+}
+.vjs-theme-plyr .vjs-picture-in-picture-control::after {
+    margin-left: -20px;
 }
 .vjs-progress-holder .vjs-time-tooltip:before,
 .vjs-time-tooltip:before {
@@ -193,6 +179,8 @@
 }
 .video-js .vjs-mute-control:hover::after,
 .video-js .vjs-mute-control:hover::before,
+.video-js.pause .vjs-gradient-bar-overlay,
+.video-js:hover .vjs-gradient-bar-overlay,
 .vjs-theme-plyr .vjs-fullscreen-control:hover::after,
 .vjs-theme-plyr .vjs-fullscreen-control:hover::before,
 .vjs-theme-plyr .vjs-picture-in-picture-control:hover::after,
@@ -212,7 +200,7 @@
     transition: color 0.3s;
 }
 .vjs-menu .vjs-menu-content {
-    background-color: var(--vjs-theme-plyr--secondary) !important;
+    background-color: #fff !important;
     border-radius: 4px;
     transition: background-color 0.3s;
 }
@@ -221,17 +209,21 @@
     color: #0b0c0c;
     border-radius: 4px;
     transition: color 0.3s;
+    font-size: 10px;
+    font-family: Arial, Helvetica, sans-serif;
 }
 .video-js .vjs-settings-menu:hover .vjs-menu li:hover,
 .vjs-menu li.vjs-menu-item:hover,
 .vjs-menu li.vjs-selected:hover {
-    color: var(--vjs-theme-plyr--secondary);
-    background-color: var(--vjs-theme-plyr--primary);
-    transition: background-color 0.3s, color 0.3s;
+    color: #fff;
+    background-color: var(--vjs-theme-plyr--accent);
+    transition:
+        background-color 0.3s,
+        color 0.3s;
 }
 .video-js .vjs-settings-menu li.vjs-menu-item.vjs-selected,
 .vjs-menu li.vjs-selected {
-    color: var(--vjs-theme-plyr--primary);
+    color: var(--vjs-theme-plyr--accent);
     transition: color 0.3s;
 }
 .video-js ul.vjs-sm-top-level-header {
@@ -241,11 +233,11 @@
 }
 .video-js .vjs-sm-top-level-header,
 .video-js li.setting-menu-header {
-    background: var(--vjs-theme-plyr--secondary) !important;
+    background: #fff !important;
     transition: background-color 0.3s;
 }
 .video-js li.setting-menu-header:hover {
-    background: var(--vjs-theme-plyr--primary) !important;
+    background: var(--vjs-theme-plyr--accent) !important;
     transition: background-color 0.3s;
 }
 .vjs-progress-holder .vjs-time-tooltip {
@@ -256,10 +248,10 @@
     transform: scale(1.5) translateY(-20px);
 }
 .vjs-progress-holder .vjs-time-tooltip:before {
-    background: var(--vjs-theme-plyr--secondary) !important;
+    background: var(--vjs-theme-plyr--icons) !important;
 }
+.video-js .vjs-volume-control.vjs-slider-horizontal,
 .video-js .vjs-volume-panel {
-    width: 30px;
     display: flex;
     align-items: center;
 }
@@ -273,27 +265,19 @@
     margin-right: 5px;
 }
 .video-js .vjs-volume-level {
-    background-color: var(--vjs-theme-plyr--primary);
+    background-color: var(--vjs-theme-plyr--accent);
     border-radius: 10px;
     height: 100%;
 }
 .video-js .vjs-volume-handle {
-    background-color: var(--vjs-theme-plyr--secondary);
+    background-color: var(--vjs-theme-plyr--icons);
     border-radius: 50%;
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
 }
-.video-js .vjs-volume-control.vjs-slider-horizontal {
-    display: flex;
-    align-items: center;
-}
 .vjs-control-bar {
     background-color: rgb(0 0 0 / 0.1);
-}
-.video-js.pause .vjs-control-bar,
-.video-js:hover .vjs-control-bar {
-    background: linear-gradient(#fff0, rgb(0 0 0 / 0.1), rgb(0 0 0 / 0.1), #fff0);
 }
 .vjs-time-tooltip.vjs-time-tooltip-2 {
     display: none !important;
@@ -312,4 +296,58 @@
     visibility: visible !important;
     opacity: 1 !important;
     width: auto !important;
+}
+.vjs-title {
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    z-index: 20;
+    color: #fff;
+    font-size: 16px;
+    background-color: var(--vjs-theme-plyr--primary);
+    padding: 5px;
+    border-radius: 3px;
+}
+.video-js {
+    background-color: var(--vjs-theme-plyr--background);
+}
+.vjs-control .vjs-icon-placeholder,
+.vjs-icon {
+    color: var(--vjs-theme-plyr--icons);
+}
+.video-js.vjs-ended .vjs-poster {
+    display: block;
+}
+.vjs-poster {
+    position: relative !important;
+}
+.video-js .vjs-time-control {
+    font-size: 12px;
+    line-height: 2.4em;
+}
+@media only screen and (max-width: 600px) {
+    .video-js .vjs-volume-panel .vjs-volume-control,
+
+    .video-js.vjs-user-active .vjs-control-bar {
+        transform: translateY(-35%);
+        opacity: 1;
+        transition:
+            transform 0.3s,
+            opacity 0.3s;
+        background-color: #fff0;
+    }
+    .video-js.vjs-user-active .vjs-gradient-bar-overlay {
+        opacity: 1;
+    }
+}
+.vjs-gradient-bar-overlay {
+    display: block;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 50%;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease-in-out;
 }


### PR DESCRIPTION
Earlier the video timestamps like remaining video time are not displayed in mobiles. This PR updates the player design to display the video timestamps in the mobile view allowing consistent design across all devices..