### PR TITLE
fix: change text color in dark mode on course list page

### DIFF
--- a/src/testpress/my_courses/list.html
+++ b/src/testpress/my_courses/list.html
@@ -66,7 +66,7 @@
           <div class="hs-tooltip [--trigger:click] [--placement:bottom] hover:cursor-pointer inline-block">
             <button type="button" class="hs-tooltip-toggle inline">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                stroke="currentColor" class="w-4 h-4 text-gray-400 hover:cursor-pointer inline">
+                stroke="currentColor" class="w-4 h-4 text-gray-400 hover:cursor-pointer inline dark:text-neutral-400">
                 <path stroke-linecap="round" stroke-linejoin="round"
                   d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
               </svg>
@@ -83,11 +83,11 @@
       <div class="">
         <ul>
           <div class="text-sm">
-            <span class="text-gray-500 hover:cursor-pointer">{{ product.chapters }} chapters</span>
+            <span class="text-gray-500 hover:cursor-pointer dark:text-neutral-500">{{ product.chapters }} chapters</span>
             <!-- space -->
-            <span class="text-gray-500">·</span>
+            <span class="text-gray-500 dark:text-neutral-500">·</span>
             <!-- space -->
-            <span class="text-gray-500 hover:cursor-pointer">{{ product.contents }} contents</span>
+            <span class="text-gray-500 hover:cursor-pointer dark:text-neutral-500">{{ product.contents }} contents</span>
           </div>
         </ul>
       </div>
@@ -119,7 +119,7 @@
         <a href="#"
           class="flex items-center gap-x-1 text-sm underline underline-offset-4
                 {{ is_disabled
-                    and 'pointer-events-none text-gray-400'
+                    and 'pointer-events-none text-gray-400 dark:text-neutral-400'
                     or 'text-gray-800 hover:text-primary-600 focus:outline-none focus:text-primary-600 dark:text-neutral-200 dark:hover:text-primary-400 dark:focus:text-primary-400' }}"
           {% if is_disabled %}aria-disabled="true"{% endif %}>
 
@@ -150,7 +150,7 @@
         <div class="hs-dropdown relative inline-flex [--placement:bottom] [--trigger:click] [--strategy:absolute]">
           <button type="button" class="hs-dropdown-toggle inline items-center justify-center">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                stroke="currentColor" class="w-4 h-4 text-gray-400 hover:cursor-pointer inline">
+                stroke="currentColor" class="w-4 h-4 text-gray-400 hover:cursor-pointer inline dark:text-neutral-400">
                 <path stroke-linecap="round" stroke-linejoin="round"
                   d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
             </svg>


### PR DESCRIPTION
- This commit changes text colour in dark mode in course list page.
- Previously gray colour was used, now it is changed to neutral for dark mode.