### PR TITLE
fix: Suggest improve recommendation based on specific error reason

### DIFF
--- a/src/_data/mindset_report.json
+++ b/src/_data/mindset_report.json
@@ -298,9 +298,7 @@
         "exampleQuestions": [
           "Q7 - data interpretation",
           "Q15 - paragraph summary"
-        ],
-        "suggestedStrategy": "test_skill",
-        "suggestedImprovement": "focusing on timing discipline and exam strategy"
+        ]
       },
       {
         "id": "lack_knowledge",
@@ -311,9 +309,7 @@
         "exampleQuestions": [
           "Q3 - algebraic simplification",
           "Q19 - grammar rule"
-        ],
-        "suggestedStrategy": "conceptual",
-        "suggestedImprovement": "revising weak concepts and practicing targeted questions"
+        ]
       },
       {
         "id": "didnt_understand",
@@ -323,42 +319,8 @@
         "count": 3,
         "exampleQuestions": [
           "Q28 - data interpretation set"
-        ],
-        "suggestedStrategy": "comprehension",
-        "suggestedImprovement": "slowing down to interpret questions carefully"
+        ]
       }
     ]
-  },
-  "improvementStrategies": {
-    "test_skill": {
-      "name": "Boost Exam-Taking Skills",
-      "guidance": "Focus on pacing during the exam, double-check work for small errors, and avoid rushing at the end. Practice timed quizzes to build consistency under pressure.",
-      "description": "Improving exam behavior and time management can significantly increase accuracy without needing major concept revision.",
-      "studentBehavior": "Try short timed sections and celebrate small wins (e.g., finishing one section without rushing). When you notice time slipping, pause and choose 1 quick step: simplify the problem, mark it to return, or estimate an answer."
-    },
-    "conceptual": {
-      "name": "Strengthen Concept Mastery",
-      "guidance": "Review foundational ideas behind the topics where mistakes occurred. Practice similar question types to reinforce core strategies and problem-solving methods.",
-      "description": "Better command of required knowledge leads to more confident and reliable performance.",
-      "studentBehavior": "Break down the concept into 2–3 core rules and practice 5 focused problems. Keep notes of repeated patterns that help you solve similar problems faster next time."
-    },
-    "comprehension": {
-      "name": "Improve Question Understanding",
-      "guidance": "Slow down while reading, underline key words, and restate the problem in your own words. Look out for small hints or constraints in the question.",
-      "description": "Careful reading helps avoid avoidable errors and ensures the right strategy is applied.",
-      "studentBehavior": "Before solving, spend 6–8 seconds paraphrasing the question out loud or in writing and underline what the question specifically asks for. This habit prevents misapplied strategies."
-    }
-  },
-  "strategyMap": {
-    "rushed": "test_skill",
-    "didnt_understand": "comprehension",
-    "misread": "comprehension",
-    "time_pressure": "test_skill",
-    "calculation": "test_skill",
-    "lack_knowledge": "conceptual",
-    "careless": "test_skill",
-    "wrong_strategy": "conceptual",
-    "guessed": "test_skill",
-    "others": "test_skill"
   }
 }

