### PR TITLE
fix: Replace incorrect settings icon with billing icon in Billing tab

### DIFF
--- a/src/_includes/partials/tpstreams/sidebar_desktop.html
+++ b/src/_includes/partials/tpstreams/sidebar_desktop.html
@@ -44,11 +44,8 @@
         </a>
         <a href="{{ '/tpstreams/billing/plans/'|url }}"
           class="group flex items-center border-l-4 py-2 px-3 text-sm font-medium {% if page.url == '/tpstreams/billing/plans/' or page.url == '/tpstreams/billing/checkout/' or page.url == '/tpstreams/billing/invoices/'%} bg-blue-50 border-blue-700 text-blue-700 {% else %} border-transparent text-gray-600 hover:bg-gray-50 hover:text-gray-900 {% endif %}">
-          <svg
-            class="mr-3 h-6 w-6 flex-shrink-0 {% if page.url == '/tpstreams/billing/plans/' or page.url == '/tpstreams/billing/checkout/' or page.url == '/tpstreams/billing/invoices/'%} text-blue-600 {% else %} text-gray-400 group-hover:text-gray-500 {% endif %}"
-            fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round"
-              d="M4.5 12a7.5 7.5 0 0015 0m-15 0a7.5 7.5 0 1115 0m-15 0H3m16.5 0H21m-1.5 0H12m-8.457 3.077l1.41-.513m14.095-5.13l1.41-.513M5.106 17.785l1.15-.964m11.49-9.642l1.149-.964M7.501 19.795l.75-1.3m7.5-12.99l.75-1.3m-6.063 16.658l.26-1.477m2.605-14.772l.26-1.477m0 17.726l-.26-1.477M10.698 4.614l-.26-1.477M16.5 19.794l-.75-1.299M7.5 4.205L12 12m6.894 5.785l-1.149-.964M6.256 7.178l-1.15-.964m15.352 8.864l-1.41-.513M4.954 9.435l-1.41-.514M12.002 12l-3.75 6.495" />
+          <svg class="mr-3 h-6 w-6 flex-shrink-0 {% if page.url == '/tpstreams/billing/plans/' or page.url == '/tpstreams/billing/checkout/' or page.url == '/tpstreams/billing/invoices/'%} text-blue-600 {% else %} text-gray-400 group-hover:text-gray-500 {% endif %}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
           </svg>
           Billing
         </a>


### PR DESCRIPTION
- Previously, the Billing tab displayed the Settings icon by mistake.
- This commit updates it to use the correct Billing icon.