### PR TITLE
style: Add dark styles for attachment, video conference, exams, videos, assignments and discussion pages

### DIFF
--- a/src/content_detail_page/assignment.html
+++ b/src/content_detail_page/assignment.html
@@ -43,7 +43,7 @@ pagination:
       <!-- Left sidebar & main wrapper -->
       <div class="flex-1 xl:flex">
   
-        <div class="px-4 py-6 sm:px-6 lg:pl-8 xl:flex-1 xl:pl-6">
+        <div class="px-4 py-6 sm:px-6 lg:pl-8 xl:flex-1 xl:pl-6 dark:bg-neutral-800">
           {% include "./includes/assignment_heading.html" %}
             
             {% if assignment.instructions %}
@@ -58,7 +58,7 @@ pagination:
         </div>
       </div>
   
-      <div class="shrink-0 border-t border-gray-200 px-4 py-6 sm:px-6 xl:w-96 xl:border-l xl:border-t-0 xl:pr-6">
+      <div class="shrink-0 border-t border-gray-200 px-4 py-6 sm:px-6 xl:w-96 xl:border-l xl:border-t-0 xl:pr-6 dark:bg-neutral-800 dark:border-neutral-700">
         {% include "./includes/assignment_attempt_details.html" %}
       </div>
     </div>
