### PR TITLE
ui: add create and edit page modal with auto-generated slug

### DIFF
--- a/src/flimix/page/list/create_page.html
+++ b/src/flimix/page/list/create_page.html
@@ -1,0 +1,153 @@
+<!-- Create Page Modal -->
+<div
+  id="create-page-modal"
+  class="hs-overlay hidden size-full fixed top-0 start-0 z-[80] overflow-x-hidden overflow-y-auto [--close-when-click-inside:true] pointer-events-none"
+  role="dialog"
+  tabindex="-1"
+  aria-labelledby="create-page-modal-label"
+>
+  <div
+    class="hs-overlay-open:mt-7 hs-overlay-open:opacity-100 hs-overlay-open:duration-500 mt-0 opacity-0 ease-out transition-all sm:max-w-xl sm:w-full m-3 sm:mx-auto h-[calc(100%-3.5rem)] min-h-[calc(100%-3.5rem)] flex items-center"
+  >
+    <div
+      class="w-full max-h-full flex flex-col bg-white rounded-xl pointer-events-auto shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)]"
+    >
+      <!-- Header -->
+      <div class="py-2.5 px-4 flex justify-between items-center border-b">
+        <h3 id="create-page-modal-label" class="font-medium text-gray-800">
+          Create Page
+        </h3>
+        <button
+          type="button"
+          class="size-8 inline-flex justify-center items-center gap-x-2 rounded-full border border-transparent bg-gray-100 text-gray-800 hover:bg-gray-200 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-200"
+          aria-label="Close"
+          data-hs-overlay="#create-page-modal"
+        >
+          <span class="sr-only">Close</span>
+          <svg
+            class="shrink-0 size-4"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      </div>
+      <!-- End Header -->
+
+      <!-- Body -->
+      <div
+        class="overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300"
+      >
+        <div class="p-4 space-y-5">
+          <!-- Title Field -->
+          <div>
+            <label
+              for="page-title-input"
+              class="block mb-2 text-sm font-medium text-gray-800 dark:text-white"
+            >
+              Title
+            </label>
+
+            <input
+              type="text"
+              id="page-title-input"
+              placeholder="Enter page title"
+              class="py-2.5 px-3 block w-full border-gray-200 rounded-lg text-sm placeholder:text-gray-400 focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-transparent dark:border-neutral-700 dark:text-neutral-300 dark:placeholder:text-white/60 dark:focus:ring-neutral-600"
+            />
+          </div>
+
+          <!-- Description Field -->
+          <div>
+            <label
+              for="page-description-input"
+              class="block mb-2 text-sm font-medium text-gray-800 dark:text-white"
+            >
+              Description
+            </label>
+
+            <textarea
+              id="page-description-input"
+              rows="4"
+              placeholder="Enter page description"
+              class="py-2.5 px-3 block w-full border-gray-200 rounded-lg text-sm placeholder:text-gray-400 focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-transparent dark:border-neutral-700 dark:text-neutral-300 dark:placeholder:text-white/60 dark:focus:ring-neutral-600"
+            ></textarea>
+          </div>
+
+          <!-- Slug Field (Auto-generated) -->
+          <div>
+            <label
+              for="page-slug-input"
+              class="block mb-2 text-sm font-medium text-gray-800 dark:text-white"
+            >
+              Slug
+            </label>
+
+            <input
+              type="text"
+              id="page-slug-input"
+              placeholder="page-slug"
+              class="py-2.5 px-3 block w-full border-gray-200 rounded-lg text-sm placeholder:text-gray-400 bg-gray-50 focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:placeholder:text-white/60 dark:focus:ring-neutral-600"
+            />
+          </div>
+        </div>
+      </div>
+      <!-- End Body -->
+
+      <!-- Footer -->
+      <div class="p-4 flex justify-end gap-x-2">
+        <div class="flex-1 flex justify-end items-center gap-2">
+          <button
+            type="button"
+            class="py-2 px-3 text-nowrap inline-flex justify-center items-center text-start bg-white border border-gray-200 text-gray-800 text-sm font-medium rounded-lg shadow-sm align-middle hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none"
+            data-hs-overlay="#create-page-modal"
+          >
+            Cancel
+          </button>
+
+          <button
+            type="button"
+            id="create-page-submit-btn"
+            class="py-2 px-3 text-nowrap inline-flex justify-center items-center gap-x-2 text-start bg-blue-600 border border-blue-600 text-white text-sm font-medium rounded-lg shadow-sm align-middle hover:bg-blue-700 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:ring-1 focus:ring-blue-300"
+            data-hs-overlay="#create-page-modal"
+          >
+            Create Page
+          </button>
+        </div>
+      </div>
+      <!-- End Footer -->
+    </div>
+  </div>
+</div>
+<!-- End Create Page Modal -->
+
+<script>
+  // Auto-generate slug from title
+  document.addEventListener('DOMContentLoaded', function () {
+    const titleInput = document.getElementById('page-title-input')
+    const slugInput = document.getElementById('page-slug-input')
+
+    if (titleInput && slugInput) {
+      titleInput.addEventListener('input', function () {
+        const title = this.value
+        // Convert title to slug: lowercase, replace spaces with hyphens, remove special characters
+        const slug = title
+          .toLowerCase()
+          .trim()
+          .replace(/[^\w\s-]/g, '') // Remove special characters
+          .replace(/\s+/g, '-') // Replace spaces with hyphens
+          .replace(/-+/g, '-') // Replace multiple hyphens with single hyphen
+
+        slugInput.value = slug
+      })
+    }
+  })
+</script>

