### PR TITLE
fix: Update navbar container to have sticky position for notes

### DIFF
--- a/src/content_detail_page/includes/content_heading.html
+++ b/src/content_detail_page/includes/content_heading.html
@@ -1,4 +1,4 @@
-<div x-data="{ is_completed: false}" class="pt-4 mt-6 px-4 lg:px-0 flex flex-wrap items-center justify-between gap-4">
+<div x-data="{ is_completed: false}" class="pt-4 px-4 lg:px-0 flex flex-wrap items-center justify-between gap-4">
   <h1 class="text-lg lg:text-2xl font-bold text-gray-900">What is Markup language?</h1>
   <div class="flex items-center space-x-2">
     <a class="cursor-pointer" title="Download" x-show="is_renderable" x-cloak>

--- a/src/content_detail_page/includes/content_heading.html
+++ b/src/content_detail_page/includes/content_heading.html
@@ -1,5 +1,5 @@
 <div x-data="{ is_completed: false}" class="pt-4 px-4 lg:px-0 flex flex-wrap items-center justify-between gap-4">
-  <h1 class="text-lg lg:text-2xl font-bold text-gray-900">What is Markup language?</h1>
+  <h1 class="text-lg lg:text-2xl font-bold text-gray-900 [text-shadow:0_1px_1px_rgba(0,0,0,0.25)]">What is Markup language?</h1>
   <div class="flex items-center space-x-2">
     <a class="cursor-pointer" title="Download" x-show="is_renderable" x-cloak>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-6 h-6 text-emerald-600" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/content_detail_page/includes/content_heading.html
+++ b/src/content_detail_page/includes/content_heading.html
@@ -1,5 +1,5 @@
-<div x-data="{ is_completed: false}" class="pt-4 px-4 lg:px-0 flex flex-wrap items-center justify-between gap-4">
-  <h1 class="text-lg lg:text-2xl font-bold text-gray-900 [text-shadow:0_1px_1px_rgba(0,0,0,0.25)]">What is Markup language?</h1>
+<div x-data="{ is_completed: false}" class="flex flex-wrap gap-4 items-center justify-between pt-4 px-4 lg:px-6">
+  <h1 class="text-lg lg:text-2xl font-bold text-gray-900">What is Markup language?</h1>
   <div class="flex items-center space-x-2">
     <a class="cursor-pointer" title="Download" x-show="is_renderable" x-cloak>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-6 h-6 text-emerald-600" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/content_detail_page/includes/mobile_sidebar.html
+++ b/src/content_detail_page/includes/mobile_sidebar.html
@@ -91,7 +91,7 @@
   </div>
 </div>
 
-<div class="sticky top-16 z-5 flex items-center gap-x-6 bg-white px-4 py-3 shadow-sm sm:px-6 xl:hidden">
+<div class="sticky top-16 z-30 flex items-center gap-x-6 bg-white px-4 py-3 shadow-sm sm:px-6 xl:hidden">
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
     <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
   </svg>

--- a/src/content_detail_page/notes.html
+++ b/src/content_detail_page/notes.html
@@ -14,10 +14,11 @@
 	{% include "./includes/desktop_sidebar.html" %}  
 	<main class="lg:pl-96">
 		{% include "./includes/navigate_content.html" %}
-    <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
-
+    <div class="sticky top-28 xl:top-16 z-30 bg-white p-2"  x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
+      {% include "./includes/content_heading.html" %}
+    </div>
+    <div class="lg:px-8">
       <div>
-        {% include "./includes/content_heading.html" %}
         <div class="mt-6 prose prose-slate px-4 sm:px-6 lg:px-0 lg:prose-md max-w-none">
           <h4><strong>Mentor Links </strong></h4>
           <p>Before coming to the session, be ready with specific doubts/issues you are facing with regards to the preparation.</p>

--- a/src/content_detail_page/notes.html
+++ b/src/content_detail_page/notes.html
@@ -14,7 +14,7 @@
 	{% include "./includes/desktop_sidebar.html" %}  
 	<main class="lg:pl-96">
 		{% include "./includes/navigate_content.html" %}
-    <div class="sticky top-28 xl:top-16 z-30 bg-white p-2"  x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
+    <div class="sticky top-28 xl:top-16 z-30 bg-white p-2 shadow"  x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
       {% include "./includes/content_heading.html" %}
     </div>
     <div class="lg:px-8">


### PR DESCRIPTION
- Content heading Container elements were scrolling out of view, reducing accessibility to important navigation or content like mark as completed button, this happened because they lacked sticky positioning on the page.
- This is fixed by applying sticky positioning with appropriate top offsets and ensuring proper z-index layering so the container stays visible and interactive while users scroll.