@@ -115,11 +115,11 @@ pagination:
         }),
         Placeholder.configure({
           placeholder: 'Add your response here.',
-          emptyNodeClass: 'before:text-gray-400'
+          emptyNodeClass: 'before:text-gray-400 dark:before:text-neutral-500'
         }),
         Paragraph.configure({
           HTMLAttributes: {
-            class: 'text-sm text-gray-800'
+            class: 'text-sm text-gray-800 dark:text-neutral-300'
           }
         }),
         Bold.configure({
@@ -130,17 +130,17 @@ pagination:
         Underline,
         Link.configure({
           HTMLAttributes: {
-            class: 'inline-flex items-center gap-x-1 text-green-600 decoration-2 hover:underline font-medium'
+            class: 'inline-flex items-center gap-x-1 text-green-600 dark:text-green-500 decoration-2 hover:underline font-medium'
           }
         }),
         BulletList.configure({
           HTMLAttributes: {
-            class: 'list-disc list-inside text-gray-800'
+            class: 'list-disc list-inside text-gray-800 dark:text-neutral-300'
           }
         }),
         OrderedList.configure({
           HTMLAttributes: {
-            class: 'list-decimal list-inside text-gray-800'
+            class: 'list-decimal list-inside text-gray-800 dark:text-neutral-300'
           }
         }),
         ListItem.configure({
@@ -150,27 +150,27 @@ pagination:
         }),
         Blockquote.configure({
           HTMLAttributes: {
-            class: 'relative border-s-4 ps-4 sm:ps-6 [&>p]:sm:text-lg text-gray-800'
+            class: 'relative border-s-4 ps-4 sm:ps-6 [&>p]:sm:text-lg text-gray-800 dark:text-neutral-300 border-gray-200 dark:border-neutral-700'
           }
         })
       ]
     });
     const actions = [
       {
-        id: `${id} [data-hs-editor-bold]`,
-        fn: () => editor.chain().focus().toggleBold().run()
+         id: `${id} [data-hs-editor-bold]`,
+         fn: () => editor.chain().focus().toggleBold().run()
       },
       {
-        id: `${id} [data-hs-editor-italic]`,
-        fn: () => editor.chain().focus().toggleItalic().run()
+         id: `${id} [data-hs-editor-italic]`,
+         fn: () => editor.chain().focus().toggleItalic().run() 
       },
-      {
-        id: `${id} [data-hs-editor-underline]`,
-        fn: () => editor.chain().focus().toggleUnderline().run()
+      { 
+        id: `${id} [data-hs-editor-underline]`, 
+        fn: () => editor.chain().focus().toggleUnderline().run() 
       },
-      {
-        id: `${id} [data-hs-editor-strike]`,
-        fn: () => editor.chain().focus().toggleStrike().run()
+      { 
+        id: `${id} [data-hs-editor-strike]`, 
+        fn: () => editor.chain().focus().toggleStrike().run() 
       },
       {
         id: `${id} [data-hs-editor-link]`,
@@ -179,21 +179,21 @@ pagination:
           editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
         }
       },
-      {
-        id: `${id} [data-hs-editor-ol]`,
-        fn: () => editor.chain().focus().toggleOrderedList().run()
+      { 
+        id: `${id} [data-hs-editor-ol]`, 
+        fn: () => editor.chain().focus().toggleOrderedList().run() 
       },
-      {
-        id: `${id} [data-hs-editor-ul]`,
-        fn: () => editor.chain().focus().toggleBulletList().run()
+      { 
+        id: `${id} [data-hs-editor-ul]`, 
+        fn: () => editor.chain().focus().toggleBulletList().run() 
       },
-      {
-        id: `${id} [data-hs-editor-blockquote]`,
-        fn: () => editor.chain().focus().toggleBlockquote().run()
+      { 
+        id: `${id} [data-hs-editor-blockquote]`, 
+        fn: () => editor.chain().focus().toggleBlockquote().run() 
       },
-      {
-        id: `${id} [data-hs-editor-code]`,
-        fn: () => editor.chain().focus().toggleCode().run()
+      { 
+        id: `${id} [data-hs-editor-code]`, 
+        fn: () => editor.chain().focus().toggleCode().run() 
       }
     ];
 

--- a/src/content_detail_page/attachment.html
+++ b/src/content_detail_page/attachment.html
@@ -10,19 +10,19 @@
 <div x-data="contents">
   {% include "./includes/mobile_sidebar.html" %}
   {% include "./includes/desktop_sidebar.html" %}
-  <main class="lg:pl-96">
+  <main class="lg:pl-96 dark:bg-neutral-800">
     {% include "./includes/navigate_content.html" %}
     <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
       {% include "./includes/content_heading.html" %}
       <div class="mt-6 py-2 px-4 sm:px-6 lg:px-0 max-w-5xl mx-auto flex justify-center">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-teal-50 text-teal-700 ring-4 ring-white">
+          <span class="inline-flex rounded-lg p-3 bg-teal-50 text-teal-700 ring-4 ring-white dark:bg-teal-800 dark:ring-neutral-800 dark:text-teal-400">
             <svg fill="none" stroke="currentColor" stroke-width="1" class="h-20 w-20" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round"
                 d="m18.375 12.739-7.693 7.693a4.5 4.5 0 0 1-6.364-6.364l10.94-10.94A3 3 0 1 1 19.5 7.372L8.552 18.32m.009-.01-.01.01m5.699-9.941-7.81 7.81a1.5 1.5 0 0 0 2.112 2.13" />
             </svg>
           </span>
-          <div class="flex justify-center font-medium mt-2 text-xs text-gray-500">
+          <div class="flex justify-center font-medium mt-2 text-xs text-gray-500 dark:text-neutral-400">
             <div> 200 MB</div>
           </div>
           <button type="button"

--- a/src/content_detail_page/create_discussion.html
+++ b/src/content_detail_page/create_discussion.html
@@ -13,7 +13,7 @@ tab: "discussions"
 <div x-data="contents">
   {% include "./includes/mobile_sidebar.html" %}
   {% include "./includes/desktop_sidebar.html" %}
-  <main class="lg:pl-96">
+  <main class="lg:pl-96 dark:bg-neutral-800">
     {% include "./includes/course_tabs.html" %}
     {% include "./includes/discussion_form.html" %}
   </main>

--- a/src/content_detail_page/empty_history.html
+++ b/src/content_detail_page/empty_history.html
@@ -20,7 +20,7 @@ tab: "history"
       <div class="text-center">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8 mx-auto text-gray-500 dark:text-neutral-500"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
         <h3 class="mt-2 text-sm font-semibold text-gray-900 dark:text-neutral-200">History is Empty</h3>
-        <p class="mt-1 text-sm text-gray-500 dark:text-neutral-400c">This section will display contents once they have been engaged with or completed.</p>
+        <p class="mt-1 text-sm text-gray-500 dark:text-neutral-400">This section will display contents once they have been engaged with or completed.</p>
       </div>
     </div>
   </main>

--- a/src/content_detail_page/exam.html
+++ b/src/content_detail_page/exam.html
@@ -12,7 +12,7 @@
 	{% include "./includes/desktop_sidebar.html" %}  
 	<main class="lg:pl-96" x-data="GenerateorDownloadCertificate">
     {% include "./includes/navigate_content.html" %}
-    <div class="lg:px-8 dark:bg-neutral-900" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
+    <div class="lg:px-8 dark:bg-neutral-800" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
         <div class="mt-6 p-4 sm:px-6 lg:px-0 flex items-center justify-between">
           <div class="min-w-0 flex-1">
             <h1 class="text-lg lg:text-2xl font-bold text-gray-900 dark:text-neutral-200">What is Markup language?</h1>

--- a/src/content_detail_page/exam.html
+++ b/src/content_detail_page/exam.html
@@ -12,14 +12,14 @@
 	{% include "./includes/desktop_sidebar.html" %}  
 	<main class="lg:pl-96" x-data="GenerateorDownloadCertificate">
     {% include "./includes/navigate_content.html" %}
-    <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
+    <div class="lg:px-8 dark:bg-neutral-900" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
         <div class="mt-6 p-4 sm:px-6 lg:px-0 flex items-center justify-between">
           <div class="min-w-0 flex-1">
-            <h1 class="text-lg lg:text-2xl font-bold text-gray-900">What is Markup language?</h1>
+            <h1 class="text-lg lg:text-2xl font-bold text-gray-900 dark:text-neutral-200">What is Markup language?</h1>
           </div>
           <div class="flex ml-4">
-            <button type="button" @click="getcertificate()" class="inline-flex text-sm font-semibold items-center text-emerald-600 focus:outline-none">
-          <svg xmlns="http://www.w3.org/2000/svg" class="mr-1.5 -ml-0.5 size-5 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+            <button type="button" @click="getcertificate()" class="inline-flex text-sm font-semibold items-center text-emerald-600 focus:outline-none dark:text-emerald-400">
+          <svg xmlns="http://www.w3.org/2000/svg" class="mr-1.5 -ml-0.5 size-5 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
           </svg>  
               <span class="hover:underline">Certificate</span>  

--- a/src/content_detail_page/includes/assignment_attachments.html
+++ b/src/content_detail_page/includes/assignment_attachments.html
@@ -1,20 +1,20 @@
 <div id="hs-show-hide-collapse-heading" class="hs-collapse hidden w-full overflow-hidden transition-[height] duration-300 pt-4" aria-labelledby="hs-show-hide-collapse">
-  <h3 class="text-sm font-medium text-gray-700">Attachments</h3>
-  <dd class="mt-2 text-sm text-gray-900 sm:col-span-2">
-    <ul role="list" class="divide-y divide-gray-100 rounded-md border border-gray-200">
+  <h3 class="text-sm font-medium text-gray-700 dark:text-neutral-300">Attachments</h3>
+  <dd class="mt-2 text-sm text-gray-900 sm:col-span-2 dark:text-neutral-200">
+    <ul role="list" class="divide-y divide-gray-100 rounded-md border border-gray-200 dark:border-neutral-700 dark:divide-neutral-700">
       {% for attachment in assignment.attachments %}
       <li class="flex items-center justify-between py-4 pr-5 pl-4 text-sm/6">
         <div class="flex w-0 flex-1 items-center">
-          <svg class="size-5 shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+          <svg class="size-5 shrink-0 text-gray-400 dark:text-neutral-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
 <path fill-rule="evenodd" d="M15.621 4.379a3 3 0 0 0-4.242 0l-7 7a3 3 0 0 0 4.241 4.243h.001l.497-.5a.75.75 0 0 1 1.064 1.057l-.498.501-.002.002a4.5 4.5 0 0 1-6.364-6.364l7-7a4.5 4.5 0 0 1 6.368 6.36l-3.455 3.553A2.625 2.625 0 1 1 9.52 9.52l3.45-3.451a.75.75 0 1 1 1.061 1.06l-3.45 3.451a1.125 1.125 0 0 0 1.587 1.595l3.454-3.553a3 3 0 0 0 0-4.242Z" clip-rule="evenodd"></path>
 </svg>
           <div class="ml-4 flex min-w-0 flex-1 gap-2">
-            <span class="truncate font-medium">{{attachment.filename}}</span>
-            <span class="shrink-0 text-gray-400">{{attachment.filesize}}</span>
+            <span class="truncate font-medium dark:text-neutral-200">{{attachment.filename}}</span>
+            <span class="shrink-0 text-gray-400 dark:text-neutral-500">{{attachment.filesize}}</span>
           </div>
         </div>
         <div class="ml-4 shrink-0">
-          <a href="{{attachment.url}}" target="_blank" class="font-medium text-emerald-600 hover:text-emerald-500">Download</a>
+          <a href="{{attachment.url}}" target="_blank" class="font-medium text-emerald-600 hover:text-emerald-500 dark:text-emerald-500 dark:hover:text-emerald-400">Download</a>
         </div>
       </li>
       {% endfor %}
@@ -23,7 +23,7 @@
 </div>
 
 <p class="mt-2 px-4 sm:px-6 lg:px-0">
-  <button type="button" class="hs-collapse-toggle inline-flex items-center gap-x-1 text-sm font-semibold rounded-lg border border-transparent text-emerald-600 decoration-2 hover:text-emerald-700 hover:underline focus:outline-none focus:underline focus:text-emerald-700 disabled:opacity-50 disabled:pointer-events-none dark:text-emerald-500 dark:hover:text-emerald-600 dark:focus:text-emerald-600" id="hs-show-hide-collapse" aria-expanded="false" aria-controls="hs-show-hide-collapse-heading" data-hs-collapse="#hs-show-hide-collapse-heading">
+  <button type="button" class="hs-collapse-toggle inline-flex items-center gap-x-1 text-sm font-semibold rounded-lg border border-transparent text-emerald-600 decoration-2 hover:text-emerald-700 hover:underline focus:outline-none focus:underline focus:text-emerald-700 disabled:opacity-50 disabled:pointer-events-none dark:text-emerald-500 dark:hover:text-emerald-400 dark:focus:text-emerald-400" id="hs-show-hide-collapse" aria-expanded="false" aria-controls="hs-show-hide-collapse-heading" data-hs-collapse="#hs-show-hide-collapse-heading">
     <span class="hs-collapse-open:hidden">Show attachments</span>
     <span class="hs-collapse-open:block hidden">Hide attachments</span>
     <svg class="hs-collapse-open:rotate-180 shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/content_detail_page/includes/assignment_attempt_details.html
+++ b/src/content_detail_page/includes/assignment_attempt_details.html
@@ -1,64 +1,60 @@
 <div class="space-y-6">
   <!-- Your Response -->
-  <div class="border border-gray-200 divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow-xs">
+  <div class="border border-gray-200 divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow-xs dark:bg-neutral-900 dark:border-neutral-800 dark:divide-neutral-800">
     <div class="py-3 px-5">
       <div class="flex justify-between items-center">
-        <h3 class="text-sm font-semibold text-gray-900">Your Response</h3>
-        <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-neutral-200">Your Response</h3>
+        <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20 dark:bg-green-500/10 dark:text-green-500 dark:ring-green-500/20">
           Submitted
         </span>
       </div>
     </div>
-    <div class="py-3 px-5 relative group flex items-center gap-x-3 bg-white">
-      <svg class="shrink-0 size-6 text-gray-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"></path></svg>
+    <div class="py-3 px-5 relative group flex items-center gap-x-3 bg-white dark:bg-neutral-900">
+      <svg class="shrink-0 size-6 text-gray-500 dark:text-neutral-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"></path></svg>
 
       <div class="grow truncate">
-        <p class="block truncate text-sm font-medium text-gray-800">
+        <p class="block truncate text-sm font-medium text-gray-800 dark:text-neutral-200">
           john_assignment_1.jpg
         </p>
-        <p class="block truncate text-xs text-gray-500">
+        <p class="block truncate text-xs text-gray-500 dark:text-neutral-500">
           2MB
         </p>
       </div>
 
-      <!-- More Dropdown -->
       <div class="lg:absolute lg:top-3 lg:end-5 group-hover:opacity-100 lg:opacity-0">
-        <div class="p-0.5 sm:p-1 inline-flex items-center gap-0.5 bg-white border border-gray-200 lg:shadow rounded-lg">
-          <!-- Button Icon -->
+        <div class="p-0.5 sm:p-1 inline-flex items-center gap-0.5 bg-white border border-gray-200 lg:shadow rounded-lg dark:bg-neutral-800 dark:border-neutral-700">
           <div class="hs-tooltip inline-block">
-            <a class="hs-tooltip-toggle size-[30px] inline-flex justify-center items-center gap-x-2 rounded-lg border border-transparent text-gray-500 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100" href="https://images.unsplash.com/photo-1635776062360-af423602aff3?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=crop&amp;w=988&amp;q=80" target="_blank" download="">
+            <a class="hs-tooltip-toggle size-[30px] inline-flex justify-center items-center gap-x-2 rounded-lg border border-transparent text-gray-500 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#" target="_blank" download="">
               <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" x2="12" y1="15" y2="3"></line></svg>
             </a>
-            <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 inline-block absolute invisible z-20 py-1.5 px-2.5 bg-gray-900 text-xs text-white rounded-lg hidden" role="tooltip" style="position: fixed; inset: auto auto 0px 0px; margin: 0px; transform: translate3d(1703.17px, -293.333px, 0px);" data-popper-placement="top">
+            <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 inline-block absolute invisible z-20 py-1.5 px-2.5 bg-gray-900 text-xs text-white rounded-lg hidden dark:bg-neutral-700" role="tooltip">
               Download
             </span>
           </div>
-          <!-- End Button Icon -->
         </div>
       </div>
-      <!-- End More Dropdown -->
     </div>
-    <div class="py-3 px-5 relative group flex items-center gap-x-3 bg-white">
-      <svg class="shrink-0 size-6 text-gray-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"></path></svg>
+    <div class="py-3 px-5 relative group flex items-center gap-x-3 bg-white dark:bg-neutral-900">
+      <svg class="shrink-0 size-6 text-gray-500 dark:text-neutral-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"></path></svg>
 
       <div class="grow truncate">
-        <p class="block truncate text-sm font-medium text-gray-800">
+        <p class="block truncate text-sm font-medium text-gray-800 dark:text-neutral-200">
           john_assignment_2.jpg
         </p>
-        <p class="block truncate text-xs text-gray-500">
+        <p class="block truncate text-xs text-gray-500 dark:text-neutral-500">
           2MB
         </p>
       </div>
 
       <!-- More Dropdown -->
       <div class="lg:absolute lg:top-3 lg:end-5 group-hover:opacity-100 lg:opacity-0">
-        <div class="p-0.5 sm:p-1 inline-flex items-center gap-0.5 bg-white border border-gray-200 lg:shadow rounded-lg">
+        <div class="p-0.5 sm:p-1 inline-flex items-center gap-0.5 bg-white border border-gray-200 lg:shadow rounded-lg dark:bg-neutral-800 dark:border-neutral-700">
           <!-- Button Icon -->
           <div class="hs-tooltip inline-block">
-            <a class="hs-tooltip-toggle size-[30px] inline-flex justify-center items-center gap-x-2 rounded-lg border border-transparent text-gray-500 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100" href="https://images.unsplash.com/photo-1635776062360-af423602aff3?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=crop&amp;w=988&amp;q=80" target="_blank" download="">
+            <a class="hs-tooltip-toggle size-[30px] inline-flex justify-center items-center gap-x-2 rounded-lg border border-transparent text-gray-500 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" href="#" target="_blank" download="">
               <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" x2="12" y1="15" y2="3"></line></svg>
             </a>
-            <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 inline-block absolute invisible z-20 py-1.5 px-2.5 bg-gray-900 text-xs text-white rounded-lg hidden" role="tooltip" style="position: fixed; inset: auto auto 0px 0px; margin: 0px; transform: translate3d(1703.17px, -293.333px, 0px);" data-popper-placement="top">
+            <span class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible opacity-0 inline-block absolute invisible z-20 py-1.5 px-2.5 bg-gray-900 text-xs text-white rounded-lg hidden dark:bg-neutral-700" role="tooltip">
               Download
             </span>
           </div>
@@ -90,35 +86,35 @@
     </div>
   </div> -->
   <!-- Grading & Feedbacks -->
-  <div class="border border-gray-200 divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow-xs">
+  <div class="border border-gray-200 divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow-xs dark:bg-neutral-900 dark:border-neutral-800 dark:divide-neutral-800">
     <div class="py-3 px-5">
       <div class="flex justify-between items-center">
-        <h3 class="text-sm font-semibold text-gray-900">Grading & Feedbacks</h3>
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-neutral-200">Grading & Feedbacks</h3>
 
       </div>
     </div>
 
     <!-- Marks -->
     <div class="py-3 px-5 flex justify-between items-center">
-      <dt class="text-sm font-medium text-gray-900">Marks</dt>
-      <dd class="text-sm/6 font-semibold text-gray-800">85 / 100</dd>
+      <dt class="text-sm font-medium text-gray-900 dark:text-neutral-400">Marks</dt>
+      <dd class="text-sm/6 font-semibold text-gray-800 dark:text-emerald-500">85 / 100</dd>
     </div>
 
     <!-- Evaluation Date -->
     <div class="py-3 px-5 flex justify-between items-center">
-      <dt class="text-sm font-medium text-gray-900">Evaluation Date</dt>
-      <dd class="text-sm/6 text-gray-700">March 5, 2024</dd>
+      <dt class="text-sm font-medium text-gray-900 dark:text-neutral-400">Evaluation Date</dt>
+      <dd class="text-sm/6 text-gray-700 dark:text-neutral-300">March 5, 2024</dd>
     </div>
 
     <!-- Feedback -->
     <div class="py-3 px-5">
-      <dt class="text-sm font-medium text-gray-900">
+      <dt class="text-sm font-medium text-gray-900 dark:text-neutral-400">
         Feedback
       </dt>
-      <dd class="mt-1 text-sm/6 text-gray-700">Great job on the research! The structure is well-organized, but consider refining your introduction for better clarity.</dd>
+      <dd class="mt-1 text-sm/6 text-gray-700 dark:text-neutral-300">Great job on the research! The structure is well-organized, but consider refining your introduction for better clarity.</dd>
     </div>
   </div>
 
 
-  <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 ring-1 shadow-xs ring-gray-300 ring-inset hover:bg-gray-50 sm:mt-0" aria-controls="unsubmit-confirmation" data-hs-overlay="#unsubmit-confirmation">Unsubmit</button>
+  <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 ring-1 shadow-xs ring-gray-300 ring-inset hover:bg-gray-50 sm:mt-0 dark:bg-neutral-900 dark:text-neutral-300 dark:ring-neutral-800 dark:hover:bg-neutral-800 transition-colors" data-hs-overlay="#unsubmit-confirmation">Unsubmit</button>
 </div>

--- a/src/content_detail_page/includes/assignment_heading.html
+++ b/src/content_detail_page/includes/assignment_heading.html
@@ -1,18 +1,18 @@
 <div class="flex justify-between items-center">
   <div>
-    <h2 class="text-2xl/7 font-bold text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">{{assignment.title}}</h2>
+    <h2 class="text-2xl/7 font-bold text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight dark:text-neutral-200">{{assignment.title}}</h2>
     <div class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
       {% if assignment.end_date %}
-      <div class="mt-2 flex items-center text-sm text-gray-500">
-        <svg class="mr-1.5 size-5 shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+      <div class="mt-2 flex items-center text-sm text-gray-500 dark:text-neutral-400">
+        <svg class="mr-1.5 size-5 shrink-0 text-gray-400 dark:text-neutral-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
           <path fill-rule="evenodd" d="M5.75 2a.75.75 0 0 1 .75.75V4h7V2.75a.75.75 0 0 1 1.5 0V4h.25A2.75 2.75 0 0 1 18 6.75v8.5A2.75 2.75 0 0 1 15.25 18H4.75A2.75 2.75 0 0 1 2 15.25v-8.5A2.75 2.75 0 0 1 4.75 4H5V2.75A.75.75 0 0 1 5.75 2Zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75Z" clip-rule="evenodd" />
         </svg>
         Due on {{assignment.end_date}} at {{assignment.end_time}}
       </div>
       {% endif %}
       {% if assignment.maximum_marks %}
-      <div class="mt-2 flex items-center text-sm text-gray-500">
-        <svg class="mr-1.5 size-[1.1rem] shrink-0 text-gray-400" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+      <div class="mt-2 flex items-center text-sm text-gray-500 dark:text-neutral-400">
+        <svg class="mr-1.5 size-[1.1rem] shrink-0 text-gray-400 dark:text-neutral-500" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
           <path d="M3 14.5A1.5 1.5 0 0 1 1.5 13V3A1.5 1.5 0 0 1 3 1.5h8a.5.5 0 0 1 0 1H3a.5.5 0 0 0-.5.5v10a.5.5 0 0 0 .5.5h10a.5.5 0 0 0 .5-.5V8a.5.5 0 0 1 1 0v5a1.5 1.5 0 0 1-1.5 1.5z"/>
           <path d="m8.354 10.354 7-7a.5.5 0 0 0-.708-.708L8 9.293 5.354 6.646a.5.5 0 1 0-.708.708l3 3a.5.5 0 0 0 .708 0"/>
         </svg>

--- a/src/content_detail_page/includes/assignment_instructions.html
+++ b/src/content_detail_page/includes/assignment_instructions.html
@@ -1,3 +1,3 @@
-<div class="py-4 text-base/7 text-gray-700">
+<div class="py-4 text-base/7 text-gray-700 dark:text-neutral-300">
   {{ assignment.instructions | safe }}
 </div>

--- a/src/content_detail_page/includes/assignment_submission.html
+++ b/src/content_detail_page/includes/assignment_submission.html
@@ -1,20 +1,20 @@
-<section class="bg-white sm:overflow-hidden sm:rounded-lg py-4">
+<section class="bg-white sm:overflow-hidden sm:rounded-lg py-4 dark:bg-neutral-800 transition-colors duration-300">
   <!-- Tab -->
-  <div class="bg-white space-y-4">
+  <div class="bg-white space-y-4 dark:bg-neutral-800">
     {% if assignment.allowed_submission_types and 'ONLINE_TEXT' in assignment.allowed_submission_types and 'FILE_TYPE' in assignment.allowed_submission_types %}
-    <div id="hs-pro-shchal" class="rounded-md bg-blue-50 p-4" role="alert" tabindex="-1" aria-labelledby="hs-pro-shchal-label">
+    <div id="hs-pro-shchal" class="rounded-md bg-blue-50 p-4 dark:bg-blue-900/30 dark:border dark:border-blue-800/50" role="alert" tabindex="-1" aria-labelledby="hs-pro-shchal-label">
       <div class="flex">
         <div class="shrink-0">
-          <svg class="size-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+          <svg class="size-5 text-blue-400 dark:text-blue-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
             <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
           </svg>
         </div>
         <div class="ml-3 flex-1 md:flex md:justify-between">
-          <p class="text-sm text-blue-700">Submit either an uploaded file or a typed response—not both.</p>
+          <p class="text-sm text-blue-700 dark:text-blue-400">Submit either an uploaded file or a typed response—not both.</p>
         </div>
         <div class="ml-auto pl-3">
           <div class="-mx-1.5 -my-1.5">
-            <button type="button" class="inline-flex rounded-md bg-blue-50 p-1.5 text-blue-500 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-blue-50" data-hs-remove-element="#hs-pro-shchal">
+            <button type="button" class="inline-flex rounded-md bg-blue-50 p-1.5 text-blue-500 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-blue-50 dark:bg-transparent dark:text-blue-400 dark:hover:bg-white/10" data-hs-remove-element="#hs-pro-shchal">
               <span class="sr-only">Dismiss</span>
               <svg class="size-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
                 <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
@@ -25,18 +25,18 @@
       </div>
     </div>
     <!-- Nav Tab -->
-    <nav class="relative  flex space-x-1 after:absolute after:bottom-0 after:inset-x-0 after:border-b-2 after:border-gray-200" aria-label="Tabs" role="tablist" aria-orientation="horizontal">
-      <button type="button" class="hs-tab-active:after:bg-gray-800 hs-tab-active:text-gray-800 px-2.5 py-1.5 mb-2 relative inline-flex justify-center items-center gap-x-2  hover:bg-gray-100 text-gray-500 hover:text-gray-800 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 after:absolute after:-bottom-2 after:inset-x-0 after:z-10 after:h-0.5 after:pointer-events-none active " id="hs-pro-tabs-fwb-item-open" aria-selected="true" data-hs-tab="#hs-pro-tabs-fwb-open" aria-controls="hs-pro-tabs-fwb-open" role="tab" >
+    <nav class="relative flex space-x-1 after:absolute after:bottom-0 after:inset-x-0 after:border-b-2 after:border-gray-200 dark:after:border-neutral-700" aria-label="Tabs" role="tablist" aria-orientation="horizontal">
+      <button type="button" class="hs-tab-active:after:bg-gray-800 dark:hs-tab-active:after:bg-neutral-200 hs-tab-active:text-gray-800 dark:hs-tab-active:text-neutral-200 px-2.5 py-1.5 mb-2 relative inline-flex justify-center items-center gap-x-2 hover:bg-gray-100 dark:hover:bg-neutral-700 text-gray-500 dark:text-neutral-400 hover:text-gray-800 dark:hover:text-neutral-200 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-700 after:absolute after:-bottom-2 after:inset-x-0 after:z-10 after:h-0.5 after:pointer-events-none active " id="hs-pro-tabs-fwb-item-open" aria-selected="true" data-hs-tab="#hs-pro-tabs-fwb-open" aria-controls="hs-pro-tabs-fwb-open" role="tab" >
         File Upload
       </button>
-      <button type="button" class="hs-tab-active:after:bg-gray-800 hs-tab-active:text-gray-800 px-2.5 py-1.5 mb-2 relative inline-flex justify-center items-center gap-x-2  hover:bg-gray-100 text-gray-500 hover:text-gray-800 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 after:absolute after:-bottom-2 after:inset-x-0 after:z-10 after:h-0.5 after:pointer-events-none  " id="hs-pro-tabs-fwb-item-archived" aria-selected="false" data-hs-tab="#hs-pro-tabs-fwb-archived" aria-controls="hs-pro-tabs-fwb-archived" role="tab" >
+      <button type="button" class="hs-tab-active:after:bg-gray-800 dark:hs-tab-active:after:bg-neutral-200 hs-tab-active:text-gray-800 dark:hs-tab-active:text-neutral-200 px-2.5 py-1.5 mb-2 relative inline-flex justify-center items-center gap-x-2 hover:bg-gray-100 dark:hover:bg-neutral-700 text-gray-500 dark:text-neutral-400 hover:text-gray-800 dark:hover:text-neutral-200 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-700 after:absolute after:-bottom-2 after:inset-x-0 after:z-10 after:h-0.5 after:pointer-events-none " id="hs-pro-tabs-fwb-item-archived" aria-selected="false" data-hs-tab="#hs-pro-tabs-fwb-archived" aria-controls="hs-pro-tabs-fwb-archived" role="tab" >
         Online Text
       </button>
     </nav>
     <!-- End Nav Tab -->
-     {% else %}
+    {% else %}
      <div>
-        <h2 id="notes-title" class="text-base lg:text-lg font-medium text-gray-900">
+        <h2 id="notes-title" class="text-base lg:text-lg font-medium text-gray-900 dark:text-neutral-200">
           {% if assignment.allowed_submission_types and 'FILE_TYPE' in assignment.allowed_submission_types %}
           Upload Your Assignment Files
           {% else %}
@@ -67,17 +67,17 @@
         }
       }'>
         <template data-hs-file-upload-preview="">
-          <div class="p-3 bg-white border border-solid border-gray-300 rounded-xl">
+          <div class="p-3 bg-white dark:bg-neutral-900 border border-solid border-gray-300 dark:border-neutral-700 rounded-xl">
             <div class="mb-1 flex justify-between items-center">
               <div class="flex items-center gap-x-3">
-                <span class="size-10 flex justify-center items-center border border-gray-200 text-gray-500 rounded-lg" data-hs-file-upload-file-icon="">
+                <span class="size-10 flex justify-center items-center border border-gray-200 dark:border-neutral-700 text-gray-500 dark:text-neutral-400 rounded-lg" data-hs-file-upload-file-icon="">
                   <img class="rounded-lg hidden" data-dz-thumbnail="">
                 </span>
                 <div>
-                  <p class="text-sm font-medium text-gray-800">
+                  <p class="text-sm font-medium text-gray-800 dark:text-neutral-200">
                     <span class="truncate inline-block max-w-[300px] align-bottom" data-hs-file-upload-file-name=""></span>.<span data-hs-file-upload-file-ext=""></span>
                   </p>
-                  <p class="text-xs text-gray-500" data-hs-file-upload-file-size="" data-hs-file-upload-file-success=""></p>
+                  <p class="text-xs text-gray-500 dark:text-neutral-500" data-hs-file-upload-file-size="" data-hs-file-upload-file-success=""></p>
                   <p class="text-xs text-red-500" style="display: none;" data-hs-file-upload-file-error="">File exceeds size limit.</p>
                 </div>
               </div>
@@ -94,13 +94,13 @@
                     </span>
                   </span>
                 </span>
-                <button type="button" class="text-gray-500 hover:text-gray-800 focus:outline-none focus:text-gray-800" data-hs-file-upload-reload="">
+                <button type="button" class="text-gray-500 dark:text-neutral-500 hover:text-gray-800 dark:hover:text-neutral-200 focus:outline-none" data-hs-file-upload-reload="">
                   <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"></path>
                     <path d="M21 3v5h-5"></path>
                   </svg>
                 </button>
-                <button type="button" class="text-gray-500 hover:text-gray-800 focus:outline-none focus:text-gray-800" data-hs-file-upload-remove="">
+                <button type="button" class="text-gray-500 dark:text-neutral-500 hover:text-gray-800 dark:hover:text-neutral-200 focus:outline-none" data-hs-file-upload-remove="">
                   <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M3 6h18"></path>
                     <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path>
@@ -111,13 +111,13 @@
                 </button>
               </div>
             </div>
-      
+
             <div class="flex items-center gap-x-3 whitespace-nowrap">
-              <div class="flex w-full h-2 bg-gray-200 rounded-full overflow-hidden" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" data-hs-file-upload-progress-bar="">
+              <div class="flex w-full h-2 bg-gray-200 dark:bg-neutral-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" data-hs-file-upload-progress-bar="">
                 <div class="flex flex-col justify-center rounded-full overflow-hidden bg-emerald-600 text-xs text-white text-center whitespace-nowrap transition-all duration-500 hs-file-upload-complete:bg-emerald-500" style="width: 0" data-hs-file-upload-progress-bar-pane=""></div>
               </div>
               <div class="w-10 text-end">
-                <span class="text-sm text-gray-800">
+                <span class="text-sm text-gray-800 dark:text-neutral-200">
                   <span data-hs-file-upload-progress-bar-value="">0</span>%
                 </span>
               </div>
@@ -127,32 +127,32 @@
 
         <!-- <label class="block text-sm font-medium text-gray-700">Upload your files:</label> -->
       
-        <div class="mt-2 cursor-pointer p-12 flex justify-center bg-white border border-dashed border-gray-300 rounded-xl" data-hs-file-upload-trigger="">
+        <div class="mt-2 cursor-pointer p-12 flex justify-center bg-white dark:bg-neutral-900 border border-dashed border-gray-300 dark:border-neutral-700 rounded-xl" data-hs-file-upload-trigger="">
           <div class="text-center">
-            <span class="inline-flex justify-center items-center size-16 bg-gray-100 text-gray-800 rounded-full">
+            <span class="inline-flex justify-center items-center size-16 bg-gray-100 dark:bg-neutral-800 text-gray-800 dark:text-neutral-200 rounded-full">
               <svg class="shrink-0 size-6" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
                 <polyline points="17 8 12 3 7 8"></polyline>
                 <line x1="12" x2="12" y1="3" y2="15"></line>
               </svg>
             </span>
-      
-            <div class="mt-4 flex flex-wrap justify-center text-sm leading-6 text-gray-600">
-              <span class="pe-1 font-medium text-gray-800">
+
+            <div class="mt-4 flex flex-wrap justify-center text-sm leading-6 text-gray-600 dark:text-neutral-400">
+              <span class="pe-1 font-medium text-gray-800 dark:text-neutral-200">
                 Drop your file here or
               </span>
-              <span class="bg-white font-semibold text-emerald-600 hover:text-emerald-700 rounded-lg decoration-2 hover:underline focus-within:outline-none focus-within:ring-2 focus-within:ring-emerald-600 focus-within:ring-offset-2">browse</span>
+              <span class="bg-white dark:bg-transparent font-semibold text-emerald-600 dark:text-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-400 rounded-lg decoration-2 hover:underline focus-within:outline-none focus-within:ring-2 focus-within:ring-emerald-600">browse</span>
             </div>
-      
-            <p class="mt-1 text-xs text-gray-400">
+
+            <p class="mt-1 text-xs text-gray-400 dark:text-neutral-500">
               Pick a file up to 2MB.
             </p>
           </div>
         </div>
-      
+
         <div class="mt-4 space-y-2 empty:mt-0" data-hs-file-upload-previews=""></div>
         <div class="mt-6 flex justify-end">
-          <button class="px-4 py-2 text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg text-sm font-medium" aria-haspopup="dialog" aria-expanded="false" aria-controls="confirm-online-text-submittion" data-hs-overlay="#confirm-file-submittion" >
+          <button class="px-4 py-2 text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg text-sm font-medium transition-colors" data-hs-overlay="#confirm-file-submittion" >
             Submit Response
           </button>
         </div>
@@ -160,41 +160,41 @@
       {% endif %}
       {% if assignment.allowed_submission_types and 'ONLINE_TEXT' in assignment.allowed_submission_types %}
       <div id="hs-pro-tabs-fwb-archived" class="{% if assignment.allowed_submission_types and 'ONLINE_TEXT' in assignment.allowed_submission_types and 'FILE_TYPE' in assignment.allowed_submission_types %}hidden{% endif %}" role="tabpanel" aria-labelledby="hs-pro-tabs-fwb-item-archived">
-        <div class="bg-white border border-gray-200 rounded-xl overflow-hidden dark:bg-neutral-800 dark:border-neutral-700">
+        <div class="bg-white border border-gray-200 rounded-xl overflow-hidden dark:bg-neutral-900 dark:border-neutral-700">
           <div id="hs-editor-tiptap">
-            <div class="sticky top-0 bg-white flex align-middle gap-x-0.5 border-b border-gray-200 p-2 dark:border-neutral-700">
-              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-white dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" type="button" data-hs-editor-bold>
+            <div class="sticky top-0 bg-white dark:bg-neutral-900 flex align-middle gap-x-0.5 border-b border-gray-200 dark:border-neutral-700 p-2">
+              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 dark:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-800" type="button" data-hs-editor-bold>
                 <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 12a4 4 0 0 0 0-8H6v8"/><path d="M15 20a4 4 0 0 0 0-8H6v8Z"/></svg>
               </button>
-              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-white dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" type="button" data-hs-editor-italic>
+              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 dark:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-800" type="button" data-hs-editor-italic>
                 <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" x2="10" y1="4" y2="4"/><line x1="14" x2="5" y1="20" y2="20"/><line x1="15" x2="9" y1="4" y2="20"/></svg>
               </button>
-              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-white dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" type="button" data-hs-editor-underline>
+              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 dark:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-800" type="button" data-hs-editor-underline>
                 <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 4v6a6 6 0 0 0 12 0V4"/><line x1="4" x2="20" y1="20" y2="20"/></svg>
               </button>
-              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-white dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" type="button" data-hs-editor-strike>
+              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 dark:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-800" type="button" data-hs-editor-strike>
                 <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><line x1="4" x2="20" y1="12" y2="12"/></svg>
               </button>
-              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-white dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" type="button" data-hs-editor-link>
+              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 dark:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-800" type="button" data-hs-editor-link>
                 <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
               </button>
-              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-white dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" type="button" data-hs-editor-ol>
+              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 dark:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-800" type="button" data-hs-editor-ol>
                 <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="10" x2="21" y1="6" y2="6"/><line x1="10" x2="21" y1="12" y2="12"/><line x1="10" x2="21" y1="18" y2="18"/><path d="M4 6h1v4"/><path d="M4 10h2"/><path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1"/></svg>
               </button>
-              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-white dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" type="button" data-hs-editor-ul>
+              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 dark:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-800" type="button" data-hs-editor-ul>
                 <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" x2="21" y1="6" y2="6"/><line x1="8" x2="21" y1="12" y2="12"/><line x1="8" x2="21" y1="18" y2="18"/><line x1="3" x2="3.01" y1="6" y2="6"/><line x1="3" x2="3.01" y1="12" y2="12"/><line x1="3" x2="3.01" y1="18" y2="18"/></svg>
               </button>
-              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-white dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" type="button" data-hs-editor-blockquote>
+              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 dark:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-800" type="button" data-hs-editor-blockquote>
                 <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 6H3"/><path d="M21 12H8"/><path d="M21 18H8"/><path d="M3 12v6"/></svg>
               </button>
-              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-white dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" type="button" data-hs-editor-code>
+              <button class="size-8 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-full border border-transparent text-gray-800 dark:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-800" type="button" data-hs-editor-code>
                 <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 16 4-4-4-4"/><path d="m6 8-4 4 4 4"/><path d="m14.5 4-5 16"/></svg>
               </button>
             </div>
-            <div class="h-[10rem] overflow-auto " data-hs-editor-field></div>
+            <div class="h-[10rem] overflow-auto prose prose-sm max-w-none dark:prose-invert dark:text-neutral-300 [&_*]:dark:text-neutral-300 p-2 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500" data-hs-editor-field></div>
           </div>
         </div>
-        <p class="mt-1 inline-flex items-center gap-x-1 text-xs text-gray-500" href="#">
+        <p class="mt-1 inline-flex items-center gap-x-1 text-xs text-gray-500 dark:text-neutral-500" href="#">
           <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"></path>
             <path d="M9 18h6"></path>
@@ -203,7 +203,7 @@
           Your response will be auto-saved.
         </p>
         <div class="mt-6 flex justify-end">
-          <button class="px-4 py-2 text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg text-sm font-medium" aria-haspopup="dialog" aria-expanded="false" aria-controls="confirm-online-text-submittion" data-hs-overlay="#confirm-online-text-submittion" >
+          <button class="px-4 py-2 text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg text-sm font-medium transition-colors" data-hs-overlay="#confirm-online-text-submittion" >
             Submit Response
           </button>
         </div>
@@ -211,5 +211,5 @@
       {% endif %}
     </div>
   </div>
-  <!-- End Tab -->
+
 </section>

--- a/src/content_detail_page/includes/certificate_generating_modal.html
+++ b/src/content_detail_page/includes/certificate_generating_modal.html
@@ -7,7 +7,7 @@
   x-transition:leave-start="opacity-100"
   x-transition:leave-end="opacity-0"
   x-show="showGeneratingCertificateModal"
-  class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-950 dark:bg-opacity-80" aria-hidden="true"></div>
+  class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-800 dark:bg-opacity-80" aria-hidden="true"></div>
 
   <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
@@ -18,8 +18,8 @@
       x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
       x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
       x-show="showGeneratingCertificateModal" 
-      class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg dark:bg-neutral-900 dark:ring-1 dark:ring-white/10">
-        <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 dark:bg-neutral-900">
+      class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg dark:bg-neutral-800 dark:ring-1 dark:ring-white/10">
+        <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 dark:bg-neutral-800">
           <div class="sm:flex sm:items-start">
             <div class="mt-3 text-center sm:mt-0 sm:text-left">
               <h3 class="text-base font-semibold text-gray-900 dark:text-neutral-200" id="modal-title">Generating Certificate</h3>
@@ -29,7 +29,7 @@
             </div>
           </div>
         </div>
-        <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 dark:bg-neutral-900">
+        <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 dark:bg-neutral-800">
           <button type="button" @click="showGeneratingCertificateModal=false" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 sm:ml-3 sm:w-auto dark:bg-emerald-500 dark:hover:bg-emerald-400">Close</button>
         </div>
       </div>

--- a/src/content_detail_page/includes/certificate_generating_modal.html
+++ b/src/content_detail_page/includes/certificate_generating_modal.html
@@ -7,7 +7,7 @@
   x-transition:leave-start="opacity-100"
   x-transition:leave-end="opacity-0"
   x-show="showGeneratingCertificateModal"
-  class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-950 dark:bg-opacity-80" aria-hidden="true"></div>
 
   <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
@@ -18,19 +18,19 @@
       x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
       x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
       x-show="showGeneratingCertificateModal" 
-      class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-        <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+      class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg dark:bg-neutral-900 dark:ring-1 dark:ring-white/10">
+        <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 dark:bg-neutral-900">
           <div class="sm:flex sm:items-start">
             <div class="mt-3 text-center sm:mt-0 sm:text-left">
-              <h3 class="text-base font-semibold text-gray-900" id="modal-title">Generating Certificate</h3>
+              <h3 class="text-base font-semibold text-gray-900 dark:text-neutral-200" id="modal-title">Generating Certificate</h3>
               <div class="mt-2">
-                <p class="text-sm text-gray-500" x-text="certificateMessage"></p>
+                <p class="text-sm text-gray-500 dark:text-neutral-400" x-text="certificateMessage"></p>
               </div>
             </div>
           </div>
         </div>
-        <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
-          <button type="button" @click="showGeneratingCertificateModal=false" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 sm:ml-3 sm:w-auto">Close</button>
+        <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 dark:bg-neutral-900">
+          <button type="button" @click="showGeneratingCertificateModal=false" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 sm:ml-3 sm:w-auto dark:bg-emerald-500 dark:hover:bg-emerald-400">Close</button>
         </div>
       </div>
     </div>

--- a/src/content_detail_page/includes/certificate_generating_modal.html
+++ b/src/content_detail_page/includes/certificate_generating_modal.html
@@ -7,7 +7,7 @@
   x-transition:leave-start="opacity-100"
   x-transition:leave-end="opacity-0"
   x-show="showGeneratingCertificateModal"
-  class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-800 dark:bg-opacity-80" aria-hidden="true"></div>
+  class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-900 dark:bg-opacity-80" aria-hidden="true"></div>
 
   <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">

--- a/src/content_detail_page/includes/certificate_generating_modal.html
+++ b/src/content_detail_page/includes/certificate_generating_modal.html
@@ -30,7 +30,7 @@
           </div>
         </div>
         <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 dark:bg-neutral-800">
-          <button type="button" @click="showGeneratingCertificateModal=false" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 sm:ml-3 sm:w-auto dark:bg-emerald-500 dark:hover:bg-emerald-400">Close</button>
+          <button type="button" @click="showGeneratingCertificateModal=false" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 sm:ml-3 sm:w-auto dark:bg-emerald-600 dark:hover:bg-emerald-500">Close</button>
         </div>
       </div>
     </div>

--- a/src/content_detail_page/includes/comment_section.html
+++ b/src/content_detail_page/includes/comment_section.html
@@ -1,11 +1,11 @@
 <!-- Comments-->
 <section aria-labelledby="notes-title" class="mt-6">
-  <div class="bg-white sm:overflow-hidden sm:rounded-lg">
+  <div class="bg-white sm:overflow-hidden sm:rounded-lg dark:bg-neutral-800">
     <div class="">
       <div class="px-4 sm:px-6 lg:px-8">
-        <h2 id="notes-title" class="text-base lg:text-lg font-medium text-gray-900">Comments</h2>
+        <h2 id="notes-title" class="text-base lg:text-lg font-medium text-gray-900 dark:text-neutral-200">Comments</h2>
       </div>
-      <div class="px-4 py-6 sm:px-6 lg:px-8 border-t border-gray-200 mt-4">
+      <div class="px-4 py-6 sm:px-6 lg:px-8 border-t border-gray-200 mt-4 dark:border-neutral-700">
         <ul role="list" class="space-y-8">
           {% for comment in comments %}
             <li>
@@ -15,29 +15,29 @@
                 </div>
                 <div>
                   <div class="text-sm flex space-x-2 items-center">
-                    <a href="#" class="font-medium text-gray-900">{{ comment.author }}</a>
-                    <span class="font-medium text-gray-500">4d ago</span>
+                    <a href="#" class="font-medium text-gray-900 dark:text-neutral-200">{{ comment.author }}</a>
+                    <span class="font-medium text-gray-500 dark:text-neutral-400">4d ago</span>
                     {% if comment.warning %}
-                      <span class="inline-flex items-center rounded-md bg-yellow-50 px-1.5 py-0.5 text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-600/20">Pending Moderation</span>
+                      <span class="inline-flex items-center rounded-md bg-yellow-50 px-1.5 py-0.5 text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-600/20 dark:bg-yellow-500/10 dark:text-yellow-500">Pending Moderation</span>
                     {% endif %}
                   </div>
-                  <div class="mt-1 text-sm text-gray-700">
+                  <div class="mt-1 text-sm text-gray-700 dark:text-neutral-300">
                     <p>{{ comment.text }}</p>
                   </div>
                   <div class="flex mt-2 truncate text-sm">
-                    <span class="flex items-center hover:cursor-pointer" :class="{ 'text-emerald-600':'{{comment.upvoted}}', 'text-gray-600': !'{{comment.downvoted}}'}">
+                    <span class="flex items-center hover:cursor-pointer" :class="{ 'text-emerald-600 dark:text-emerald-400':'{{comment.upvoted}}', 'text-gray-600 dark:text-neutral-200': !'{{comment.downvoted}}'}">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-1"><path stroke-linecap="round" stroke-linejoin="round" d="M6.633 10.5c.806 0 1.533-.446 2.031-1.08a9.041 9.041 0 0 1 2.861-2.4c.723-.384 1.35-.956 1.653-1.715a4.498 4.498 0 0 0 .322-1.672V3a.75.75 0 0 1 .75-.75A2.25 2.25 0 0 1 16.5 4.5c0 1.152-.26 2.243-.723 3.218-.266.558.107 1.282.725 1.282h3.126c1.026 0 1.945.694 2.054 1.715.045.422.068.85.068 1.285a11.95 11.95 0 0 1-2.649 7.521c-.388.482-.987.729-1.605.729H13.48a4.53 4.53 0 0 1-1.423-.23l-3.114-1.04a4.501 4.501 0 0 0-1.423-.23H5.904M14.25 9h2.25M5.904 18.75c.083.205.173.405.27.602.197.4-.078.898-.523.898h-.908c-.889 0-1.713-.518-1.972-1.368a12 12 0 0 1-.521-3.507c0-1.553.295-3.036.831-4.398C3.387 10.203 4.167 9.75 5 9.75h1.053c.472 0 .745.556.5.96a8.958 8.958 0 0 0-1.302 4.665 8.97 8.97 0 0 0 .654 3.375z"/></svg>
                       <span>{{ comment.upvotes }}</span>
                     </span>
-                    <span class="mx-2 text-gray-400" aria-hidden="true">·</span>
-                    <span class="flex items-center hover:cursor-pointer" :class="{ 'text-red-600':!'{{comment.downvoted}}', 'text-gray-600': '{{comment.upvoted}}'}">
+                    <span class="mx-2 text-gray-400 dark:text-neutral-500" aria-hidden="true">·</span>
+                    <span class="flex items-center hover:cursor-pointer" :class="{ 'text-red-600 dark:text-red-400':!'{{comment.downvoted}}', 'text-gray-600 dark:text-neutral-200': '{{comment.upvoted}}'}">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-1"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 15h2.25m8.024-9.75c.011.05.028.1.052.148.591 1.2.924 2.55.924 3.977a8.96 8.96 0 0 1-.999 4.125m.023-8.25c-.076-.365.183-.75.575-.75h.908c.889 0 1.713.518 1.972 1.368.339 1.11.521 2.287.521 3.507 0 1.553-.295 3.036-.831 4.398C20.613 14.547 19.833 15 19 15h-1.053c-.472 0-.745-.556-.5-.96a8.95 8.95 0 0 0 .303-.54m.023-8.25H16.48a4.5 4.5 0 0 1-1.423-.23l-3.114-1.04a4.5 4.5 0 0 0-1.423-.23H6.504c-.618 0-1.217.247-1.605.729A11.95 11.95 0 0 0 2.25 12c0 .434.023.863.068 1.285C2.427 14.306 3.346 15 4.372 15h3.126c.618 0 .991.724.725 1.282A7.471 7.471 0 0 0 7.5 19.5a2.25 2.25 0 0 0 2.25 2.25.75.75 0 0 0 .75-.75v-.633c0-.573.11-1.14.322-1.672.304-.76.93-1.33 1.653-1.715a9.04 9.04 0 0 0 2.86-2.4c.498-.634 1.226-1.08 2.032-1.08h.384"/></svg>
                       <span>{{ comment.downvotes }}</span>
                     </span>
                   </div>
                   {% if comment.replies %}
                     <div class="mt-4 text-sm" x-data="{ showReply: false }">
-                      <span class="flex items-center space-x-2 font-medium text-emerald-700 hover:cursor-pointer" @click="showReply = !showReply">
+                      <span class="flex items-center space-x-2 font-medium text-emerald-700 hover:cursor-pointer dark:text-emerald-400" @click="showReply = !showReply">
                         <svg class="w-3 h-3 mr-1 transition-transform duration-300 transform" fill="currentColor" stroke-width="1.5" stroke="currentColor" viewBox="0 0 24 24"
                             :class="{ '-rotate-90': !showReply, 'rotate-0': showReply }">
                             <path d="M11.178 19.569a.998.998 0 0 0 1.644 0l9-13A.999.999 0 0 0 21 5H3a1.002 1.002 0 0 0-.822 1.569l9 13z"/>
@@ -54,19 +54,19 @@
                               </div>
                               <div>
                                 <div class="text-sm flex space-x-2 items-center">
-                                  <a href="#" class="font-medium text-gray-900">{{ reply.author }}</a>
-                                  <span class="font-medium text-gray-500">4d ago</span>
+                                  <a href="#" class="font-medium text-gray-900 dark:text-neutral-200">{{ reply.author }}</a>
+                                  <span class="font-medium text-gray-500 dark:text-neutral-400">4d ago</span>
                                 </div>
-                                <div class="mt-1 text-sm text-gray-700">
+                                <div class="mt-1 text-sm text-gray-700 dark:text-neutral-300">
                                   <p>{{ reply.text }}</p>
                                 </div>
                                 <div class="flex mt-2 truncate text-sm">
-                                  <span class="flex text-gray-600 items-center hover:cursor-pointer">
+                                  <span class="flex text-gray-600 items-center hover:cursor-pointer dark:text-neutral-400">
                                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-1"><path stroke-linecap="round" stroke-linejoin="round" d="M6.633 10.5c.806 0 1.533-.446 2.031-1.08a9.041 9.041 0 0 1 2.861-2.4c.723-.384 1.35-.956 1.653-1.715a4.498 4.498 0 0 0 .322-1.672V3a.75.75 0 0 1 .75-.75A2.25 2.25 0 0 1 16.5 4.5c0 1.152-.26 2.243-.723 3.218-.266.558.107 1.282.725 1.282h3.126c1.026 0 1.945.694 2.054 1.715.045.422.068.85.068 1.285a11.95 11.95 0 0 1-2.649 7.521c-.388.482-.987.729-1.605.729H13.48a4.53 4.53 0 0 1-1.423-.23l-3.114-1.04a4.501 4.501 0 0 0-1.423-.23H5.904M14.25 9h2.25M5.904 18.75c.083.205.173.405.27.602.197.4-.078.898-.523.898h-.908c-.889 0-1.713-.518-1.972-1.368a12 12 0 0 1-.521-3.507c0-1.553.295-3.036.831-4.398C3.387 10.203 4.167 9.75 5 9.75h1.053c.472 0 .745.556.5.96a8.958 8.958 0 0 0-1.302 4.665 8.97 8.97 0 0 0 .654 3.375z"/></svg>
                                     <span>{{ reply.upvotes }}</span>
                                   </span>
-                                  <span class="mx-2 text-gray-400" aria-hidden="true">·</span>
-                                  <span class="flex text-gray-600 items-center hover:cursor-pointer">
+                                  <span class="mx-2 text-gray-400 dark:text-neutral-500" aria-hidden="true">·</span>
+                                  <span class="flex text-gray-600 items-center hover:cursor-pointer dark:text-neutral-400">
                                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-1"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 15h2.25m8.024-9.75c.011.05.028.1.052.148.591 1.2.924 2.55.924 3.977a8.96 8.96 0 0 1-.999 4.125m.023-8.25c-.076-.365.183-.75.575-.75h.908c.889 0 1.713.518 1.972 1.368.339 1.11.521 2.287.521 3.507 0 1.553-.295 3.036-.831 4.398C20.613 14.547 19.833 15 19 15h-1.053c-.472 0-.745-.556-.5-.96a8.95 8.95 0 0 0 .303-.54m.023-8.25H16.48a4.5 4.5 0 0 1-1.423-.23l-3.114-1.04a4.5 4.5 0 0 0-1.423-.23H6.504c-.618 0-1.217.247-1.605.729A11.95 11.95 0 0 0 2.25 12c0 .434.023.863.068 1.285C2.427 14.306 3.346 15 4.372 15h3.126c.618 0 .991.724.725 1.282A7.471 7.471 0 0 0 7.5 19.5a2.25 2.25 0 0 0 2.25 2.25.75.75 0 0 0 .75-.75v-.633c0-.573.11-1.14.322-1.672.304-.76.93-1.33 1.653-1.715a9.04 9.04 0 0 0 2.86-2.4c.498-.634 1.226-1.08 2.032-1.08h.384"/></svg>
                                     <span>{{ reply.downvotes }}</span>
                                   </span>
@@ -85,7 +85,7 @@
         </ul>
       </div>
     </div>
-    <div class="bg-gray-50 px-4 py-6 sm:px-6 lg:px-8">
+    <div class="bg-gray-50 px-4 py-6 sm:px-6 lg:px-8 dark:bg-neutral-800">
       <div class="flex space-x-3">
         <div class="flex-shrink-0">
           <img class="h-10 w-10 rounded-full" src="https://images.unsplash.com/photo-1517365830460-955ce3ccd263?ixlib=rb-=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=8&w=256&h=256&q=80" alt="">
@@ -94,10 +94,10 @@
           <form action="#">
             <div>
               <label for="comment" class="sr-only">About</label>
-              <textarea id="comment" name="comment" rows="3" class="block w-full rounded-md border-0 py-1.5 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6" placeholder="Add a note"></textarea>
+              <textarea id="comment" name="comment" rows="3" class="block w-full rounded-md border-0 py-1.5 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-800 dark:ring-neutral-600 dark:placeholder:text-neutral-400 dark:text-neutral-200" placeholder="Add a note"></textarea>
             </div>
             <div class="mt-3 flex items-center justify-end">           
-              <button type="submit" class="inline-flex items-center justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600">Comment</button>
+              <button type="submit" class="inline-flex items-center justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 dark:bg-emerald-600 dark:hover:bg-emerald-500">Comment</button>
             </div>
           </form>
         </div>

--- a/src/content_detail_page/includes/confirm_file_submittion_modal.html
+++ b/src/content_detail_page/includes/confirm_file_submittion_modal.html
@@ -1,12 +1,12 @@
 <div id="confirm-file-submittion" class="hs-overlay hidden size-full fixed top-0 start-0 z-[80] overflow-x-hidden overflow-y-auto [--close-when-click-inside:true] pointer-events-none" role="dialog" tabindex="-1" aria-labelledby="confirm-file-submittion-label">
   <div class="hs-overlay-open:mt-7 hs-overlay-open:opacity-100 hs-overlay-open:duration-500 mt-0 opacity-0 ease-out transition-all sm:max-w-lg sm:w-full m-3 sm:mx-auto h-[calc(100%-3.5rem)] min-h-[calc(100%-3.5rem)] flex items-center">
-    <div class="relative w-full max-h-full overflow-hidden flex flex-col bg-white rounded-xl pointer-events-auto shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)]">
-      <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 w-full">
+    <div class="relative w-full max-h-full overflow-hidden flex flex-col bg-white rounded-xl pointer-events-auto shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:bg-neutral-900 dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)]">
+      <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 w-full dark:bg-neutral-900">
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
-            <h3 class="text-base font-semibold text-gray-900" id="modal-title">Confirm Submission</h3>
+            <h3 class="text-base font-semibold text-gray-900 dark:text-neutral-100" id="modal-title">Confirm Submission</h3>
             <div class="mt-2">
-              <p class="text-sm text-gray-500">You are about to submit the following files for <span class="font-medium text-gray-800">Assignment 1</span>. Once submitted, you may not be able to make changes.</p>
+              <p class="text-sm text-gray-500 dark:text-neutral-400">You are about to submit the following files for <span class="font-medium text-gray-800 dark:text-neutral-200">Assignment 1</span>. Once submitted, you may not be able to make changes.</p>
             </div>
             <div class="mt-4">
               <h3 class="text-sm font-medium text-gray-800 dark:text-neutral-200">
@@ -15,24 +15,24 @@
 
               <div class="mt-3 ps-1 space-y-1 cursor-default">
                 <div class="flex items-center gap-x-3">
-                  <svg class="shrink-0 size-4 text-gray-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                  <svg class="shrink-0 size-4 text-gray-500 dark:text-neutral-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"></path>
                     <path d="M14 2v4a2 2 0 0 0 2 2h4"></path>
                   </svg>
                   <div class="grow">
-                    <span class="text-sm text-gray-500">
+                    <span class="text-sm text-gray-500 dark:text-neutral-400">
                       essay_on_climate_change.pdf
                     </span>
                   </div>
                 </div>
   
                 <div class="flex items-center gap-x-3">
-                  <svg class="shrink-0 size-4 text-gray-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                  <svg class="shrink-0 size-4 text-gray-500 dark:text-neutral-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"></path>
                     <path d="M14 2v4a2 2 0 0 0 2 2h4"></path>
                   </svg>
                   <div class="grow">
-                    <span class="text-sm text-gray-500">
+                    <span class="text-sm text-gray-500 dark:text-neutral-400">
                       essay_on_climate_change_part_2.pdf
                     </span>
                   </div>
@@ -42,9 +42,9 @@
           </div>
         </div>
       </div>
-      <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
-        <button type="button" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 sm:ml-3 sm:w-auto">Submit</button>
-        <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto" data-hs-overlay="#confirm-file-submittion">Cancel</button>
+      <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 dark:bg-neutral-800">
+        <button type="button" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 sm:ml-3 sm:w-auto dark:bg-emerald-600 dark:hover:bg-emerald-500 transition-colors">Submit</button>
+        <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-600" data-hs-overlay="#confirm-file-submittion">Cancel</button>
       </div>
     </div>
   </div>

--- a/src/content_detail_page/includes/confirm_online_text_submittion_modal.html
+++ b/src/content_detail_page/includes/confirm_online_text_submittion_modal.html
@@ -1,19 +1,19 @@
 <div id="confirm-online-text-submittion" class="hs-overlay hidden size-full fixed top-0 start-0 z-[80] overflow-x-hidden overflow-y-auto [--close-when-click-inside:true] pointer-events-none" role="dialog" tabindex="-1" aria-labelledby="confirm-online-text-submittion-label">
   <div class="hs-overlay-open:mt-7 hs-overlay-open:opacity-100 hs-overlay-open:duration-500 mt-0 opacity-0 ease-out transition-all sm:max-w-lg sm:w-full m-3 sm:mx-auto h-[calc(100%-3.5rem)] min-h-[calc(100%-3.5rem)] flex items-center">
-    <div class="relative w-full max-h-full overflow-hidden flex flex-col bg-white rounded-xl pointer-events-auto shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)]">
-      <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 w-full">
+    <div class="relative w-full max-h-full overflow-hidden flex flex-col bg-white rounded-xl pointer-events-auto shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:bg-neutral-900 dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)]">
+      <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 w-full dark:bg-neutral-900">
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
-            <h3 class="text-base font-semibold text-gray-900" id="modal-title">Confirm Submission</h3>
+            <h3 class="text-base font-semibold text-gray-900 dark:text-neutral-100" id="modal-title">Confirm Submission</h3>
             <div class="mt-2">
-              <p class="text-sm text-gray-500">You are about to submit your **typed response** for <span class="font-medium text-gray-800">"Assignment 1"</span>. Once submitted, you may not be able to make changes.</p>
+              <p class="text-sm text-gray-500 dark:text-neutral-400">You are about to submit your **typed response** for <span class="font-medium text-gray-800 dark:text-neutral-200">"Assignment 1"</span>. Once submitted, you may not be able to make changes.</p>
             </div>
           </div>
         </div>
       </div>
-      <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
-        <button type="button" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 sm:ml-3 sm:w-auto">Submit</button>
-        <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto" data-hs-overlay="#confirm-online-text-submittion">Cancel</button>
+      <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 dark:bg-neutral-800/50">
+        <button type="button" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 sm:ml-3 sm:w-auto dark:bg-emerald-500 dark:hover:bg-emerald-400 transition-colors duration-200">Submit</button>
+        <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-600" data-hs-overlay="#confirm-online-text-submittion">Cancel</button>
       </div>
     </div>
   </div>

--- a/src/content_detail_page/includes/content_heading.html
+++ b/src/content_detail_page/includes/content_heading.html
@@ -1,18 +1,18 @@
-<div x-data="{ is_completed: false}" class="flex flex-wrap gap-4 items-center justify-between pt-4 px-4 lg:px-6">
-  <h1 class="text-lg lg:text-2xl font-bold text-gray-900">What is Markup language?</h1>
+<div x-data="{ is_completed: false}" class="flex flex-wrap gap-4 items-center justify-between pt-4 px-4 lg:px-6 dark:bg-neutral-800">
+  <h1 class="text-lg lg:text-2xl font-bold text-gray-900 dark:text-neutral-200">What is Markup language?</h1>
   <div class="flex items-center space-x-2">
     <a class="cursor-pointer" title="Download" x-show="is_renderable" x-cloak>
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-6 h-6 text-emerald-600" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="w-6 h-6 text-emerald-600 dark:text-emerald-500" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/>
       </svg>                
     </a>
     <a class="cursor-pointer" x-on:click="toggleSVG = !toggleSVG" title="Bookmark" x-show="!isBookmarked" x-cloak>
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600 dark:text-emerald-500">
         <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
       </svg>  
     </a>
     <a class="cursor-pointer" x-on:click="isBookmarked = false" title="Remove Bookmark" x-show="isBookmarked" x-cloak> 
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600 dark:text-emerald-500">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l1.664 1.664M21 21l-1.5-1.5m-5.485-1.242L12 17.25 4.5 21V8.742m.164-4.078a2.15 2.15 0 011.743-1.342 48.507 48.507 0 0111.186 0c1.1.128 1.907 1.077 1.907 2.185V19.5M4.664 4.664L19.5 19.5" />
       </svg>                
     </a>
@@ -29,13 +29,13 @@
       </svg>
     </button>
     <div class="hidden md:flex space-x-3 ml-4">
-      <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0">
+      <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-600">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
         </svg>
         Previous
       </a>
-      <a href="{{ pagination.nextPageHref|url }}" class="relative ml-3 inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0">
+      <a href="{{ pagination.nextPageHref|url }}" class="relative ml-3 inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-600">
         Next
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
           <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
@@ -59,25 +59,25 @@
 </button>
 <div class="flex justify-end" x-show="!toggleSVG" x-cloak>
   <div class="absolute z-10">
-    <input id="combobox" type="text" class="w-full rounded-md border-0 bg-white py-1.5 pl-3 pr-12 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-emerald-600 text-sm leading-6" role="combobox" aria-controls="options" aria-expanded="false" placeholder="Search folder...">
-    <ul class="mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none text-sm" id="options" role="listbox">
+    <input id="combobox" type="text" class="w-full rounded-md border-0 bg-white py-1.5 pl-3 pr-12 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-emerald-600 text-sm leading-6 dark:bg-neutral-900 dark:text-neutral-200 dark:ring-neutral-700 dark:placeholder:text-neutral-500" role="combobox" aria-controls="options" aria-expanded="false" placeholder="Search folder...">
+    <ul class="mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none text-sm dark:bg-neutral-900 dark:ring-white/10" id="options" role="listbox">
       {% for _ in range(3) %}
-        <li x-on:click="isBookmarked = true; toggleSVG=true" class="relative cursor-pointer select-none py-2 pl-8 pr-4 text-gray-900" id="option-0" role="option" tabindex="-1">
-          <!-- Selected: "font-semibold" -->
+        <li x-on:click="isBookmarked = true; toggleSVG=true" class="relative cursor-pointer select-none py-2 pl-8 pr-4 text-gray-900 dark:text-neutral-200 dark:hover:bg-neutral-700" id="option-0" role="option" tabindex="-1">
+        <!-- Selected: "font-semibold" -->
           <span class="block truncate">Folder</span>
-          <span class="absolute inset-y-0 left-0 flex items-center pl-1.5 text-gray-400">
+          <span class="absolute inset-y-0 left-0 flex items-center pl-1.5 text-gray-400 dark:text-neutral-500">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
             </svg>          
           </span>
         </li>
       {% endfor %}   
-      <div class="flex items-center space-x-2 border-t py-3 mr-2">
+      <div class="flex items-center space-x-2 border-t py-3 mr-2 dark:border-neutral-700">
         <label for="folder" class="sr-only">Create Folder</label>
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-400">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-400 dark:text-neutral-500">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 10.5v6m3-3H9m4.06-7.19l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
         </svg>          
-        <input name="folder" id="folder" class="block w-full rounded-md border-0 py-1 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 text-sm leading-6" placeholder="Add Folder">
+        <input name="folder" id="folder" class="block w-full rounded-md border-0 py-1 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 text-sm leading-6 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-700 dark:placeholder:text-neutral-500" placeholder="Add Folder">
       </div>  
     </ul>
   </div>

--- a/src/content_detail_page/includes/discussion.html
+++ b/src/content_detail_page/includes/discussion.html
@@ -1,12 +1,12 @@
 <div>
   <div class="px-4 sm:px-6 lg:px-8 mt-1">
     <div class="pt-3 flex items-center gap-x-3">
-      <p class="text-lg lg:text-2xl font-semibold leading-6 text-gray-900">
+      <p class="text-lg lg:text-2xl font-semibold leading-6 text-gray-900 dark:text-neutral-200">
         Microbiology
       </p>
-      <p class="rounded-md whitespace-nowrap mt-0.5 px-1.5 py-0.5 text-xs font-medium ring-1 ring-inset text-emerald-700 bg-emerald-50 ring-emerald-600/20">UPSC Updates</p>
+      <p class="rounded-md whitespace-nowrap mt-0.5 px-1.5 py-0.5 text-xs font-medium ring-1 ring-inset text-emerald-700 bg-emerald-50 ring-emerald-600/20 dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-emerald-500/20">UPSC Updates</p>
     </div>
-    <div class="flex items-center gap-x-2 text-xs leading-5 text-gray-500">
+    <div class="flex items-center gap-x-2 text-xs leading-5 text-gray-500 dark:text-neutral-500">
       <p class="whitespace-nowrap"><time datetime="2023-03-17T00:00Z">4d ago</time></p>
       <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current">
         <circle cx="1" cy="1" r="1"></circle>
@@ -17,7 +17,7 @@
   <div class="px-4 sm:px-6 lg:px-8">
     <dl class="grid grid-cols-1 sm:grid-cols-2">
       <div class="px-4 py-4 sm:col-span-2 sm:px-0">
-        <dd class="mt-1 text-sm leading-6 text-gray-700 sm:mt-2">Exploring the Dynamics of Political Science. Navigate through the complexities of governance, international relations, and policy-making as we delve into the heart of political science. From the structures of power to the study of ideologies, embark on a journey that unravels the intricacies of shaping societies and global affairs.</dd>
+        <dd class="mt-1 text-sm leading-6 text-gray-700 sm:mt-2 dark:text-neutral-400">Exploring the Dynamics of Political Science. Navigate through the complexities of governance, international relations, and policy-making as we delve into the heart of political science. From the structures of power to the study of ideologies, embark on a journey that unravels the intricacies of shaping societies and global affairs.</dd>
       </div>
     </dl>
   </div>

--- a/src/content_detail_page/includes/discussion_form.html
+++ b/src/content_detail_page/includes/discussion_form.html
@@ -1,27 +1,27 @@
-<div class="mx-auto max-w-2xl">
-  <div class="flex items-center justify-between py-4 mx-4 my-2 space-x-2 border-b border-gray-200">
-    <h3 class="text-2xl font-bold text-gray-900">Create Discussion</h3>
+<div class="mx-auto max-w-2xl dark:bg-neutral-800">
+  <div class="flex items-center justify-between py-4 mx-4 my-2 space-x-2 border-b border-gray-200 dark:border-neutral-700">
+    <h3 class="text-2xl font-bold text-gray-900 dark:text-neutral-200">Create Discussion</h3>
   </div>
   <form>
     <div class="space-y-12">
-      <div class="border-b border-gray-900/10 pb-8">
+      <div class="border-b border-gray-900/10 dark:border-neutral-800 pb-8">
         <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
           <div class="col-span-full px-4">
-            <label for="title" class="block text-sm font-medium leading-6 text-gray-900">Title</label>
+            <label for="title" class="block text-sm font-medium leading-6 text-gray-900 dark:text-neutral-200">Title</label>
             <div class="mt-2">
-              <input type="text" name="title" id="title" autocomplete="title" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+              <input type="text" name="title" id="title" autocomplete="title" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-900 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500">
             </div>
           </div>
           <div class="col-span-full px-4">
-            <label for="description" class="block text-sm font-medium leading-6 text-gray-900">Add a Description</label>
+            <label for="description" class="block text-sm font-medium leading-6 text-gray-900 dark:text-neutral-200">Add a Description</label>
             <div class="mt-2">
-              <textarea id="description" name="description" rows="3" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6"></textarea>
+              <textarea id="description" name="description" rows="3" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-900 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500"></textarea>
             </div>
           </div>
           <div class="sm:col-span-3  px-4">
-            <label for="category" class="block text-sm font-medium leading-6 text-gray-900">Category</label>
+            <label for="category" class="block text-sm font-medium leading-6 text-gray-900 dark:text-neutral-200">Category</label>
             <div class="mt-2">
-              <select id="category" name="category" autocomplete="category-name" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:max-w-xs sm:text-sm sm:leading-6">
+              <select id="category" name="category" autocomplete="category-name" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:max-w-xs sm:text-sm sm:leading-6 dark:bg-neutral-900 dark:ring-neutral-700 dark:text-neutral-200 dark:focus:ring-emerald-500">
                 <option>UPSC</option>
                 <option>KPSC Updates</option>
                 <option>TNPSC</option>
@@ -32,8 +32,8 @@
       </div>
     </div>
     <div class="mt-6 px-4 flex items-center justify-end gap-x-6">
-      <button type="button" class="text-sm font-semibold leading-6 text-gray-900">Cancel</button>
-      <button type="submit" class="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600">Submit</button>
+      <button type="button" class="text-sm font-semibold leading-6 text-gray-900 dark:text-neutral-400 dark:hover:text-neutral-200">Cancel</button>
+      <button type="submit" class="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 dark:bg-emerald-500 dark:hover:bg-emerald-400 transition-colors">Submit</button>
     </div>
   </form>
 </div>

--- a/src/content_detail_page/includes/discussion_form.html
+++ b/src/content_detail_page/includes/discussion_form.html
@@ -1,4 +1,4 @@
-<div class="mx-auto max-w-2xl dark:bg-neutral-900/80 dark:rounded-md mt-4">
+<div class="mx-auto max-w-2xl dark:bg-neutral-800 mt-4">
   <div class="flex items-center justify-between py-4 mx-4 my-2 space-x-2 border-b border-gray-200 dark:border-neutral-700">
     <h3 class="text-2xl font-bold text-gray-900 dark:text-neutral-200">Create Discussion</h3>
   </div>
@@ -9,19 +9,19 @@
           <div class="col-span-full px-4">
             <label for="title" class="block text-sm font-medium leading-6 text-gray-900 dark:text-neutral-200">Title</label>
             <div class="mt-2">
-              <input type="text" name="title" id="title" autocomplete="title" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-900/80 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500">
+              <input type="text" name="title" id="title" autocomplete="title" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-800 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500">
             </div>
           </div>
           <div class="col-span-full px-4">
             <label for="description" class="block text-sm font-medium leading-6 text-gray-900 dark:text-neutral-200">Add a Description</label>
             <div class="mt-2">
-              <textarea id="description" name="description" rows="3" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-900/80 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500"></textarea>
+              <textarea id="description" name="description" rows="3" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-800 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500"></textarea>
             </div>
           </div>
           <div class="sm:col-span-3  px-4">
             <label for="category" class="block text-sm font-medium leading-6 text-gray-900 dark:text-neutral-200">Category</label>
             <div class="mt-2">
-              <select id="category" name="category" autocomplete="category-name" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:max-w-xs sm:text-sm sm:leading-6 dark:bg-neutral-900 dark:ring-neutral-700 dark:text-neutral-200 dark:focus:ring-emerald-500">
+              <select id="category" name="category" autocomplete="category-name" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:max-w-xs sm:text-sm sm:leading-6 dark:bg-neutral-800 dark:ring-neutral-700 dark:text-neutral-200 dark:focus:ring-emerald-500">
                 <option>UPSC</option>
                 <option>KPSC Updates</option>
                 <option>TNPSC</option>

--- a/src/content_detail_page/includes/discussion_form.html
+++ b/src/content_detail_page/includes/discussion_form.html
@@ -1,4 +1,4 @@
-<div class="mx-auto max-w-2xl dark:bg-neutral-800">
+<div class="mx-auto max-w-2xl dark:bg-neutral-900/80 dark:rounded-md mt-4">
   <div class="flex items-center justify-between py-4 mx-4 my-2 space-x-2 border-b border-gray-200 dark:border-neutral-700">
     <h3 class="text-2xl font-bold text-gray-900 dark:text-neutral-200">Create Discussion</h3>
   </div>
@@ -9,13 +9,13 @@
           <div class="col-span-full px-4">
             <label for="title" class="block text-sm font-medium leading-6 text-gray-900 dark:text-neutral-200">Title</label>
             <div class="mt-2">
-              <input type="text" name="title" id="title" autocomplete="title" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-900 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500">
+              <input type="text" name="title" id="title" autocomplete="title" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-900/80 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500">
             </div>
           </div>
           <div class="col-span-full px-4">
             <label for="description" class="block text-sm font-medium leading-6 text-gray-900 dark:text-neutral-200">Add a Description</label>
             <div class="mt-2">
-              <textarea id="description" name="description" rows="3" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-900 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500"></textarea>
+              <textarea id="description" name="description" rows="3" class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-900/80 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500"></textarea>
             </div>
           </div>
           <div class="sm:col-span-3  px-4">
@@ -31,9 +31,9 @@
         </div>
       </div>
     </div>
-    <div class="mt-6 px-4 flex items-center justify-end gap-x-6">
-      <button type="button" class="text-sm font-semibold leading-6 text-gray-900 dark:text-neutral-400 dark:hover:text-neutral-200">Cancel</button>
-      <button type="submit" class="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 dark:bg-emerald-500 dark:hover:bg-emerald-400 transition-colors">Submit</button>
+    <div class="mt-6 px-4 flex items-center justify-end gap-x-6 pb-2">
+      <button type="button" class="text-sm mb-2 font-semibold leading-6 text-gray-900 dark:text-neutral-400 dark:hover:text-neutral-200">Cancel</button>
+      <button type="submit" class="rounded-md mb-2 bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 dark:bg-emerald-500 dark:hover:bg-emerald-400 transition-colors">Submit</button>
     </div>
   </form>
 </div>

--- a/src/content_detail_page/includes/doubt_button.html
+++ b/src/content_detail_page/includes/doubt_button.html
@@ -1,5 +1,5 @@
 <div class="mt-6 flex justify-end ">
-    <a href="#" class="flex gap-2 text-emerald-700 text-bold text-sm cursor-pointer font-medium hover:underline">
+    <a href="#" class="flex gap-2 text-emerald-700 text-bold text-sm cursor-pointer font-medium hover:underline dark:text-emerald-500">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" width="15" height="15" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"></path>
         </svg>

--- a/src/content_detail_page/includes/doubt_button.html
+++ b/src/content_detail_page/includes/doubt_button.html
@@ -1,5 +1,5 @@
 <div class="mt-6 flex justify-end ">
-    <a href="#" class="flex gap-2 text-emerald-700 text-bold text-sm cursor-pointer font-medium hover:underline dark:text-emerald-500">
+    <a href="#" class="flex gap-2 text-emerald-700 text-bold text-sm cursor-pointer font-medium hover:underline dark:text-emerald-400">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" width="15" height="15" stroke-width="1.5" stroke="currentColor" class="size-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"></path>
         </svg>

--- a/src/content_detail_page/includes/exam_details.html
+++ b/src/content_detail_page/includes/exam_details.html
@@ -110,7 +110,7 @@
   </section>
   <div class="hidden sm:flex justify-center mt-6">
     <button type="button" x-on:click="showExamModeModal=true"
-      class="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 dark:bg-emerald-500 dark:hover:bg-emerald-400">
+      class="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 dark:bg-emerald-600 dark:hover:bg-emerald-500">
       Start Exam
     </button>
   </div>

--- a/src/content_detail_page/includes/exam_details.html
+++ b/src/content_detail_page/includes/exam_details.html
@@ -1,9 +1,9 @@
 <div class="px-6 lg:px-0">
-  <section class="p-0 xl:pl-10 xl:py-2 2xl:px-8 mx-auto xl:max-w-4xl xl:border rounded-md">
+  <section class="p-0 xl:pl-10 xl:py-2 2xl:px-8 mx-auto xl:max-w-4xl xl:border rounded-md dark:border-neutral-800">
     <dl class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3">
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-indigo-50 text-indigo-700 ring-4 ring-white">
+          <span class="inline-flex rounded-lg p-3 bg-indigo-50 text-indigo-700 ring-4 ring-white dark:bg-indigo-500/10 dark:text-indigo-400 dark:ring-neutral-900">
             <svg class="w-5 h-5 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
               aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z">
@@ -12,13 +12,13 @@
           </span>
         </div>
         <div class="flex-auto pl-3 sm:pl-6">
-          <dt class="text-sm font-semibold leading-6 text-gray-600">Duration</dt>
-          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">40 minutes</dd>
+          <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Duration</dt>
+          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">40 minutes</dd>
         </div>
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white">
+          <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white dark:bg-amber-500/10 dark:text-amber-400 dark:ring-neutral-900">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -27,13 +27,13 @@
           </span>
         </div>
         <div class="flex-auto pl-3 sm:pl-6">
-          <dt class="text-sm font-semibold leading-6 text-gray-600">Questions</dt>
-          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">20</dd>
+          <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Questions</dt>
+          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">20</dd>
         </div>
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white">
+          <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-900">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -42,13 +42,13 @@
           </span>
         </div>
         <div class="flex-auto pl-3 sm:pl-6">
-          <dt class="text-sm font-semibold leading-6 text-gray-600">Correct Answer</dt>
-          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">+4 marks</dd>
+          <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Correct Answer</dt>
+          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">+4 marks</dd>
         </div>
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white">
+          <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white dark:bg-rose-500/10 dark:text-rose-400 dark:ring-neutral-900">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -57,13 +57,13 @@
           </span>
         </div>
         <div class="flex-auto pl-3 sm:pl-6">
-          <dt class="text-sm font-semibold leading-6 text-gray-600">Incorrect Answer</dt>
-          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">-2 marks</dd>
+          <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Incorrect Answer</dt>
+          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">-2 marks</dd>
         </div>
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white">
+          <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white dark:bg-cyan-500/10 dark:text-cyan-400 dark:ring-neutral-900">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -72,13 +72,13 @@
           </span>
         </div>
         <div class="flex-auto pl-3 sm:pl-6">
-          <dt class="text-sm font-semibold leading-6 text-gray-600">Trophies</dt>
-          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">55</dd>
+          <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Trophies</dt>
+          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">55</dd>
         </div>
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white">
+          <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-500/10 dark:text-purple-400 dark:ring-neutral-900">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -87,13 +87,13 @@
           </span>
         </div>
         <div class="flex-auto pl-3 sm:pl-6">
-          <dt class="text-sm font-semibold leading-6 text-gray-600">Comments</dt>
-          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">22</dd>
+          <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Comments</dt>
+          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">22</dd>
         </div>
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-blue-50 text-blue-700 ring-4 ring-white">
+          <span class="inline-flex rounded-lg p-3 bg-blue-50 text-blue-700 ring-4 ring-white dark:bg-blue-500/10 dark:text-blue-400 dark:ring-neutral-900">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -102,15 +102,15 @@
           </span>
         </div>
         <div class="flex-auto pl-3 sm:pl-6">
-          <dt class="text-sm font-semibold leading-6 text-gray-600">Participants</dt>
-          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">55</dd>
+          <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Participants</dt>
+          <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">55</dd>
         </div>
       </div>
     </dl>
   </section>
   <div class="hidden sm:flex justify-center mt-6">
     <button type="button" x-on:click="showExamModeModal=true"
-      class="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600">
+      class="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 dark:bg-emerald-500 dark:hover:bg-emerald-400">
       Start Exam
     </button>
   </div>

--- a/src/content_detail_page/includes/exam_details.html
+++ b/src/content_detail_page/includes/exam_details.html
@@ -1,5 +1,5 @@
 <div class="px-6 lg:px-0">
-  <section class="p-0 xl:pl-10 xl:py-2 2xl:px-8 mx-auto xl:max-w-4xl xl:border rounded-md dark:border-neutral-800">
+  <section class="p-0 xl:pl-10 xl:py-2 2xl:px-8 mx-auto xl:max-w-4xl xl:border rounded-md dark:border-neutral-700">
     <dl class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3">
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>

--- a/src/content_detail_page/includes/exam_details.html
+++ b/src/content_detail_page/includes/exam_details.html
@@ -3,7 +3,7 @@
     <dl class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3">
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-indigo-50 text-indigo-700 ring-4 ring-white dark:bg-indigo-500/10 dark:text-indigo-400 dark:ring-neutral-900">
+          <span class="inline-flex rounded-lg p-3 bg-indigo-50 text-indigo-700 ring-4 ring-white dark:bg-indigo-500/10 dark:text-indigo-400 dark:ring-neutral-800">
             <svg class="w-5 h-5 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
               aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z">
@@ -18,7 +18,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white dark:bg-amber-500/10 dark:text-amber-400 dark:ring-neutral-900">
+          <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white dark:bg-amber-500/10 dark:text-amber-400 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -33,7 +33,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-900">
+          <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -48,7 +48,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white dark:bg-rose-500/10 dark:text-rose-400 dark:ring-neutral-900">
+          <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white dark:bg-rose-500/10 dark:text-rose-400 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -63,7 +63,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white dark:bg-cyan-500/10 dark:text-cyan-400 dark:ring-neutral-900">
+          <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white dark:bg-cyan-500/10 dark:text-cyan-400 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -78,7 +78,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-500/10 dark:text-purple-400 dark:ring-neutral-900">
+          <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-500/10 dark:text-purple-400 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -93,7 +93,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-blue-50 text-blue-700 ring-4 ring-white dark:bg-blue-500/10 dark:text-blue-400 dark:ring-neutral-900">
+          <span class="inline-flex rounded-lg p-3 bg-blue-50 text-blue-700 ring-4 ring-white dark:bg-blue-500/10 dark:text-blue-400 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"

--- a/src/content_detail_page/includes/exam_details.html
+++ b/src/content_detail_page/includes/exam_details.html
@@ -3,7 +3,7 @@
     <dl class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3">
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-indigo-50 text-indigo-700 ring-4 ring-white dark:bg-indigo-500/10 dark:text-indigo-400 dark:ring-neutral-800">
+          <span class="inline-flex rounded-lg p-3 bg-indigo-50 text-indigo-700 ring-4 ring-white dark:bg-indigo-800 dark:text-indigo-300 dark:ring-neutral-800">
             <svg class="w-5 h-5 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
               aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z">
@@ -18,7 +18,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white dark:bg-amber-500/10 dark:text-amber-400 dark:ring-neutral-800">
+          <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white dark:bg-amber-800 dark:text-amber-300 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -33,7 +33,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-800">
+          <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-800 dark:text-emerald-300 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -48,7 +48,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white dark:bg-rose-500/10 dark:text-rose-400 dark:ring-neutral-800">
+          <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white dark:bg-rose-800 dark:text-rose-300 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -63,7 +63,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white dark:bg-cyan-500/10 dark:text-cyan-400 dark:ring-neutral-800">
+          <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white dark:bg-cyan-800 dark:text-cyan-300 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -78,7 +78,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-500/10 dark:text-purple-400 dark:ring-neutral-800">
+          <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-800 dark:text-purple-300 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"
@@ -93,7 +93,7 @@
       </div>
       <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
         <div>
-          <span class="inline-flex rounded-lg p-3 bg-blue-50 text-blue-700 ring-4 ring-white dark:bg-blue-500/10 dark:text-blue-400 dark:ring-neutral-800">
+          <span class="inline-flex rounded-lg p-3 bg-blue-50 text-blue-700 ring-4 ring-white dark:bg-blue-800 dark:text-blue-300 dark:ring-neutral-800">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
               stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
               <path stroke-linecap="round" stroke-linejoin="round"

--- a/src/content_detail_page/includes/exam_footer.html
+++ b/src/content_detail_page/includes/exam_footer.html
@@ -1,4 +1,4 @@
-<nav class="sm:hidden bg-gray-50 flex items-center justify-center p-4 lg:px-8 sticky bottom-0" aria-label="Global">
+<nav class="sm:hidden bg-gray-50 flex items-center justify-center p-4 lg:px-8 sticky bottom-0 dark:bg-neutral-800" aria-label="Global">
   <div class="flex flex-col gap-y-4 lg:flex-row lg:flex lg:gap-x-12">
 
     <button type="button"

--- a/src/content_detail_page/includes/exam_mode_modal.html
+++ b/src/content_detail_page/includes/exam_mode_modal.html
@@ -7,7 +7,7 @@
       x-transition:leave-start="opacity-100"
       x-transition:leave-end="opacity-0"
       x-show="showExamModeModal"
-      class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+      class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-950/80"></div>
 
   <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
@@ -18,29 +18,29 @@
           x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
           x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           x-show="showExamModeModal" 
-          class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-md sm:p-6">
+          class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-md sm:p-6 dark:bg-neutral-900 dark:ring-1 dark:ring-white/10">
         <div>
           <div class="text-center">
-            <h3 class="text-base font-semibold leading-6 text-gray-900" id="modal-title">Select Exam Mode</h3>
-            <div class="mt-4 overflow-hidden rounded-md bg-white border border-gray-200">
-              <ul role="list" class="divide-y divide-gray-200">
-                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50" @click="showExamModeModal = false; showPreTestModal = true">
+            <h3 class="text-base font-semibold leading-6 text-gray-900 dark:text-neutral-100" id="modal-title">Select Exam Mode</h3>
+            <div class="mt-4 overflow-hidden rounded-md bg-white border border-gray-200 dark:bg-neutral-900 dark:border-neutral-800">
+              <ul role="list" class="divide-y divide-gray-200 dark:divide-neutral-800">
+                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-800" @click="showExamModeModal = false; showPreTestModal = true">
                   <div class="ml-3 text-sm leading-6 text-left">
-                    <p class="font-medium text-gray-900">Regular Mode</p>
-                    <p class="text-gray-500">Review answers after completing the exam.</p>
+                    <p class="font-medium text-gray-900 dark:text-neutral-200">Regular Mode</p>
+                    <p class="text-gray-500 dark:text-neutral-400">Review answers after completing the exam.</p>
                   </div>
                 </li>
-                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50">
+                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-800">
                   <div class="ml-3 text-sm leading-6 text-left">
-                    <p class="font-medium text-gray-900">Quiz Mode</p>
-                    <p class="text-gray-500">Review answers after solving each question.</p>
+                    <p class="font-medium text-gray-900 dark:text-neutral-200">Quiz Mode</p>
+                    <p class="text-gray-500 dark:text-neutral-400">Review answers after solving each question.</p>
                   </div>
                 </li>
-            
+                
                 <!-- This will not be present at production ... -->
-                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50" x-on:click="showResultModal=true">
+                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-800" x-on:click="showResultModal=true">
                   <div class="ml-3 text-sm leading-6 text-left">
-                    <p class="font-medium text-gray-900">Review Page</p>
+                    <p class="font-medium text-gray-900 dark:text-neutral-200">Review Page</p>
                   </div>
                 </li>
               </ul>

--- a/src/content_detail_page/includes/exam_mode_modal.html
+++ b/src/content_detail_page/includes/exam_mode_modal.html
@@ -7,7 +7,7 @@
       x-transition:leave-start="opacity-100"
       x-transition:leave-end="opacity-0"
       x-show="showExamModeModal"
-      class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-800/80"></div>
+      class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-900 dark:bg-opacity-80"></div>
 
   <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">

--- a/src/content_detail_page/includes/exam_mode_modal.html
+++ b/src/content_detail_page/includes/exam_mode_modal.html
@@ -7,7 +7,7 @@
       x-transition:leave-start="opacity-100"
       x-transition:leave-end="opacity-0"
       x-show="showExamModeModal"
-      class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-950/80"></div>
+      class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-800/80"></div>
 
   <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
@@ -18,19 +18,19 @@
           x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
           x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           x-show="showExamModeModal" 
-          class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-md sm:p-6 dark:bg-neutral-900 dark:ring-1 dark:ring-white/10">
+          class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-md sm:p-6 dark:bg-neutral-800 dark:ring-1 dark:ring-white/10">
         <div>
           <div class="text-center">
             <h3 class="text-base font-semibold leading-6 text-gray-900 dark:text-neutral-200" id="modal-title">Select Exam Mode</h3>
-            <div class="mt-4 overflow-hidden rounded-md bg-white border border-gray-200 dark:bg-neutral-900 dark:border-neutral-800">
-              <ul role="list" class="divide-y divide-gray-200 dark:divide-neutral-800">
-                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-800" @click="showExamModeModal = false; showPreTestModal = true">
+            <div class="mt-4 overflow-hidden rounded-md bg-white border border-gray-200 dark:bg-neutral-800 dark:border-neutral-700">
+              <ul role="list" class="divide-y divide-gray-200 dark:divide-neutral-700">
+                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-700" @click="showExamModeModal = false; showPreTestModal = true">
                   <div class="ml-3 text-sm leading-6 text-left">
                     <p class="font-medium text-gray-900 dark:text-neutral-200">Regular Mode</p>
                     <p class="text-gray-500 dark:text-neutral-400">Review answers after completing the exam.</p>
                   </div>
                 </li>
-                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-800">
+                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-700">
                   <div class="ml-3 text-sm leading-6 text-left">
                     <p class="font-medium text-gray-900 dark:text-neutral-200">Quiz Mode</p>
                     <p class="text-gray-500 dark:text-neutral-400">Review answers after solving each question.</p>
@@ -38,7 +38,7 @@
                 </li>
                 
                 <!-- This will not be present at production ... -->
-                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-800" x-on:click="showResultModal=true">
+                <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-700" x-on:click="showResultModal=true">
                   <div class="ml-3 text-sm leading-6 text-left">
                     <p class="font-medium text-gray-900 dark:text-neutral-200">Review Page</p>
                   </div>

--- a/src/content_detail_page/includes/exam_mode_modal.html
+++ b/src/content_detail_page/includes/exam_mode_modal.html
@@ -21,7 +21,7 @@
           class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-md sm:p-6 dark:bg-neutral-900 dark:ring-1 dark:ring-white/10">
         <div>
           <div class="text-center">
-            <h3 class="text-base font-semibold leading-6 text-gray-900 dark:text-neutral-100" id="modal-title">Select Exam Mode</h3>
+            <h3 class="text-base font-semibold leading-6 text-gray-900 dark:text-neutral-200" id="modal-title">Select Exam Mode</h3>
             <div class="mt-4 overflow-hidden rounded-md bg-white border border-gray-200 dark:bg-neutral-900 dark:border-neutral-800">
               <ul role="list" class="divide-y divide-gray-200 dark:divide-neutral-800">
                 <li class="px-6 py-4 hover:cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-800" @click="showExamModeModal = false; showPreTestModal = true">

--- a/src/content_detail_page/includes/exam_tabs.html
+++ b/src/content_detail_page/includes/exam_tabs.html
@@ -57,8 +57,8 @@
       <div class="mt-4 sm:mt-0">
         <nav class="-mb-px flex space-x-8">
           <!-- Current: "border-emerald-500 text-emerald-600", Default: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700" -->
-          <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" aria-current="page" :class="{ 'border-emerald-500 border-b-2 text-emerald-600 dark:text-emerald-500': activeTab === 'previous', 'text-gray-500 dark:text-neutral-400': activeTab !== 'previous' }" x-on:click="activeTab = 'previous'; section='ATTEMPT';">Previous Attempts</a>
-          <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" :class="{ 'border-emerald-500 border-b-2 text-emerald-600 dark:text-emerald-500': activeTab === 'leaderboard', 'text-gray-500 dark:text-neutral-400':activeTab !== 'leaderboard' }" x-on:click="activeTab = 'leaderboard'; section='LEADERBOARD';">LeaderBoard</a>
+          <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" aria-current="page" :class="{ 'border-emerald-500 border-b-2 text-emerald-600 dark:text-emerald-400': activeTab === 'previous', 'text-gray-500 dark:text-neutral-400': activeTab !== 'previous' }" x-on:click="activeTab = 'previous'; section='ATTEMPT';">Previous Attempts</a>
+          <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" :class="{ 'border-emerald-500 border-b-2 text-emerald-600 dark:text-emerald-400': activeTab === 'leaderboard', 'text-gray-500 dark:text-neutral-400':activeTab !== 'leaderboard' }" x-on:click="activeTab = 'leaderboard'; section='LEADERBOARD';">LeaderBoard</a>
         </nav>
       </div>
     </div>

--- a/src/content_detail_page/includes/exam_tabs.html
+++ b/src/content_detail_page/includes/exam_tabs.html
@@ -57,7 +57,7 @@
       <div class="mt-4 sm:mt-0">
         <nav class="-mb-px flex space-x-8">
           <!-- Current: "border-emerald-500 text-emerald-600", Default: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700" -->
-          <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" aria-current="page" :class="{ 'border-emerald-500 border-b-2 text-emerald-600 dark:text-emerald-500': activeTab === 'previous', 'text-gray-500 dark:text-neutral-500': activeTab !== 'previous' }" x-on:click="activeTab = 'previous'; section='ATTEMPT';">Previous Attempts</a>
+          <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" aria-current="page" :class="{ 'border-emerald-500 border-b-2 text-emerald-600 dark:text-emerald-500': activeTab === 'previous', 'text-gray-500 dark:text-neutral-400': activeTab !== 'previous' }" x-on:click="activeTab = 'previous'; section='ATTEMPT';">Previous Attempts</a>
           <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" :class="{ 'border-emerald-500 border-b-2 text-emerald-600 dark:text-emerald-500': activeTab === 'leaderboard', 'text-gray-500 dark:text-neutral-400':activeTab !== 'leaderboard' }" x-on:click="activeTab = 'leaderboard'; section='LEADERBOARD';">LeaderBoard</a>
         </nav>
       </div>

--- a/src/content_detail_page/includes/exam_tabs.html
+++ b/src/content_detail_page/includes/exam_tabs.html
@@ -50,7 +50,7 @@
     this.showDownloadModal = false;
   }
 }">
-  <div class="px-4 lg:px-0 mt-8 border-b border-gray-200">
+  <div class="px-4 lg:px-0 mt-8 border-b border-gray-200 dark:border-neutral-800">
 <div class="mt-6 mb-6 dark:bg-neutral-800" x-data="{activeTab:'previous'}">
   <div class="px-4 lg:px-0 mt-8 border-b border-gray-200 dark:border-neutral-700">
     <div class="sm:flex sm:items-baseline">

--- a/src/content_detail_page/includes/exam_tabs.html
+++ b/src/content_detail_page/includes/exam_tabs.html
@@ -51,7 +51,7 @@
   }
 }">
   <div class="px-4 lg:px-0 mt-8 border-b border-gray-200">