--- a/src/flimix/page/list/edit_page.html
+++ b/src/flimix/page/list/edit_page.html
@@ -1,0 +1,155 @@
+<!-- Edit Page Modal -->
+<div
+  id="edit-page-modal"
+  class="hs-overlay hidden size-full fixed top-0 start-0 z-[80] overflow-x-hidden overflow-y-auto [--close-when-click-inside:true] pointer-events-none"
+  role="dialog"
+  tabindex="-1"
+  aria-labelledby="edit-page-modal-label"
+>
+  <div
+    class="hs-overlay-open:mt-7 hs-overlay-open:opacity-100 hs-overlay-open:duration-500 mt-0 opacity-0 ease-out transition-all sm:max-w-xl sm:w-full m-3 sm:mx-auto h-[calc(100%-3.5rem)] min-h-[calc(100%-3.5rem)] flex items-center"
+  >
+    <div
+      class="w-full max-h-full flex flex-col bg-white rounded-xl pointer-events-auto shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)]"
+    >
+      <!-- Header -->
+      <div class="py-2.5 px-4 flex justify-between items-center border-b">
+        <h3 id="edit-page-modal-label" class="font-medium text-gray-800">
+          Edit Page
+        </h3>
+        <button
+          type="button"
+          class="size-8 inline-flex justify-center items-center gap-x-2 rounded-full border border-transparent bg-gray-100 text-gray-800 hover:bg-gray-200 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-200"
+          aria-label="Close"
+          data-hs-overlay="#edit-page-modal"
+        >
+          <span class="sr-only">Close</span>
+          <svg
+            class="shrink-0 size-4"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      </div>
+      <!-- End Header -->
+
+      <!-- Body -->
+      <div
+        class="overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300"
+      >
+        <div class="p-4 space-y-5">
+          <!-- Title Field -->
+          <div>
+            <label
+              for="edit-page-title-input"
+              class="block mb-2 text-sm font-medium text-gray-800 dark:text-white"
+            >
+              Title
+            </label>
+
+            <input
+              type="text"
+              id="edit-page-title-input"
+              placeholder="Enter page title"
+              value="Landing Page"
+              class="py-2.5 px-3 block w-full border-gray-200 rounded-lg text-sm placeholder:text-gray-400 focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-transparent dark:border-neutral-700 dark:text-neutral-300 dark:placeholder:text-white/60 dark:focus:ring-neutral-600"
+            />
+          </div>
+
+          <!-- Description Field -->
+          <div>
+            <label
+              for="edit-page-description-input"
+              class="block mb-2 text-sm font-medium text-gray-800 dark:text-white"
+            >
+              Description
+            </label>
+
+            <textarea
+              id="edit-page-description-input"
+              rows="4"
+              placeholder="Enter page description"
+              class="py-2.5 px-3 block w-full border-gray-200 rounded-lg text-sm placeholder:text-gray-400 focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-transparent dark:border-neutral-700 dark:text-neutral-300 dark:placeholder:text-white/60 dark:focus:ring-neutral-600"
+            >Landing Page Description</textarea>
+          </div>
+
+          <!-- Slug Field (Auto-generated) -->
+          <div>
+            <label
+              for="edit-page-slug-input"
+              class="block mb-2 text-sm font-medium text-gray-800 dark:text-white"
+            >
+              Slug
+            </label>
+
+            <input
+              type="text"
+              id="edit-page-slug-input"
+              placeholder="page-slug"
+              value="landing-page"
+              class="py-2.5 px-3 block w-full border-gray-200 rounded-lg text-sm placeholder:text-gray-400 bg-gray-50 focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:placeholder:text-white/60 dark:focus:ring-neutral-600"
+            />
+          </div>
+        </div>
+      </div>
+      <!-- End Body -->
+
+      <!-- Footer -->
+      <div class="p-4 flex justify-end gap-x-2">
+        <div class="flex-1 flex justify-end items-center gap-2">
+          <button
+            type="button"
+            class="py-2 px-3 text-nowrap inline-flex justify-center items-center text-start bg-white border border-gray-200 text-gray-800 text-sm font-medium rounded-lg shadow-sm align-middle hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none"
+            data-hs-overlay="#edit-page-modal"
+          >
+            Cancel
+          </button>
+
+          <button
+            type="button"
+            id="edit-page-submit-btn"
+            class="py-2 px-3 text-nowrap inline-flex justify-center items-center gap-x-2 text-start bg-blue-600 border border-blue-600 text-white text-sm font-medium rounded-lg shadow-sm align-middle hover:bg-blue-700 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:ring-1 focus:ring-blue-300"
+            data-hs-overlay="#edit-page-modal"
+          >
+            Save Changes
+          </button>
+        </div>
+      </div>
+      <!-- End Footer -->
+    </div>
+  </div>
+</div>
+<!-- End Edit Page Modal -->
+
+<script>
+  // Auto-generate slug from title for edit modal
+  document.addEventListener('DOMContentLoaded', function () {
+    const titleInput = document.getElementById('edit-page-title-input')
+    const slugInput = document.getElementById('edit-page-slug-input')
+
+    if (titleInput && slugInput) {
+      titleInput.addEventListener('input', function () {
+        const title = this.value
+        // Convert title to slug: lowercase, replace spaces with hyphens, remove special characters
+        const slug = title
+          .toLowerCase()
+          .trim()
+          .replace(/[^\w\s-]/g, '') // Remove special characters
+          .replace(/\s+/g, '-') // Replace spaces with hyphens
+          .replace(/-+/g, '-') // Replace multiple hyphens with single hyphen
+
+        slugInput.value = slug
+      })
+    }
+  })
+</script>

