### PR TITLE
feat: Add prominent callout toast for mistake reflection button

### DIFF
--- a/src/exam_review/answers/includes/question_heading.html
+++ b/src/exam_review/answers/includes/question_heading.html
@@ -11,8 +11,7 @@
 </div>
 <div class="flex space-x-1 justify-center items-center">
   <div class="relative">
-    <button type="button" x-cloak  x-show="currentQuestion.response_status === 'incorrect' || currentQuestion.response_status === 'unanswered'" @click='HSOverlay.open("#hs-pro-mistake-reflection")' data-hs-overlay="#hs-pro-mistake-reflection" title="Reflect on mistake" class="inline-flex items-center gap-x-1 p-1 mb-1 text-xs text-gray-700 hover:text-emerald-700 underline hover:underline underline-offset-2 transition-colors focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 dark:text-neutral-300 dark:hover:text-emerald-500" >
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0" >
+    <button type="button" x-cloak  x-show="getQuestionStatus(currentQuestion) === 'incorrect' || getQuestionStatus(currentQuestion) === 'unanswered'" @click='HSOverlay.open("#hs-pro-mistake-reflection"); showReflectionToast = false' data-hs-overlay="#hs-pro-mistake-reflection" title="Reflect on mistake" class="inline-flex items-center gap-x-1 p-1 mb-1 text-xs text-gray-700 hover:text-emerald-700 underline hover:underline underline-offset-2 transition-colors focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 dark:text-neutral-300 dark:hover:text-emerald-500">      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0" >
         <path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
       </svg>
       <span class="hidden sm:inline ">Why I missed this?</span>

--- a/src/exam_review/answers/includes/question_heading.html
+++ b/src/exam_review/answers/includes/question_heading.html
@@ -10,14 +10,16 @@
 
 </div>
 <div class="flex space-x-1 justify-center items-center">
-  <button type="button" x-show="currentQuestion.response_status === 'incorrect'" @click='HSOverlay.open("#hs-pro-mistake-reflection")' data-hs-overlay="#hs-pro-mistake-reflection" title="Reflect on mistake" class="inline-flex items-center gap-x-1 p-1 mb-1 text-xs text-gray-700 hover:text-emerald-700 underline hover:underline underline-offset-2 transition-colors focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 dark:text-neutral-300 dark:hover:text-emerald-500" >
-    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0" >
-      <path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
-    </svg>
-    <span class="hidden sm:inline ">Why I missed this?</span>
-  </button>
-
-<div class="relative inline-block text-left" x-data="{showbookmark:false}">
+  <div class="relative">
+    <button type="button" x-cloak  x-show="currentQuestion.response_status === 'incorrect' || currentQuestion.response_status === 'unanswered'" @click='HSOverlay.open("#hs-pro-mistake-reflection")' data-hs-overlay="#hs-pro-mistake-reflection" title="Reflect on mistake" class="inline-flex items-center gap-x-1 p-1 mb-1 text-xs text-gray-700 hover:text-emerald-700 underline hover:underline underline-offset-2 transition-colors focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 dark:text-neutral-300 dark:hover:text-emerald-500" >
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0" >
+        <path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
+      </svg>
+      <span class="hidden sm:inline ">Why I missed this?</span>
+    </button>
+    {% include "./reflection_toast.html" %}
+  </div>
+  <div class="relative inline-block text-left" x-data="{showbookmark:false}">
   <button class="justify-center items-center" x-cloak x-show="!currentQuestion.isBookmarked" @click="showbookmark=true">
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 text-emerald-600">
     <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />

--- a/src/exam_review/answers/includes/question_reflection_modal.html
+++ b/src/exam_review/answers/includes/question_reflection_modal.html
@@ -43,6 +43,17 @@
               {% endfor %}
             </div>
           </div>
+
+          <div class="mt-6">
+            <label for="reflection-notes" class="block text-sm font-medium text-gray-900 dark:text-neutral-200 mb-2">Additional Notes (Optional)</label>
+            <textarea 
+              id="reflection-notes" 
+              x-model="notes" 
+              rows="3" 
+              class="block w-full rounded-lg border-0 py-2 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 text-sm leading-6 dark:bg-neutral-900 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500" 
+              placeholder="Add any specific thoughts about this mistake...">
+            </textarea>
+          </div>
         </div>
       </div>
   
@@ -60,6 +71,7 @@
   function questionReflection() {
     return {
       selectedReason: null,
+      notes: '',
       reasons: {{ question_mistake_reflection | dump | safe }},
     }
   }