-<div class="mt-6 mb-6 dark:bg-neutral-900" x-data="{activeTab:'previous'}">
+<div class="mt-6 mb-6 dark:bg-neutral-800" x-data="{activeTab:'previous'}">
   <div class="px-4 lg:px-0 mt-8 border-b border-gray-200 dark:border-neutral-700">
     <div class="sm:flex sm:items-baseline">
       <div class="mt-4 sm:mt-0">

--- a/src/content_detail_page/includes/exam_tabs.html
+++ b/src/content_detail_page/includes/exam_tabs.html
@@ -51,12 +51,14 @@
   }
 }">
   <div class="px-4 lg:px-0 mt-8 border-b border-gray-200">
+<div class="mt-6 mb-6 dark:bg-neutral-900" x-data="{activeTab:'previous'}">
+  <div class="px-4 lg:px-0 mt-8 border-b border-gray-200 dark:border-neutral-700">
     <div class="sm:flex sm:items-baseline">
       <div class="mt-4 sm:mt-0">
         <nav class="-mb-px flex space-x-8">
           <!-- Current: "border-emerald-500 text-emerald-600", Default: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700" -->
-          <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" aria-current="page" :class="{ 'border-emerald-500 border-b-2 text-emerald-600': activeTab === 'previous', 'text-gray-500': activeTab !== 'previous' }" x-on:click="activeTab = 'previous'; section='ATTEMPT';">Previous Attempts</a>
-          <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" :class="{ 'border-emerald-500 border-b-2 text-emerald-600': activeTab === 'leaderboard', 'text-gray-500':activeTab !== 'leaderboard' }" x-on:click="activeTab = 'leaderboard'; section='LEADERBOARD';">LeaderBoard</a>
+          <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" aria-current="page" :class="{ 'border-emerald-500 border-b-2 text-emerald-600 dark:text-emerald-500': activeTab === 'previous', 'text-gray-500 dark:text-neutral-500': activeTab !== 'previous' }" x-on:click="activeTab = 'previous'; section='ATTEMPT';">Previous Attempts</a>
+          <a class="whitespace-nowrap px-1 pb-4 text-sm sm:text-md font-medium hover:cursor-pointer" :class="{ 'border-emerald-500 border-b-2 text-emerald-600 dark:text-emerald-500': activeTab === 'leaderboard', 'text-gray-500 dark:text-neutral-400':activeTab !== 'leaderboard' }" x-on:click="activeTab = 'leaderboard'; section='LEADERBOARD';">LeaderBoard</a>
         </nav>
       </div>
     </div>