--- a/src/_data/mindset_report.json
+++ b/src/_data/mindset_report.json
@@ -291,6 +291,8 @@
     "topErrors": [
       {
         "id": "rushed",
+        "name": "Rushed Through",
+        "tip": "Try dedicating the first 15 seconds to just scanning the question. It feels slow, but it's often faster than recovery.",
         "label": "Rushed",
         "count": 6,
         "exampleQuestions": [
@@ -302,6 +304,8 @@
       },
       {
         "id": "lack_knowledge",
+        "name": "Concept Gap",
+        "tip": "Note the exact fact or rule you missed and do a 2-minute refresher. Filling a single gap is often enough to unlock similar problems.",
         "label": "Lack of Knowledge",
         "count": 4,
         "exampleQuestions": [
@@ -313,6 +317,8 @@
       },
       {
         "id": "didnt_understand",
+        "name": "Interpretation Error",
+        "tip": "Before solving, try restating the question in your own words. If you can't explain it simply, you might not understand what it's asking.",
         "label": "Didn't Understand Question",
         "count": 3,
         "exampleQuestions": [

--- a/src/exam_review/mindset_insights/script/mindset_insights_component.html
+++ b/src/exam_review/mindset_insights/script/mindset_insights_component.html
@@ -66,9 +66,6 @@
         totalErrors: 0
       },
 
-      improvementStrategies: {},
-      strategyMap: {},
-      
       colorMapper: null,
       _bubbleRendered: false,
 
@@ -154,8 +151,6 @@
       },
 
       processPathway(src) {
-        this.improvementStrategies = src.improvementStrategies || {};
-        this.strategyMap = src.strategyMap || {};
         const srcPathway = src.pathway || { topErrors: [] };
         if (this.pathway.totalErrors > 0) {
           this.pathway.topErrors = (srcPathway.topErrors || [])
@@ -169,7 +164,6 @@
                 reason: err.label,
                 count: err.count,
                 percentage: Math.round((err.count / this.pathway.totalErrors) * 100),
-                improvementPhrase: err.suggestedImprovement || "reviewing your errors"
               };
             });
         }

--- a/src/exam_review/mindset_insights/script/mindset_insights_component.html
+++ b/src/exam_review/mindset_insights/script/mindset_insights_component.html
@@ -164,6 +164,8 @@
             .map(err => {
               return {
                 id: err.id,
+                name: err.name,
+                tip: err.tip,
                 reason: err.label,
                 count: err.count,
                 percentage: Math.round((err.count / this.pathway.totalErrors) * 100),

--- a/src/exam_review/mindset_insights/steps_to_improve.html
+++ b/src/exam_review/mindset_insights/steps_to_improve.html
@@ -91,37 +91,26 @@
             </div>
           </div>
           <div>
-            <div class="flex flex-col gap-6 lg:gap-10">
-              <template x-for="(error, idx) in pathway.topErrors.slice(0, 2)" :key="error.id">
-                <template x-data="{ strategyKey: strategyMap[error.id], strategy: improvementStrategies[strategyMap[error.id]] }" x-if="strategy">
-                  <div class="p-5 flex flex-col bg-white dark:bg-neutral-800">
-                    <div class="mb-4 flex items-start justify-between gap-x-3">
-                      <div class="grow">
-                        <p class="font-semibold text-xl md:text-2xl text-gray-800 dark:text-neutral-200" x-text="strategy.name"></p>
-                      </div>
+          <div class="min-h-0 flex flex-col h-full">
+            <div class="flex flex-col justify-between p-5 gap-y-4 h-full flex-grow">
+              <template x-for="(error, idx) in pathway.topErrors.slice(0, 3)" :key="error.id">
+                <div 
+                  x-data="{ tip: error.tip }" 
+                  x-show="tip"
+                  class="rounded-xl shadow-sm hover:shadow-md transition-shadow duration-200 flex-1 flex flex-col"
+                >
+                  <div class="p-6 flex flex-col bg-white dark:bg-neutral-800 rounded-xl flex-grow justify-center">
+                    <div class="pb-2 mb-3">
+                      <p class="font-bold text-lg text-gray-800 dark:text-neutral-200 mb-1" x-text="error.name"></p>
+                      <p class="text-xs font-medium uppercase tracking-wider text-emerald-600 dark:text-emerald-400" x-text="'How to improve'"></p>
                     </div>
-                    <div class="space-y-3">
-                      <p class="text-sm text-gray-500 dark:text-neutral-500" x-text="'This strategy helps with errors like: ' + error.reason + '.'"></p>
-                      <div>
-                        <h4 class="text-sm font-semibold text-gray-800 dark:text-neutral-200">About This Strategy</h4>
-                        <p class="mt-1 text-sm text-gray-700 dark:text-neutral-300" x-text="strategy.description"></p>
-                      </div>
-                      <div>
-                        <h4 class="text-sm font-semibold text-gray-800 dark:text-neutral-200">Recommended Focus</h4>
-                        <p class="mt-1 text-sm text-gray-700 dark:text-neutral-300" x-text="strategy.guidance"></p>
-                      </div>
-                      <div>
-                        <h4 class="text-sm font-semibold text-gray-800 dark:text-neutral-200">Actionable Steps</h4>
-                        <p class="mt-1 text-sm text-gray-700 dark:text-neutral-300" x-text="strategy.studentBehavior"></p>
-                      </div>
-                    </div>
-                  </div>              
-                </template>
-                <template x-if="idx === 0">
-                  <div class="my-5 border-t border-gray-200 dark:border-neutral-700"></div>
-                </template>
+                    
+                    <p class="text-sm text-gray-700 dark:text-neutral-300 leading-relaxed italic" x-text="tip"></p>
+                  </div>
+                </div>
               </template>
             </div>
+          </div>
           </div>
         </div>
       </template>

--- a/src/exam_review/mindset_insights/steps_to_improve.html
+++ b/src/exam_review/mindset_insights/steps_to_improve.html
@@ -65,7 +65,7 @@
               <template x-for="(error, idx) in pathway.topErrors.slice(0, 3)" :key="error.id">
                 <div x-show="error.tip" class="flex flex-col">
                   <div class="flex items-center gap-x-1 mb-2">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-5" :style="`color: ${colorMapper.getColor(error.reason)}`">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-5 text-gray-600">
                       <path d="m6 17 5-5-5-5"/>
                       <path d="m13 17 5-5-5-5"/>
                     </svg>

--- a/src/exam_review/mindset_insights/steps_to_improve.html
+++ b/src/exam_review/mindset_insights/steps_to_improve.html
@@ -57,37 +57,6 @@
                   </li>
                 </template>
               </ul>
-              <template x-if="pathway.topErrors.length > 0">
-                <div
-                  x-data="{
-                    firstErrorReason: pathway.topErrors[0].reason,
-                    secondErrorReason: pathway.topErrors.length > 1 ? pathway.topErrors[1].reason : null,
-                    improvementPhrase: pathway.topErrors[0].improvementPhrase
-                  }"
-                  class="mt-4 p-3.5 bg-emerald-50 border border-emerald-200 rounded-lg dark:bg-emerald-900/20 dark:border-emerald-700/50"
-                >
-                  <div class="flex">
-                    <div class="flex-shrink-0">
-                      <svg class="shrink-0 size-5 text-emerald-600 dark:text-emerald-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <circle cx="12" cy="12" r="10"/>
-                        <line x1="12" y1="16" x2="12" y2="12"/>
-                        <line x1="12" y1="8" x2="12.01" y2="8"/>
-                      </svg>
-                    </div>
-                    <div class="ms-3">
-                      <p class="text-sm text-emerald-700 dark:text-emerald-300">
-                        The two prominent reasons for the mistakes you did during the exam are
-                        <strong x-text="firstErrorReason"></strong>
-                        <template x-if="secondErrorReason">
-                          <span> and <strong x-text="secondErrorReason"></strong></span>
-                        </template>
-                        as per your reflections.
-                        This indicates that <strong x-text="improvementPhrase"></strong> will be most effective in boosting your score.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </template>
             </div>
           </div>
           <div>

--- a/src/exam_review/mindset_insights/steps_to_improve.html
+++ b/src/exam_review/mindset_insights/steps_to_improve.html
@@ -69,7 +69,7 @@
                   >
                     <div class="p-6 flex flex-col bg-white dark:bg-neutral-800 rounded-xl flex-grow justify-center">
                       <div class="pb-2 mb-3">
-                        <p class="font-bold text-lg text-gray-800 dark:text-neutral-200 mb-1" x-text="error.name"></p>
+                        <p class="font-bold text-lg text-gray-800 dark:text-neutral-200 mb-1" x-text="error.reason"></p>
                         <p class="text-xs font-medium uppercase tracking-wider text-emerald-600 dark:text-emerald-400">How to improve</p>
                       </div>
                       

--- a/src/exam_review/mindset_insights/steps_to_improve.html
+++ b/src/exam_review/mindset_insights/steps_to_improve.html
@@ -60,26 +60,25 @@
             </div>
           </div>
           <div>
-          <div class="min-h-0 flex flex-col h-full">
-            <div class="flex flex-col justify-between p-5 gap-y-4 h-full flex-grow">
-              <template x-for="(error, idx) in pathway.topErrors.slice(0, 3)" :key="error.id">
-                <div 
-                  x-data="{ tip: error.tip }" 
-                  x-show="tip"
-                  class="rounded-xl shadow-sm hover:shadow-md transition-shadow duration-200 flex-1 flex flex-col"
-                >
-                  <div class="p-6 flex flex-col bg-white dark:bg-neutral-800 rounded-xl flex-grow justify-center">
-                    <div class="pb-2 mb-3">
-                      <p class="font-bold text-lg text-gray-800 dark:text-neutral-200 mb-1" x-text="error.name"></p>
-                      <p class="text-xs font-medium uppercase tracking-wider text-emerald-600 dark:text-emerald-400" x-text="'How to improve'"></p>
+            <div class="min-h-0 flex flex-col h-full">
+              <div class="flex flex-col justify-between p-5 gap-y-4 h-full flex-grow">
+                <template x-for="(error, idx) in pathway.topErrors.slice(0, 3)" :key="error.id">
+                  <div 
+                    x-show="error.tip"
+                    class="rounded-xl shadow-sm hover:shadow-md transition-shadow duration-200 flex-1 flex flex-col"
+                  >
+                    <div class="p-6 flex flex-col bg-white dark:bg-neutral-800 rounded-xl flex-grow justify-center">
+                      <div class="pb-2 mb-3">
+                        <p class="font-bold text-lg text-gray-800 dark:text-neutral-200 mb-1" x-text="error.name"></p>
+                        <p class="text-xs font-medium uppercase tracking-wider text-emerald-600 dark:text-emerald-400">How to improve</p>
+                      </div>
+                      
+                      <p class="text-sm text-gray-700 dark:text-neutral-300 leading-relaxed italic" x-text="error.tip"></p>
                     </div>
-                    
-                    <p class="text-sm text-gray-700 dark:text-neutral-300 leading-relaxed italic" x-text="tip"></p>
                   </div>
-                </div>
-              </template>
+                </template>
+              </div>
             </div>
-          </div>
           </div>
         </div>
       </template>

--- a/src/exam_review/mindset_insights/steps_to_improve.html
+++ b/src/exam_review/mindset_insights/steps_to_improve.html
@@ -14,12 +14,10 @@
       <template x-if="pathway.topErrors && pathway.topErrors.length > 0">
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-10">
           <div class="flex flex-col bg-white dark:bg-neutral-800">
-            <div class="p-5 pb-4 grid grid-cols-2 items-center gap-x-4 relative z-10">
-              <div>
-                <h2 class="inline-block font-semibold text-lg text-gray-800 dark:text-neutral-200">
-                  Top Error Reasons
-                </h2>
-              </div>
+            <div class="p-5 pb-4">
+              <h2 class="inline-block font-semibold text-lg text-gray-800 dark:text-neutral-200">
+                Top Error Reasons
+              </h2>
             </div>
             <div class="p-5 pt-0">
               <div class="w-full h-64 md:h-72 lg:h-80 flex items-center justify-center">
@@ -44,10 +42,7 @@
                 <template x-for="error in pathway.topErrors" :key="error.id">
                   <li class="py-3 grid grid-cols-2 justify-between items-center gap-x-4 border-b last:border-b-0 border-gray-200 dark:border-neutral-700">
                     <div class="flex items-center">
-                      <span
-                        class="shrink-0 size-2.5 inline-block rounded-xs me-2.5"
-                        :style="`background-color: ${colorMapper.getColor(error.reason)}`"
-                      ></span>
+                      <span class="shrink-0 size-2.5 inline-block rounded-xs me-2.5" :style="`background-color: ${colorMapper.getColor(error.reason)}`"></span>
                       <span class="text-sm text-gray-800 dark:text-neutral-200" x-text="error.reason"></span>
                     </div>
                     <div class="flex justify-end items-center gap-x-1.5">
@@ -59,25 +54,26 @@
               </ul>
             </div>
           </div>
-          <div>
-            <div class="min-h-0 flex flex-col h-full">
-              <div class="flex flex-col justify-between p-5 gap-y-4 h-full flex-grow">
-                <template x-for="(error, idx) in pathway.topErrors.slice(0, 3)" :key="error.id">
-                  <div 
-                    x-show="error.tip"
-                    class="rounded-xl shadow-sm hover:shadow-md transition-shadow duration-200 flex-1 flex flex-col"
-                  >
-                    <div class="p-6 flex flex-col bg-white dark:bg-neutral-800 rounded-xl flex-grow justify-center">
-                      <div class="pb-2 mb-3">
-                        <p class="font-bold text-lg text-gray-800 dark:text-neutral-200 mb-1" x-text="error.reason"></p>
-                        <p class="text-xs font-medium uppercase tracking-wider text-emerald-600 dark:text-emerald-400">How to improve</p>
-                      </div>
-                      
-                      <p class="text-sm text-gray-700 dark:text-neutral-300 leading-relaxed italic" x-text="error.tip"></p>
-                    </div>
+
+          <div class="p-5">
+            <div class="mb-6">
+              <h2 class="font-semibold text-lg text-gray-800 dark:text-neutral-200">How to improve</h2>
+              <p class="text-sm text-gray-500">Actionable steps based on your top error patterns.</p>
+            </div>
+            
+            <div class="space-y-8 lg:space-y-12">
+              <template x-for="(error, idx) in pathway.topErrors.slice(0, 3)" :key="error.id">
+                <div x-show="error.tip" class="flex flex-col">
+                  <div class="flex items-center gap-x-1 mb-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-5" :style="`color: ${colorMapper.getColor(error.reason)}`">
+                      <path d="m6 17 5-5-5-5"/>
+                      <path d="m13 17 5-5-5-5"/>
+                    </svg>
+                    <h3 class="font-bold text-gray-800 dark:text-neutral-200" x-text="error.reason"></h3>
                   </div>
-                </template>
-              </div>
+                  <p class="text-sm text-gray-700 dark:text-neutral-300 leading-relaxed italic" x-text="error.tip"></p>
+                </div>
+              </template>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- The improvement tips shown to users in the exam mindset insights were generic and grouped by broad categories. This resulted in users seeing repetitive or less relevant advice that didn't specifically address the unique mistake 
- The insights now provide reason-specific tips. The logic has been updated to fetch specific recommendations for each identified mistake reason.