--- a/src/exam_review/answers/includes/reflection_toast.html
+++ b/src/exam_review/answers/includes/reflection_toast.html
@@ -1,0 +1,50 @@
+<div
+  x-cloak
+  x-show="showReflectionToast"
+  x-transition:enter="transition ease-out duration-200"
+  x-transition:enter-start="opacity-0 translate-y-2"
+  x-transition:enter-end="opacity-100 translate-y-0"
+  x-transition:leave="transition ease-in duration-150"
+  x-transition:leave-start="opacity-100 translate-y-0"
+  x-transition:leave-end="opacity-0 translate-y-2"
+  class="absolute top-full right-0 z-10 mt-2 w-64"
+>
+  <div class="absolute -top-2 right-6 size-4 overflow-hidden">
+    <div class="size-4 -translate-y-1/2 rotate-45 transform bg-white dark:bg-neutral-800"></div>
+  </div>
+  <div class="p-3 bg-white dark:bg-neutral-800 rounded-md shadow-xl ring-1 ring-black ring-opacity-5 dark:ring-white/10">
+    <div class="flex items-start gap-3">
+      <div class="flex-grow">
+        <h3 class="font-semibold text-gray-900 dark:text-neutral-200 text-sm">Why did you get this wrong?</h3>
+        <p class="text-xs text-gray-500 dark:text-neutral-400 mt-1">
+          Take a moment to reflect on this question. This will help you understand your mistake patterns.
+        </p>
+        <div class="mt-3 flex gap-x-2">
+          <button
+            type="button"
+            @click='HSOverlay.open("#hs-pro-mistake-reflection"); showReflectionToast = false'
+            class="inline-flex items-center justify-center gap-x-1 rounded-md border border-transparent bg-emerald-600 px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-emerald-700 disabled:opacity-50"
+          >
+            Reflect Now
+          </button>
+          <button
+            type="button"
+            @click="showReflectionToast = false"
+            class="inline-flex items-center justify-center gap-x-1 rounded-md border border-gray-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-2.5 py-1.5 text-xs font-semibold text-gray-700 dark:text-neutral-300 shadow-sm hover:bg-gray-50 dark:hover:bg-neutral-700 disabled:opacity-50"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+      <div class="flex-shrink-0">
+        <button
+          type="button"
+          @click="showReflectionToast = false"
+          class="inline-flex items-center justify-center rounded-full text-gray-400 hover:text-gray-500 dark:text-neutral-400 dark:hover:text-neutral-300"
+        >
+          <svg class="size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/exam_review/answers/scripts/exam_component.html
+++ b/src/exam_review/answers/scripts/exam_component.html
@@ -69,8 +69,8 @@ function examReviewComponent() {
       }
 
       this.scrollToTop();
-      this.$nextTick(() => {
-        this.checkCurrentQuestionForReflection();
+      this.$watch('currentQuestion', () => {
+          this.$nextTick(() => this.checkCurrentQuestionForReflection());
       });
     },
 
@@ -130,27 +130,16 @@ function examReviewComponent() {
     goToQuestion(index) {
       this.currentQuestionIndex = index;
       this.scrollToTop();
-      this.$nextTick(() => {
-        this.checkCurrentQuestionForReflection();
-      });
     },
 
     setFilter(status) {
       this.filter = status;
       this.currentQuestionIndex = 0;
-      this.$nextTick(() => {
-        this.checkCurrentQuestionForReflection();
-      });
     },
 
     checkCurrentQuestionForReflection() {
       const status = this.getQuestionStatus(this.currentQuestion);
-      const toastNeeded = (status === 'incorrect' || status === 'unanswered');
-      if (toastNeeded) {
-        this.showReflectionToast = true;
-      } else {
-        this.showReflectionToast = false;
-      }
+      this.showReflectionToast = (status === 'incorrect' || status === 'unanswered');
     },
     
     get filteredQuestions() {

--- a/src/exam_review/answers/scripts/exam_component.html
+++ b/src/exam_review/answers/scripts/exam_component.html
@@ -25,6 +25,7 @@ function examReviewComponent() {
     searchFolder:'',
     showQuestionComment:null,
     showReportQuestionModal:null,
+    showReflectionToast: false,
     folders: [
     { 'name': 'Questions' },
     { 'name': 'Videos' },
@@ -68,6 +69,9 @@ function examReviewComponent() {
       }
 
       this.scrollToTop();
+      this.$nextTick(() => {
+        this.checkCurrentQuestionForReflection();
+      });
     },
 
     addTouchEvent() {
@@ -126,13 +130,28 @@ function examReviewComponent() {
     goToQuestion(index) {
       this.currentQuestionIndex = index;
       this.scrollToTop();
+      this.$nextTick(() => {
+        this.checkCurrentQuestionForReflection();
+      });
     },
 
     setFilter(status) {
-    this.filter = status;
-    this.currentQuestionIndex = 0;
-   },
+      this.filter = status;
+      this.currentQuestionIndex = 0;
+      this.$nextTick(() => {
+        this.checkCurrentQuestionForReflection();
+      });
+    },
 
+    checkCurrentQuestionForReflection() {
+      const status = this.getQuestionStatus(this.currentQuestion);
+      const toastNeeded = (status === 'incorrect' || status === 'unanswered');
+      if (toastNeeded) {
+        this.showReflectionToast = true;
+      } else {
+        this.showReflectionToast = false;
+      }
+    },
     
     get filteredQuestions() {
       return this.currentSection.questions.filter(q => {


### PR DESCRIPTION
- The original "Why I missed this?" link in the header was easy for users to miss. This commit replaces it with a more noticeable call-to-action to improve response and engagement with the reflection feature.
- Also makes it to appear on unanswered questions as well.