--- a/src/content_detail_page/includes/leaderboard.html
+++ b/src/content_detail_page/includes/leaderboard.html
@@ -1,11 +1,11 @@
 <div x-show="activeTab === 'leaderboard'" x-cloak>
   <div class="px-4 lg:px-0">
     <div class="mt-8 flow-root">
-      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8 dark:bg-neutral-900">
+      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8 dark:bg-neutral-800">
         <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
           <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg dark:bg-neutral-800 dark:ring-neutral-700">
             <table class="min-w-full divide-y divide-gray-300 dark:divide-neutral-700">
-              <thead class="bg-gray-50 dark:bg-neutral-800">
+              <thead class="bg-gray-50 dark:bg-neutral-700">
                 <tr>
                   <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 dark:text-neutral-300">Rank</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Student</th>
@@ -15,7 +15,7 @@
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Score</th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-gray-200 bg-white dark:bg-neutral-900 dark:divide-neutral-700">
+              <tbody class="divide-y divide-gray-200 bg-white dark:bg-neutral-800 dark:divide-neutral-700">
                 {% for student in exam_data %}
                   <tr>
                     <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 dark:text-neutral-400">{{ student.rank }}</td>

--- a/src/content_detail_page/includes/leaderboard.html
+++ b/src/content_detail_page/includes/leaderboard.html
@@ -1,29 +1,29 @@
 <div x-show="activeTab === 'leaderboard'" x-cloak>
   <div class="px-4 lg:px-0">
     <div class="mt-8 flow-root">