--- a/src/flimix/page/list/header.html
+++ b/src/flimix/page/list/header.html
@@ -1,14 +1,35 @@
 <div class="flex flex-wrap justify-between items-center gap-2">
   <div>
-    <h1 class="text-lg md:text-xl font-semibold text-stone-800 dark:text-neutral-200">Pages</h1>
-    <p class="text-sm text-stone-500 dark:text-neutral-400">View and manage all viewer pages.</p>
+    <h1
+      class="text-lg md:text-xl font-semibold text-stone-800 dark:text-neutral-200"
+    >
+      Pages
+    </h1>
+    <p class="text-sm text-stone-500 dark:text-neutral-400">
+      View and manage all viewer pages.
+    </p>
   </div>
   <div class="flex justify-end items-center gap-x-2">
-<a href="#" class="py-1.5 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-transparent bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:ring-2 focus:ring-indigo-500">
-  <svg class="shrink-0 size-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M8 1C8.55228 1 9 1.44772 9 2V7L14 7C14.5523 7 15 7.44771 15 8C15 8.55228 14.5523 9 14 9L9 9V14C9 14.5523 8.55228 15 8 15C7.44772 15 7 14.5523 7 14V9.00001L2 9.00001C1.44772 9.00001 1 8.5523 1 8.00001C0.999999 7.44773 1.44771 7.00001 2 7.00001L7 7.00001V2C7 1.44772 7.44772 1 8 1Z"></path>
-  </svg>
-  Add Page
-</a>
+    <button
+      type="button"
+      data-hs-overlay="#create-page-modal"
+      class="py-1.5 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-transparent bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:ring-2 focus:ring-indigo-500"
+    >
+      <svg
+        class="shrink-0 size-3"
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        fill="currentColor"
+        viewBox="0 0 16 16"
+      >
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M8 1C8.55228 1 9 1.44772 9 2V7L14 7C14.5523 7 15 7.44771 15 8C15 8.55228 14.5523 9 14 9L9 9V14C9 14.5523 8.55228 15 8 15C7.44772 15 7 14.5523 7 14V9.00001L2 9.00001C1.44772 9.00001 1 8.5523 1 8.00001C0.999999 7.44773 1.44771 7.00001 2 7.00001L7 7.00001V2C7 1.44772 7.44772 1 8 1Z"
+        ></path>
+      </svg>
+      Add Page
+    </button>
   </div>
 </div>

--- a/src/flimix/page/list/index.html
+++ b/src/flimix/page/list/index.html
@@ -37,5 +37,6 @@ design_view: 'Pages'
       </div>
     </div>
   </div>
+  {% include "./create_page.html" %}
 </div>
 {% endblock main_content %}

--- a/src/flimix/page/list/index.html
+++ b/src/flimix/page/list/index.html
@@ -38,5 +38,6 @@ design_view: 'Pages'
     </div>
   </div>
   {% include "./create_page.html" %}
+  {% include "./edit_page.html" %}
 </div>
 {% endblock main_content %}

--- a/src/flimix/page/list/table_item.html
+++ b/src/flimix/page/list/table_item.html
@@ -83,6 +83,12 @@
       >
         <div class="p-1">
           <button
+          aria-haspopup="dialog" aria-expanded="false" aria-controls="edit-page-modal" data-hs-overlay="#edit-page-modal" 
+          type="button" class="w-full flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 size-3.5"><path d="m18 5-2.414-2.414A2 2 0 0 0 14.172 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2"/><path d="M21.378 12.626a1 1 0 0 0-3.004-3.004l-4.01 4.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z"/><path d="M8 18h1"/></svg>           
+          Edit
+          </button>
+          <button
             aria-haspopup="dialog"
             aria-expanded="false"
             aria-controls="publish-page"


### PR DESCRIPTION
- Add new create_page.html modal component with title, description, and slug fields
- Implement automatic slug generation from page title using JavaScript
- Convert "Add Page" link to button that triggers the modal overlay
- Include create page modal in the main page list view
- Improve code formatting and structure in header.html