### PR TITLE
fix: Add feedback enable/disable option

### DIFF
--- a/src/testpress/feedback/feedback_form/admin.html
+++ b/src/testpress/feedback/feedback_form/admin.html
@@ -18,6 +18,8 @@ date: 2025-10-17
     {% include "partials/course_breadcrumb.html" %}
     {% include "./includes/header.html" %}
     <div class="mt-5 p-5 flex flex-col bg-white border border-gray-200 shadow-sm rounded-xl">
+      {% include "./includes/toggle.html" %}
+      <div x-show="is_enabled">
       {% include "./includes/navigation.html" %}
       <div x-cloak x-show="navigationTab == 'question'">
         {% include "./includes/filters.html" %}
@@ -29,6 +31,7 @@ date: 2025-10-17
       <div x-cloak x-show="navigationTab == 'settings'">
         {% include "./includes/settings_form.html" %}
       </div>
+    </div>
 
     </div>
   </div>
@@ -58,6 +61,7 @@ date: 2025-10-17
       editRow: {},
       navigationTab: 'question',
       showDeleteModal: false,
+      is_enabled: false,
 
       openAddModal: false,
       newRow: {

--- a/src/testpress/feedback/feedback_form/includes/toggle.html
+++ b/src/testpress/feedback/feedback_form/includes/toggle.html
@@ -1,0 +1,28 @@
+<div class="flex items-center justify-between" :class="{'pb-6': is_enabled}">
+  <span class="flex flex-grow flex-col">
+    <h2 class="text-base font-semibold leading-7 text-gray-900">Enable</h2>
+    <span class="text-sm text-gray-500" id="availability-description">
+      When enabled, students will be prompted to submit feedback for course. This helps collect valuable insights to improve course quality and student learning outcomes.
+    </span>
+  </span>
+
+  <form>
+    <input type="checkbox" name="force_student_data" x-model="is_enabled" class="hidden" /> 
+    <button 
+      id="enforce-toggle" 
+      type="button" 
+      class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2" 
+      role="switch" 
+      aria-checked="false"
+      :class="{'bg-emerald-600': is_enabled, 'bg-gray-200': !is_enabled}"
+      @click="is_enabled = !is_enabled">
+      
+      <span class="sr-only">Enable Enforcement</span>
+      <span 
+        aria-hidden="true" 
+        class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+        :class="{'translate-x-5': is_enabled, 'translate-x-0': !is_enabled}">
+      </span>
+    </button>
+  </form>
+</div>


### PR DESCRIPTION
This PR introduces a toggle option in the Feedback Settings page that allows administrators to enable or disable the feedback collection feature.