-      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8 dark:bg-neutral-900">
         <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-          <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
-            <table class="min-w-full divide-y divide-gray-300">
-              <thead class="bg-gray-50">
+          <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg dark:bg-neutral-800 dark:ring-neutral-700">
+            <table class="min-w-full divide-y divide-gray-300 dark:divide-neutral-700">
+              <thead class="bg-gray-50 dark:bg-neutral-800">
                 <tr>
-                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Rank</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Student</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Correct</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Incorrect</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Trophies</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Score</th>
+                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 dark:text-neutral-300">Rank</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Student</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Correct</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Incorrect</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Trophies</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Score</th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-gray-200 bg-white">
+              <tbody class="divide-y divide-gray-200 bg-white dark:bg-neutral-900 dark:divide-neutral-700">
                 {% for student in exam_data %}
                   <tr>
-                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">{{ student.rank }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">{{ student.name }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ student.first_attempt_correct }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ student.first_attempt_incorrect }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ student.first_attempt_trophies }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ student.first_attempt_score }}</td>
+                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 dark:text-neutral-400">{{ student.rank }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900 dark:text-neutral-200">{{ student.name }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ student.first_attempt_correct }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ student.first_attempt_incorrect }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ student.first_attempt_trophies }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ student.first_attempt_score }}</td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/src/content_detail_page/includes/leaderboard.html
+++ b/src/content_detail_page/includes/leaderboard.html
@@ -7,23 +7,23 @@
             <table class="min-w-full divide-y divide-gray-300 dark:divide-neutral-700">
               <thead class="bg-gray-50 dark:bg-neutral-700">
                 <tr>
-                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 dark:text-neutral-300">Rank</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Student</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Correct</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Incorrect</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Trophies</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Score</th>
+                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 dark:text-neutral-200">Rank</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200">Student</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200">Correct</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200">Incorrect</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200">Trophies</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200">Score</th>
                 </tr>
               </thead>
               <tbody class="divide-y divide-gray-200 bg-white dark:bg-neutral-800 dark:divide-neutral-700">
                 {% for student in exam_data %}
                   <tr>
-                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 dark:text-neutral-400">{{ student.rank }}</td>
+                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 dark:text-neutral-300">{{ student.rank }}</td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900 dark:text-neutral-200">{{ student.name }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ student.first_attempt_correct }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ student.first_attempt_incorrect }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ student.first_attempt_trophies }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ student.first_attempt_score }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-300">{{ student.first_attempt_correct }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-300">{{ student.first_attempt_incorrect }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-300">{{ student.first_attempt_trophies }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-300">{{ student.first_attempt_score }}</td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/src/content_detail_page/includes/navigate_content.html
+++ b/src/content_detail_page/includes/navigate_content.html
@@ -1,14 +1,14 @@
 {% include "./viewer_header.html" %}
-<nav class="h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-gray-200 bg-white px-4 py-3 dark:bg-neutral-800 dark:border-neutral-700">
+<nav class="h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-gray-200 bg-white px-4 py-3 dark:border-neutral-700 dark:bg-neutral-800">
 
   <div class="md:hidden flex flex-1 justify-between sm:justify-end">
-    <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-700">
+    <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-600">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
         <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
       </svg>
       Previous
     </a>
-    <a href="{{ pagination.nextPageHref|url }}" class="relative ml-3 inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-700">
+    <a href="{{ pagination.nextPageHref|url }}" class="relative ml-3 inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-600">
       Next
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />

--- a/src/content_detail_page/includes/navigate_content.html
+++ b/src/content_detail_page/includes/navigate_content.html
@@ -1,5 +1,5 @@
 {% include "./viewer_header.html" %}
-<nav class="h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-gray-200 bg-white px-4 py-3 ">
+<nav class="h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-gray-200 bg-white px-4 py-3 dark:bg-neutral-800 dark:border-neutral-700">
 
   <div class="md:hidden flex flex-1 justify-between sm:justify-end">
     <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-700">

--- a/src/content_detail_page/includes/navigate_content.html
+++ b/src/content_detail_page/includes/navigate_content.html
@@ -2,13 +2,13 @@
 <nav class="h-16 fixed bottom-0 left-0 w-full lg:relative lg:bottom-auto lg:border-b lg:flex items-center justify-between border-gray-200 bg-white px-4 py-3 ">
 
   <div class="md:hidden flex flex-1 justify-between sm:justify-end">
-    <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0">
+    <a href="{{pagination.previousPageHref|url}}" class="relative inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-700">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
         <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
       </svg>
       Previous
     </a>
-    <a href="{{ pagination.nextPageHref|url }}" class="relative ml-3 inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0">
+    <a href="{{ pagination.nextPageHref|url }}" class="relative ml-3 inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-600 ring-1 ring-inset ring-emerald-600 hover:bg-gray-50 focus-visible:outline-offset-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-700">
       Next
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />

--- a/src/content_detail_page/includes/previous_attempts.html
+++ b/src/content_detail_page/includes/previous_attempts.html
@@ -7,23 +7,23 @@
             <table class="min-w-full divide-y divide-gray-300 dark:divide-neutral-700">
               <thead class="bg-gray-50 dark:bg-neutral-700">
                 <tr>
-                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 dark:text-neutral-300">Date</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Score</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Correct</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Incorrect</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Trophies</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Actions</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300"></th>
+                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 dark:text-neutral-200">Date</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200">Score</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200">Correct</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200">Incorrect</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200">Trophies</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200">Actions</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-200"></th>
                 </tr>
               </thead>
               <tbody class="divide-y divide-gray-200 bg-white dark:bg-neutral-800 dark:divide-neutral-700">
                 {% for attempt in exam_data[0].attempts %}
                   <tr>
-                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-500 sm:pl-6 dark:text-neutral-400">{{ attempt.date }}</td>
+                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-500 sm:pl-6 dark:text-neutral-300">{{ attempt.date }}</td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900 dark:text-neutral-200">{{ attempt.score }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ attempt.correct }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ attempt.incorrect }}</td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ attempt.trophies }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-300">{{ attempt.correct }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-300">{{ attempt.incorrect }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-300">{{ attempt.trophies }}</td>
                     <td class="size-px whitespace-nowrap px-4 py-1 text-end">
                       <div class="hs-dropdown [--auto-close:inside] [--placement:bottom-right] relative inline-flex">
                         <button type="button" class="size-7 inline-flex justify-center items-center gap-x-2 rounded-lg border border-stone-200 bg-white text-stone-800 shadow-sm hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-stone-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">

--- a/src/content_detail_page/includes/previous_attempts.html
+++ b/src/content_detail_page/includes/previous_attempts.html
@@ -1,42 +1,38 @@
 <div x-show="activeTab === 'previous'" x-cloak>
   <div class="px-4 lg:px-0">
     <div class="mt-8 flow-root">
-      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8 dark:bg-neutral-900">
         <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-          <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
-            <table class="min-w-full divide-y divide-gray-300">
-              <thead class="bg-gray-50">
+          <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg dark:ring-neutral-700">
+            <table class="min-w-full divide-y divide-gray-300 dark:divide-neutral-700">
+              <thead class="bg-gray-50 dark:bg-neutral-800">
                 <tr>
-                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Date
-                  </th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Score</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Correct</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Incorrect</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Trophies</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Actions</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"></th>
+                  <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 dark:text-neutral-300">Date</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Score</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Correct</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Incorrect</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Trophies</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Actions</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300"></th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-gray-200 bg-white">
+              <tbody class="divide-y divide-gray-200 bg-white dark:bg-neutral-900 dark:divide-neutral-700">
                 {% for attempt in exam_data[0].attempts %}
-                <tr>
-                  <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-500 sm:pl-6">{{ attempt.date }}</td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">{{ attempt.score }}</td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ attempt.correct }}</td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ attempt.incorrect }}</td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{ attempt.trophies }}</td>
-                  <td class="size-px whitespace-nowrap px-4 py-1 text-end">
-                    <div class="hs-dropdown [--auto-close:inside] [--placement:bottom-right] relative inline-flex">
-                      <button type="button"
-                        class="size-7 inline-flex justify-center items-center gap-x-2 rounded-lg border border-stone-200 bg-white text-stone-800 shadow-sm hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-stone-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700"
-                        aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
-                        <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" fill="none"
-                          viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                          <circle cx="12" cy="12" r="1" />
-                          <circle cx="12" cy="5" r="1" />
-                          <circle cx="12" cy="19" r="1" />
-                        </svg>
-                      </button>
+                  <tr>
+                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-500 sm:pl-6 dark:text-neutral-400">{{ attempt.date }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900 dark:text-neutral-200">{{ attempt.score }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ attempt.correct }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ attempt.incorrect }}</td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{ attempt.trophies }}</td>
+                    <td class="size-px whitespace-nowrap px-4 py-1 text-end">
+                      <div class="hs-dropdown [--auto-close:inside] [--placement:bottom-right] relative inline-flex">
+                        <button type="button" class="size-7 inline-flex justify-center items-center gap-x-2 rounded-lg border border-stone-200 bg-white text-stone-800 shadow-sm hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-stone-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+                          <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="1" />
+                            <circle cx="12" cy="5" r="1" />
+                            <circle cx="12" cy="19" r="1" />
+                          </svg>
+                        </button>
 
                       <div
                         class="hs-dropdown-menu hs-dropdown-open:opacity-100 w-48 transition-[opacity,margin] duration opacity-0 hidden z-10 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)] dark:bg-neutral-900"

--- a/src/content_detail_page/includes/previous_attempts.html
+++ b/src/content_detail_page/includes/previous_attempts.html
@@ -1,11 +1,11 @@
 <div x-show="activeTab === 'previous'" x-cloak>
   <div class="px-4 lg:px-0">
     <div class="mt-8 flow-root">
-      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8 dark:bg-neutral-900">
+      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8 dark:bg-neutral-800">
         <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
           <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg dark:ring-neutral-700">
             <table class="min-w-full divide-y divide-gray-300 dark:divide-neutral-700">
-              <thead class="bg-gray-50 dark:bg-neutral-800">
+              <thead class="bg-gray-50 dark:bg-neutral-700">
                 <tr>
                   <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 dark:text-neutral-300">Date</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300">Score</th>
@@ -16,7 +16,7 @@
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-300"></th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-gray-200 bg-white dark:bg-neutral-900 dark:divide-neutral-700">
+              <tbody class="divide-y divide-gray-200 bg-white dark:bg-neutral-800 dark:divide-neutral-700">
                 {% for attempt in exam_data[0].attempts %}
                   <tr>
                     <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-500 sm:pl-6 dark:text-neutral-400">{{ attempt.date }}</td>
@@ -35,12 +35,12 @@
                         </button>
 
                       <div
-                        class="hs-dropdown-menu hs-dropdown-open:opacity-100 w-48 transition-[opacity,margin] duration opacity-0 hidden z-10 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)] dark:bg-neutral-900"
+                        class="hs-dropdown-menu hs-dropdown-open:opacity-100 w-48 transition-[opacity,margin] duration opacity-0 hidden z-10 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)] dark:bg-neutral-800"
                         role="menu" aria-orientation="vertical">
                         <div class="p-1">
                           <!-- Basic View -->
                           <button type="button"
-                            class="w-full flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 focus:outline-none dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800">
+                            class="w-full flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 focus:outline-none dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700">
                             <svg xmlns="http://www.w3.org/2000/svg" class="shrink-0 size-3.5 text-inherit"
                               viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                               stroke-linecap="round" stroke-linejoin="round"

--- a/src/content_detail_page/includes/result_modal.html
+++ b/src/content_detail_page/includes/result_modal.html
@@ -7,7 +7,7 @@
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
         x-show="showResultModal" 
-        class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-950 dark:bg-opacity-80"></div>
+        class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-800 dark:bg-opacity-80"></div>
 
   <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
@@ -18,7 +18,7 @@
             x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
             x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             x-show="showResultModal" 
-            class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-lg sm:p-6 dark:bg-neutral-900">
+            class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-lg sm:p-6 dark:bg-neutral-800">
         <div class="sm:flex sm:items-start">
           <div class="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-emerald-100 sm:mx-0 sm:h-10 sm:w-10 dark:bg-emerald-500/10 dark:text-emerald-400">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15a2.25 2.25 0 0 1 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0 1 18 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3 1.5 1.5 3-3.75"/></svg>
@@ -32,7 +32,7 @@
         </div>
         <div class="mt-5">
           <div class="">
-            <section class="p-0 xl:pl-10 xl:py-2 2xl:px-8 mx-auto xl:max-w-4xl xl:border rounded-md dark:border-neutral-800">
+            <section class="p-0 xl:pl-10 xl:py-2 2xl:px-8 mx-auto xl:max-w-4xl xl:border rounded-md dark:border-neutral-700">
               <dl class="grid grid-cols-1 sm:grid-cols-2">
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>

--- a/src/content_detail_page/includes/result_modal.html
+++ b/src/content_detail_page/includes/result_modal.html
@@ -36,7 +36,7 @@
               <dl class="grid grid-cols-1 sm:grid-cols-2">
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-900">
+                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-800">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                         stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
                         <path stroke-linecap="round" stroke-linejoin="round"
@@ -51,7 +51,7 @@
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white dark:bg-rose-500/10 dark:text-rose-400 dark:ring-neutral-900">
+                    <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white dark:bg-rose-500/10 dark:text-rose-400 dark:ring-neutral-800">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                         stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
                         <path stroke-linecap="round" stroke-linejoin="round"
@@ -66,7 +66,7 @@
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-500/10 dark:text-purple-400 dark:ring-neutral-900">
+                    <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-500/10 dark:text-purple-400 dark:ring-neutral-800">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75Zm6.75-4.5c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625Zm6.75-4.5c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></svg>
                     </span>
                   </div>
@@ -77,7 +77,7 @@
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white dark:bg-amber-500/10 dark:text-amber-400 dark:ring-neutral-900">
+                    <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white dark:bg-amber-500/10 dark:text-amber-400 dark:ring-neutral-800">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7a15.53 15.53 0 0 1-.311.06 15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"/></svg>
                     </span>
                   </div>
@@ -88,7 +88,7 @@
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white dark:bg-cyan-500/10 dark:text-cyan-400 dark:ring-neutral-900">
+                    <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white dark:bg-cyan-500/10 dark:text-cyan-400 dark:ring-neutral-800">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-5 h-5 sm:w-6 sm:h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15a2.25 2.25 0 0 1 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"/></svg>
                     </span>
                   </div>
@@ -99,7 +99,7 @@
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-900">
+                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-800">
                       <svg class="w-5 h-5 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
                         aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z">

--- a/src/content_detail_page/includes/result_modal.html
+++ b/src/content_detail_page/includes/result_modal.html
@@ -7,7 +7,7 @@
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
         x-show="showResultModal" 
-        class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+        class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-950 dark:bg-opacity-80"></div>
 
   <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
@@ -18,25 +18,25 @@
             x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
             x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             x-show="showResultModal" 
-            class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-lg sm:p-6">
+            class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-lg sm:p-6 dark:bg-neutral-900">
         <div class="sm:flex sm:items-start">
-          <div class="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-emerald-100 sm:mx-0 sm:h-10 sm:w-10">
+          <div class="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-emerald-100 sm:mx-0 sm:h-10 sm:w-10 dark:bg-emerald-500/10 dark:text-emerald-400">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15a2.25 2.25 0 0 1 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0 1 18 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3 1.5 1.5 3-3.75"/></svg>
           </div>
           <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-            <h3 class="text-base font-semibold leading-6 text-gray-900" id="modal-title">Exam Completed Successfully!</h3>
+            <h3 class="text-base font-semibold leading-6 text-gray-900 dark:text-neutral-200" id="modal-title">Exam Completed Successfully!</h3>
             <div class="mt-2">
-              <p class="text-sm text-gray-500">You have earned +5 Trophies</p>
+              <p class="text-sm text-gray-500 dark:text-neutral-400">You have earned +5 Trophies</p>
             </div>
           </div>
         </div>
         <div class="mt-5">
           <div class="">
-            <section class="p-0 xl:pl-10 xl:py-2 2xl:px-8 mx-auto xl:max-w-4xl xl:border rounded-md">
+            <section class="p-0 xl:pl-10 xl:py-2 2xl:px-8 mx-auto xl:max-w-4xl xl:border rounded-md dark:border-neutral-800">
               <dl class="grid grid-cols-1 sm:grid-cols-2">
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white">
+                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-900">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                         stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
                         <path stroke-linecap="round" stroke-linejoin="round"
@@ -45,13 +45,13 @@
                     </span>
                   </div>
                   <div class="flex-auto pl-3 sm:pl-6">
-                    <dt class="text-sm font-semibold leading-6 text-gray-600">Correct</dt>
-                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">1</dd>
+                    <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Correct</dt>
+                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">1</dd>
                   </div>
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white">
+                    <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white dark:bg-rose-500/10 dark:text-rose-400 dark:ring-neutral-900">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                         stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
                         <path stroke-linecap="round" stroke-linejoin="round"
@@ -60,46 +60,46 @@
                     </span>
                   </div>
                   <div class="flex-auto pl-3 sm:pl-6">
-                    <dt class="text-sm font-semibold leading-6 text-gray-600">Incorrect</dt>
-                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">0</dd>
+                    <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Incorrect</dt>
+                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">0</dd>
                   </div>
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white">
+                    <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-500/10 dark:text-purple-400 dark:ring-neutral-900">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75Zm6.75-4.5c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625Zm6.75-4.5c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></svg>
                     </span>
                   </div>
                   <div class="flex-auto pl-3 sm:pl-6">
-                    <dt class="text-sm font-semibold leading-6 text-gray-600">Accuracy</dt>
-                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">100%</dd>
+                    <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Accuracy</dt>
+                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">100%</dd>
                   </div>
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white">
+                    <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white dark:bg-amber-500/10 dark:text-amber-400 dark:ring-neutral-900">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7a15.53 15.53 0 0 1-.311.06 15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"/></svg>
                     </span>
                   </div>
                   <div class="flex-auto pl-3 sm:pl-6">
-                    <dt class="text-sm font-semibold leading-6 text-gray-600">QS per hour</dt>
-                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">52</dd>
+                    <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">QS per hour</dt>
+                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">52</dd>
                   </div>
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white">
+                    <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white dark:bg-cyan-500/10 dark:text-cyan-400 dark:ring-neutral-900">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-5 h-5 sm:w-6 sm:h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15a2.25 2.25 0 0 1 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"/></svg>
                     </span>
                   </div>
                   <div class="flex-auto pl-3 sm:pl-6">
-                    <dt class="text-sm font-semibold leading-6 text-gray-600">Score</dt>
-                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">4</dd>
+                    <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Score</dt>
+                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">4</dd>
                   </div>
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white">
+                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-900">
                       <svg class="w-5 h-5 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
                         aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z">
@@ -108,8 +108,8 @@
                     </span>
                   </div>
                   <div class="flex-auto pl-3 sm:pl-6">
-                    <dt class="text-sm font-semibold leading-6 text-gray-600">Time Taken</dt>
-                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900">0:00:09</dd>
+                    <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Time Taken</dt>
+                    <dd class="text-sm sm:text-base sm:mt-1 font-semibold leading-6 text-gray-900 dark:text-neutral-200">0:00:09</dd>
                   </div>
                 </div>
               </dl>
@@ -117,8 +117,8 @@
           </div>
         </div>
         <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
-          <button type="button" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 sm:col-start-2">Review</button>
-          <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">Retake Quiz</button>
+          <button type="button" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 sm:col-start-2 dark:bg-emerald-500 dark:hover:bg-emerald-400">Review</button>
+          <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-700 dark:hover:bg-neutral-700">Retake Quiz</button>
         </div>
       </div>
     </div>

--- a/src/content_detail_page/includes/result_modal.html
+++ b/src/content_detail_page/includes/result_modal.html
@@ -7,7 +7,7 @@
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
         x-show="showResultModal" 
-        class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-800 dark:bg-opacity-80"></div>
+        class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-900 dark:bg-opacity-80"></div>
 
   <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">

--- a/src/content_detail_page/includes/result_modal.html
+++ b/src/content_detail_page/includes/result_modal.html
@@ -20,7 +20,7 @@
             x-show="showResultModal" 
             class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-lg sm:p-6 dark:bg-neutral-800">
         <div class="sm:flex sm:items-start">
-          <div class="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-emerald-100 sm:mx-0 sm:h-10 sm:w-10 dark:bg-emerald-500/10 dark:text-emerald-400">
+          <div class="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-emerald-100 sm:mx-0 sm:h-10 sm:w-10 dark:bg-emerald-800 dark:text-emerald-300">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15a2.25 2.25 0 0 1 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0 1 18 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3 1.5 1.5 3-3.75"/></svg>
           </div>
           <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
@@ -36,7 +36,7 @@
               <dl class="grid grid-cols-1 sm:grid-cols-2">
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-800">
+                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-800 dark:text-emerald-300 dark:ring-neutral-800">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                         stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
                         <path stroke-linecap="round" stroke-linejoin="round"
@@ -51,7 +51,7 @@
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white dark:bg-rose-500/10 dark:text-rose-400 dark:ring-neutral-800">
+                    <span class="inline-flex rounded-lg p-3 bg-rose-50 text-rose-700 ring-4 ring-white dark:bg-rose-800 dark:text-rose-300 dark:ring-neutral-800">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                         stroke="currentColor" class="w-5 h-5 sm:w-6 sm:h-6">
                         <path stroke-linecap="round" stroke-linejoin="round"
@@ -66,7 +66,7 @@
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-500/10 dark:text-purple-400 dark:ring-neutral-800">
+                    <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-800 dark:text-purple-300 dark:ring-neutral-800">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75Zm6.75-4.5c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625Zm6.75-4.5c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></svg>
                     </span>
                   </div>
@@ -77,7 +77,7 @@
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white dark:bg-amber-500/10 dark:text-amber-400 dark:ring-neutral-800">
+                    <span class="inline-flex rounded-lg p-3 bg-amber-50 text-amber-700 ring-4 ring-white dark:bg-amber-800 dark:text-amber-300 dark:ring-neutral-800">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7a15.53 15.53 0 0 1-.311.06 15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"/></svg>
                     </span>
                   </div>
@@ -88,7 +88,7 @@
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white dark:bg-cyan-500/10 dark:text-cyan-400 dark:ring-neutral-800">
+                    <span class="inline-flex rounded-lg p-3 bg-cyan-50 text-cyan-700 ring-4 ring-white dark:bg-cyan-800 dark:text-cyan-300 dark:ring-neutral-800">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" data-slot="icon" class="w-5 h-5 sm:w-6 sm:h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15a2.25 2.25 0 0 1 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"/></svg>
                     </span>
                   </div>
@@ -99,7 +99,7 @@
                 </div>
                 <div class="flex items-center sm:col-span-1 py-3 sm:py-4 xl:py-6">
                   <div>
-                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-neutral-800">
+                    <span class="inline-flex rounded-lg p-3 bg-emerald-50 text-emerald-700 ring-4 ring-white dark:bg-emerald-800 dark:text-emerald-300 dark:ring-neutral-800">
                       <svg class="w-5 h-5 sm:w-6 sm:h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
                         aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z">

--- a/src/content_detail_page/includes/result_modal.html
+++ b/src/content_detail_page/includes/result_modal.html
@@ -117,7 +117,7 @@
           </div>
         </div>
         <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
-          <button type="button" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 sm:col-start-2 dark:bg-emerald-500 dark:hover:bg-emerald-400">Review</button>
+          <button type="button" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 sm:col-start-2 dark:bg-emerald-600 dark:hover:bg-emerald-500">Review</button>
           <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-700 dark:hover:bg-neutral-700">Retake Quiz</button>
         </div>
       </div>

--- a/src/content_detail_page/includes/unsubmit_assignment_confirmation_modal.html
+++ b/src/content_detail_page/includes/unsubmit_assignment_confirmation_modal.html
@@ -1,20 +1,19 @@
 <div id="unsubmit-confirmation" class="hs-overlay hidden size-full fixed top-0 start-0 z-[80] overflow-x-hidden overflow-y-auto [--close-when-click-inside:true] pointer-events-none" role="dialog" tabindex="-1" aria-labelledby="unsubmit-confirmation-label">
   <div class="hs-overlay-open:mt-7 hs-overlay-open:opacity-100 hs-overlay-open:duration-500 mt-0 opacity-0 ease-out transition-all sm:max-w-lg sm:w-full m-3 sm:mx-auto h-[calc(100%-3.5rem)] min-h-[calc(100%-3.5rem)] flex items-center">
-    <div class="relative w-full max-h-full overflow-hidden flex flex-col bg-white rounded-xl pointer-events-auto shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)]">
-      <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 w-full">
+    <div class="relative w-full max-h-full overflow-hidden flex flex-col bg-white rounded-xl pointer-events-auto shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:bg-neutral-900 dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)]">
+      <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 w-full dark:bg-neutral-900">
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
-            <h3 class="text-base font-semibold text-gray-900" id="modal-title">Unsubmit Assignment</h3>
+            <h3 class="text-base font-semibold text-gray-900 dark:text-neutral-100" id="modal-title">Unsubmit Assignment</h3>
             <div class="mt-2">
-              <p class="text-sm text-gray-500">Are you sure you want to unsubmit your <span class="font-medium text-gray-800">{{assignment.title}}</span> assignment? You will be able to resubmit before the due date.</p>
+              <p class="text-sm text-gray-500 dark:text-neutral-400">Are you sure you want to unsubmit your <span class="font-medium text-gray-800 dark:text-neutral-200">{{assignment.title}}</span> assignment? You will be able to resubmit before the due date.</p>
             </div>
           </div>
         </div>
       </div>
-      <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
-        <!-- <button type="button" class="inline-flex w-full justify-center rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-500 sm:ml-3 sm:w-auto">Yes, Unsubmit</button> -->
-        <button type="button" class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 sm:ml-3 sm:w-auto">Yes, Unsubmit</button>
-        <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto" data-hs-overlay="#unsubmit-confirmation">Cancel</button>
+      <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 dark:bg-neutral-800/50">
+        <button type="button" class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 sm:ml-3 sm:w-auto dark:bg-red-500 dark:hover:bg-red-400 transition-colors duration-200">Yes, Unsubmit</button>
+        <button type="button" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-600 dark:hover:bg-neutral-600" data-hs-overlay="#unsubmit-confirmation">Cancel</button>
       </div>
     </div>
   </div>

--- a/src/content_detail_page/includes/video_content.html
+++ b/src/content_detail_page/includes/video_content.html
@@ -17,18 +17,18 @@
   </div>
   <div class="px-4 lg:px-0">
   {% include "./doubt_button.html" %}
-  <div class="mt-6 text-sm text-gray-900 description" x-data="{ showFullDescription: false }">
+  <div class="mt-6 text-sm text-gray-900 description dark:text-neutral-200" x-data="{ showFullDescription: false }">
     <div x-cloak x-show="!showFullDescription">
         <span id="desc-chaptercontent-id" class="short-description">
           Discover the secrets of digital marketing in this comprehensive guide! From SEO strategies to social media growth, we cover everything you need to boost your brand online. Learn expert tips, proven techniques, and the latest trends to stay ahead of the competition. Watch now and start growing!...
         </span>
-        <span @click="showFullDescription = true" class="text-emerald-600 text-bold cursor-pointer">Show More</span>
+        <span @click="showFullDescription = true" class="text-emerald-600 text-bold cursor-pointe dark:text-emerald-400">Show More</span>
     </div>
     <div x-cloak x-show="showFullDescription">
         <span id="full-desc-chaptercontent-id" class="full-description">
           Discover the secrets of digital marketing in this comprehensive guide! From SEO strategies to social media growth, we cover everything you need to boost your brand online. Learn expert tips, proven techniques, and the latest trends to stay ahead of the competition. Watch now and start growing! Learn how to optimize your website for search engines, create engaging content, and drive organic traffic that converts. We explore the importance of keyword research, backlink building, and on-page SEO to ensure your content ranks higher on Google.
         </span>
-        <span @click="showFullDescription = false" class="text-emerald-600 text-bold cursor-pointer">Show Less</span>
+        <span @click="showFullDescription = false" class="text-emerald-600 text-bold cursor-pointer dark:text-emerald-400">Show Less</span>
     </div>
   </div>
 </div>

--- a/src/content_detail_page/notes.html
+++ b/src/content_detail_page/notes.html
@@ -12,14 +12,14 @@
 <div x-data="contents">
 	{% include "./includes/mobile_sidebar.html" %}  
 	{% include "./includes/desktop_sidebar.html" %}  
-	<main class="lg:pl-96">
+	<main class="lg:pl-96 dark:bg-neutral-800">
 		{% include "./includes/navigate_content.html" %}
-    <div class="sticky top-28 xl:top-16 z-30 bg-white p-2 shadow"  x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
+    <div class="sticky top-28 xl:top-16 z-30 bg-white p-2 shadow dark:bg-neutral-800 dark:border-b dark:border-neutral-700"  x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
       {% include "./includes/content_heading.html" %}
     </div>
     <div class="lg:px-8">
       <div>
-        <div class="mt-6 prose prose-slate px-4 sm:px-6 lg:px-0 lg:prose-md max-w-none dark:prose-invert">
+        <div class="mt-6 prose prose-neutral px-4 sm:px-6 lg:px-0 lg:prose-md max-w-none dark:prose-invert dark:bg-neutral-800">
           {{ content.body|safe }}
           <h4><strong>Mentor Links </strong></h4>
           <p>Before coming to the session, be ready with specific doubts/issues you are facing with regards to the preparation.</p>

--- a/src/content_detail_page/video.html
+++ b/src/content_detail_page/video.html
@@ -51,7 +51,7 @@ date: 2023-05-30
 <div x-data="contents">
 	{% include "./includes/mobile_sidebar.html" %}  
 	{% include "./includes/desktop_sidebar.html" %}  
-	<main class="lg:pl-96">
+	<main class="lg:pl-96 dark:bg-neutral-800">
 		{% include "./includes/navigate_content.html" %}
 		{% include "./includes/video_content.html" %}
 		{% include "./includes/comment_section.html" %}

--- a/src/content_detail_page/video_conf_start.html
+++ b/src/content_detail_page/video_conf_start.html
@@ -12,15 +12,15 @@
 <div x-data="contents">
 	{% include "./includes/mobile_sidebar.html" %}  
 	{% include "./includes/desktop_sidebar.html" %}  
-	<main class="lg:pl-96">
+	<main class="lg:pl-96 dark:bg-neutral-800">
 		{% include "./includes/navigate_content.html" %}
     <div class="lg:px-8" x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
       {% include "./includes/content_heading.html" %}    
       <div class="sm:block px-4 sm:px-6 lg:px-0 mt-6">
-        <section aria-labelledby="quick-links-title" class="p-0 sm:p-6 2xl:p-8 space-y-6 mx-auto max-w-xl sm:border rounded-md">
+        <section aria-labelledby="quick-links-title" class="p-0 sm:p-6 2xl:p-8 space-y-6 mx-auto max-w-xl sm:border rounded-md dark:border-neutral-700">
           <div class="flex items-center">
             <div>
-              <span class="inline-flex rounded-lg p-3 bg-teal-50 text-teal-700 ring-4 ring-white">
+              <span class="inline-flex rounded-lg p-3 bg-teal-50 text-teal-700 ring-4 ring-white dark:bg-teal-800 dark:ring-neutral-800 dark:text-teal-400">
                 <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
                   aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z">
@@ -29,21 +29,21 @@
               </span>
             </div>
             <div class="flex-auto pl-6">
-              <dt class="text-sm font-semibold leading-6 text-gray-600">Duration</dt>
-              <dd class="mt-1 text-base font-semibold leading-6 text-gray-900">40 minutes</dd>
+              <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Duration</dt>
+              <dd class="mt-1 text-base font-semibold leading-6 text-gray-900 dark:text-neutral-200">40 minutes</dd>
             </div>
           </div>
           <div class="flex items-center">
             <div>
-              <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white">
+              <span class="inline-flex rounded-lg p-3 bg-purple-50 text-purple-700 ring-4 ring-white dark:bg-purple-800 dark:text-purple-300 dark:ring-neutral-800">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5m-9-6h.008v.008H12v-.008zM12 15h.008v.008H12V15zm0 2.25h.008v.008H12v-.008zM9.75 15h.008v.008H9.75V15zm0 2.25h.008v.008H9.75v-.008zM7.5 15h.008v.008H7.5V15zm0 2.25h.008v.008H7.5v-.008zm6.75-4.5h.008v.008h-.008v-.008zm0 2.25h.008v.008h-.008V15zm0 2.25h.008v.008h-.008v-.008zm2.25-4.5h.008v.008H16.5v-.008zm0 2.25h.008v.008H16.5V15z" />
                 </svg>
               </span>
             </div>
             <div class="flex-auto pl-6">
-              <dt class="text-sm font-semibold leading-6 text-gray-600">Start Time</dt>
-              <dd class="mt-1 text-base font-semibold leading-6 text-gray-900">9 Dec 2023, 9.30 A.M.</dd>
+              <dt class="text-sm font-semibold leading-6 text-gray-600 dark:text-neutral-400">Start Time</dt>
+              <dd class="mt-1 text-base font-semibold leading-6 text-gray-900 dark:text-neutral-200">9 Dec 2023, 9.30 A.M.</dd>
             </div>
           </div>
         </section>  

--- a/src/testpress/exam_mindset/includes/pre_exam.html
+++ b/src/testpress/exam_mindset/includes/pre_exam.html
@@ -7,7 +7,7 @@
     x-transition:leave-start="opacity-100"
     x-transition:leave-end="opacity-0"
     x-show="showPreTestModal"
-    class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-800 dark:bg-opacity-80">
+    class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-900 dark:bg-opacity-80">
   </div>
 
   <div class="fixed inset-0 z-10 w-screen">

--- a/src/testpress/exam_mindset/includes/pre_exam.html
+++ b/src/testpress/exam_mindset/includes/pre_exam.html
@@ -7,7 +7,7 @@
     x-transition:leave-start="opacity-100"
     x-transition:leave-end="opacity-0"
     x-show="showPreTestModal"
-    class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity">
+    class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-950 dark:bg-opacity-80">
   </div>
 
   <div class="fixed inset-0 z-10 w-screen">
@@ -20,11 +20,11 @@
         x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
         x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         x-show="showPreTestModal"
-        class="relative transform rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-2xl dark:bg-neutral-800 flex flex-col max-h-[calc(100vh-2rem)] sm:max-h-[calc(100vh-4rem)]">
+        class="relative transform rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-2xl flex flex-col max-h-[calc(100vh-2rem)] sm:max-h-[calc(100vh-4rem)] dark:bg-neutral-900">
         
         <div class="py-4 px-6 md:px-8 flex justify-between items-center border-b border-gray-200 dark:border-neutral-700">
           <div class="flex items-center gap-2">
-            <h3 id="modal-title" class="text-base font-semibold leading-6 text-gray-900 dark:text-neutral-100">
+            <h3 id="modal-title" class="text-base font-semibold leading-6 text-gray-900 dark:text-neutral-200">
               Get in the right mindset
             </h3>
             <div class="relative group">

--- a/src/testpress/exam_mindset/includes/pre_exam.html
+++ b/src/testpress/exam_mindset/includes/pre_exam.html
@@ -7,7 +7,7 @@
     x-transition:leave-start="opacity-100"
     x-transition:leave-end="opacity-0"
     x-show="showPreTestModal"
-    class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-950 dark:bg-opacity-80">
+    class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity dark:bg-neutral-800 dark:bg-opacity-80">
   </div>
 
   <div class="fixed inset-0 z-10 w-screen">
@@ -20,7 +20,7 @@
         x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
         x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         x-show="showPreTestModal"
-        class="relative transform rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-2xl flex flex-col max-h-[calc(100vh-2rem)] sm:max-h-[calc(100vh-4rem)] dark:bg-neutral-900">
+        class="relative transform rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-2xl flex flex-col max-h-[calc(100vh-2rem)] sm:max-h-[calc(100vh-4rem)] dark:bg-neutral-800">
         
         <div class="py-4 px-6 md:px-8 flex justify-between items-center border-b border-gray-200 dark:border-neutral-700">
           <div class="flex items-center gap-2">


### PR DESCRIPTION
- This commit adds dark styles for exams in content detail page on new student UI
-  Adds dark styles across - Exam detail page, Exam tabs, Exam mode, result, certificate, and pre-exam modals, Leaderboard & previous attempts tables, Navigation footer and action buttons .
- Adds dark mode styles for assignments pages and assignment submission
- Adds dark mode styles for discussion list and form page.
- Adds dark mode for video and video conference pages.
- Updated backgrounds, text colors, borders, rings, and hover states for dark mode
- Ensured icons and status indicators adapt correctly in dark theme