### PR TITLE
feat: Add Copy Destination Set list page UI

### DIFF
--- a/src/_data/copy_destination_set.json
+++ b/src/_data/copy_destination_set.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": 1,
+    "name": "Premium Subscription Institutes",
+    "number_of_destinations": 20,
+    "created_by": "admin",
+    "created_at": "Jan 01, 2026, 09:15 AM"
+  },
+  {
+    "id": 2,
+    "name": "All Active Institutes",
+    "number_of_destinations": 35,
+    "created_by": "Steve Harington",
+    "created_at": "Dec 30, 2025, 11:40 AM"
+  },
+  {
+    "id": 3,
+    "name": "North Region Branches",
+    "number_of_destinations": 12,
+    "created_by": "Cristopher Nolan",
+    "created_at": "Dec 27, 2025, 04:05 PM"
+  },
+  {
+    "id": 4,
+    "name": "2026 New Onboarded Institutes",
+    "number_of_destinations": 18,
+    "created_by": "admin",
+    "created_at": "Dec 20, 2025, 10:20 AM"
+  },
+  {
+    "id": 5,
+    "name": "Beta Testing Institutes",
+    "number_of_destinations": 8,
+    "created_by": "James Cameron",
+    "created_at": "Dec 15, 2025, 02:45 PM"
+  },
+  {
+    "id": 6,
+    "name": "Internal QA Distribution",
+    "number_of_destinations": 5,
+    "created_by": "admin",
+    "created_at": "Dec 01, 2025, 09:00 AM"
+  }
+]

--- a/src/copy_contents/includes/header.html
+++ b/src/copy_contents/includes/header.html
@@ -2,4 +2,11 @@
   <div>
     <h1 class="text-lg md:text-xl font-semibold text-stone-800 dark:text-neutral-200">Copy Content - Functions in Python </h1>
   </div>
+  <div>
+    <a href="/copy_destination_sets/"
+        class="py-1.5 sm:py-2 px-2.5 inline-flex items-center gap-x-1.5 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 focus:outline-hidden dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700">
+        <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
+        View Destination Sets
+    </a>
+  </div>
 </div>

--- a/src/copy_destination_sets/includes/breadcrumbs.html
+++ b/src/copy_destination_sets/includes/breadcrumbs.html
@@ -1,0 +1,9 @@
+<div>
+<nav class="mb-2" aria-label="Back">
+  <a href="/copy_contents/" class="text-sm text-gray-600 decoration-2 hover:underline font-medium focus:outline-hidden focus:underline dark:text-gray-400 dark:hover:text-gray-500 flex items-center gap-1">
+
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mr-2 text-gray-600 dark:text-gray-400"><path d="M6 8L2 12L6 16"/><path d="M2 12H22"/></svg>
+    Back to Copy Content
+  </a>
+</nav>
+</div>

--- a/src/copy_destination_sets/includes/delete_modal.html
+++ b/src/copy_destination_sets/includes/delete_modal.html
@@ -1,0 +1,62 @@
+<div  x-cloak x-show="showDeleteModal" class="relative z-[80]" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <!--
+      Background backdrop, show/hide based on modal state.
+  
+      Entering: "ease-out duration-300"
+        From: "opacity-0"
+        To: "opacity-100"
+      Leaving: "ease-in duration-200"
+        From: "opacity-100"
+        To: "opacity-0"
+    -->
+    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+  
+    <div class="fixed z-10 inset-0 overflow-y-auto">
+      <div class="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
+        <!--
+          Modal panel, show/hide based on modal state.
+  
+          Entering: "ease-out duration-300"
+            From: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            To: "opacity-100 translate-y-0 sm:scale-100"
+          Leaving: "ease-in duration-200"
+            From: "opacity-100 translate-y-0 sm:scale-100"
+            To: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        -->
+        <div  @click.away="showDeleteModal=false" class="relative bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
+          <div class="hidden sm:block absolute top-0 right-0 pt-4 pr-4">
+            <button type="button"
+                @click="showDeleteModal = false"
+                class="bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-none">
+              <span class="sr-only">Close</span>
+              <!-- Heroicon name: outline/x -->
+              <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          <div class="sm:flex sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <svg class="h-6 w-6 text-red-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900" id="modal-title">Confirm Delete</h3>
+              <div class="mt-2">
+                <p class="text-sm text-gray-500">
+                  Are you sure you want to delete
+                  <span x-text="selectedDestinationSetIds.length > 1 ? `${selectedDestinationSetIds.length} destination sets` : 'this destination set'"></span>?
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+            <button @click="deleteDestinationSets(true)" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none sm:ml-3 sm:w-auto sm:text-sm">Delete</button>
+            <button @click="selectedDestinationSetIds=[]; showDeleteModal=false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:text-gray-500 focus:outline-none sm:mt-0 sm:w-auto sm:text-sm">Cancel</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/src/copy_destination_sets/includes/filters.html
+++ b/src/copy_destination_sets/includes/filters.html
@@ -1,0 +1,39 @@
+<div class="pb-4 grid md:grid-cols-2 gap-y-2 md:gap-y-0 md:gap-x-5 border-b border-stone-200 dark:border-neutral-700">
+  <div>
+    <!-- Search Input -->
+    <div class="relative">
+      <div class="absolute inset-y-0 start-0 flex items-center pointer-events-none z-20 ps-3.5">
+        <svg class="shrink-0 size-4 text-stone-500 dark:text-neutral-400" xmlns="http://www.w3.org/2000/svg" width="24"
+          height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <circle cx="11" cy="11" r="8" />
+          <path d="m21 21-4.3-4.3" />
+        </svg>
+      </div>
+      <input type="text"
+        class="py-[7px] ps-10 pe-8 block w-full bg-stone-100 border-transparent rounded-lg text-sm placeholder:text-stone-500 focus:border-green-500 focus:ring-green-600 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-700 dark:border-transparent dark:text-neutral-400 dark:placeholder:text-neutral-400 dark:focus:ring-neutral-600"
+        placeholder="Search Destination sets">
+      <div class="hidden absolute inset-y-0 end-0 flex items-center pointer-events-none z-20 pe-1">
+        <button type="button"
+          class="inline-flex shrink-0 justify-center items-center size-6 rounded-full text-gray-500 hover:text-blue-600 focus:outline-none focus:text-blue-600 dark:text-neutral-500 dark:hover:text-blue-500 dark:focus:text-blue-500"
+          aria-label="Close">
+          <span class="sr-only">Close</span>
+          <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+            fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10" />
+            <path d="m15 9-6 6" />
+            <path d="m9 9 6 6" />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <!-- End Search Input -->
+  </div>
+  <!-- End Col -->
+  <div></div>
+
+</div>
+
+<!-- Show PIN Modal -->
+
+<!-- End Show PIN Modal -->

--- a/src/copy_destination_sets/includes/filters.html
+++ b/src/copy_destination_sets/includes/filters.html
@@ -31,11 +31,10 @@
   </div>
   <!-- End Col -->
   <div class="flex items-center justify-start md:justify-end">
-    <button x-cloak x-show="selectedDestinationSetIds.length" @click="deleteDestinationSets()" type="button"
-      class="gap-x-1.5 inline-flex rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="shrink-0 w-4 h-4">
-        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-      </svg>
+    
+
+    <button x-cloak x-show="selectedDestinationSetIds.length" @click="deleteDestinationSets()" type="button" class="py-1.5 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg bg-layer border border-layer-line text-layer-foreground shadow-2xs hover:bg-layer-hover disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-layer-focus">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trash2-icon lucide-trash-2"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
       Delete
     </button>
   </div>

--- a/src/copy_destination_sets/includes/filters.html
+++ b/src/copy_destination_sets/includes/filters.html
@@ -30,7 +30,15 @@
     <!-- End Search Input -->
   </div>
   <!-- End Col -->
-  <div></div>
+  <div class="flex items-center justify-start md:justify-end">
+    <button x-cloak x-show="selectedDestinationSetIds.length" @click="deleteDestinationSets()" type="button"
+      class="gap-x-1.5 inline-flex rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="shrink-0 w-4 h-4">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+      </svg>
+      Delete
+    </button>
+  </div>
 
 </div>
 

--- a/src/copy_destination_sets/includes/header.html
+++ b/src/copy_destination_sets/includes/header.html
@@ -1,0 +1,6 @@
+<div class="flex flex-wrap justify-between items-center gap-2">
+  <div>
+    <h1 class="text-lg md:text-xl font-semibold text-stone-800 dark:text-neutral-200">Destination Sets(23)</h1>
+    <p class="text-sm text-stone-500 dark:text-neutral-400">List of all destination sets</p>
+  </div>
+</div>

--- a/src/copy_destination_sets/includes/pagination.html
+++ b/src/copy_destination_sets/includes/pagination.html
@@ -1,0 +1,24 @@
+<div class="mt-5 flex flex-wrap justify-between items-center gap-2">
+  <p class="text-sm text-stone-800 dark:text-neutral-200">
+    <span class="font-medium">27</span>
+    <span class="text-stone-500 dark:text-neutral-500">results</span>
+  </p>
+
+  <!-- Pagination -->
+  <nav class="flex justify-end items-center gap-x-1" aria-label="Pagination">
+    <button type="button" class="min-h-[38px] min-w-[38px] py-2 px-2.5 inline-flex justify-center items-center gap-x-2 text-sm rounded-lg text-stone-800 hover:bg-stone-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-stone-100 dark:text-white dark:hover:bg-white/10 dark:focus:bg-neutral-700" aria-label="Previous">
+      <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+      <span class="sr-only">Previous</span>
+    </button>
+    <div class="flex items-center gap-x-1">
+      <span class="min-h-[38px] min-w-[38px] flex justify-center items-center bg-stone-100 text-stone-800 py-2 px-3 text-sm rounded-lg disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-700 dark:text-white" aria-current="page">1</span>
+      <span class="min-h-[38px] flex justify-center items-center text-stone-500 py-2 px-1.5 text-sm dark:text-neutral-500">of</span>
+      <span class="min-h-[38px] flex justify-center items-center text-stone-500 py-2 px-1.5 text-sm dark:text-neutral-500">3</span>
+    </div>
+    <button type="button" class="min-h-[38px] min-w-[38px] py-2 px-2.5 inline-flex justify-center items-center gap-x-2 text-sm rounded-lg text-stone-800 hover:bg-stone-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-stone-100 dark:text-white dark:hover:bg-white/10 dark:focus:bg-neutral-700" aria-label="Next">
+      <span class="sr-only">Next</span>
+      <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+    </button>
+  </nav>
+  <!-- End Pagination -->
+</div>

--- a/src/copy_destination_sets/includes/table.html
+++ b/src/copy_destination_sets/includes/table.html
@@ -1,0 +1,29 @@
+<div class="p-5 space-y-4 flex flex-col bg-white border border-stone-200 shadow-sm rounded-xl dark:bg-neutral-800 dark:border-neutral-700 mt-5">
+  <div>
+  {% include "./filters.html" %}
+  <div>
+    <!-- Tab Content -->
+    <div id="hs-pro-tabs-dut-all" role="tabpanel" aria-labelledby="hs-pro-tabs-dut-item-all">
+      <!-- Table Content -->
+      <div class="overflow-x-auto [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500">
+        <div class="min-w-full inline-block align-middle">
+          <!-- Table -->
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
+            {% include "./table_header.html" %}
+
+            <tbody class="divide-y divide-stone-200 dark:divide-neutral-700">
+              {% include "./table_item.html" %}
+            </tbody>
+          </table>
+          <!-- End Table -->
+        </div>
+      </div>
+      <!-- End Table Content -->
+
+      <!-- Footer -->
+      {% include "./pagination.html" %}
+      <!-- End Footer -->
+    </div>
+  </div>
+  </div>
+</div>

--- a/src/copy_destination_sets/includes/table_header.html
+++ b/src/copy_destination_sets/includes/table_header.html
@@ -28,13 +28,13 @@
     <th scope="col">
       <!-- Sort Dropdown -->
       <div class="hs-dropdown relative inline-flex w-full cursor-pointer">
-        <button id="hs-pro-eptsts" type="button" class="px-4 py-2.5 text-start w-full flex items-center gap-x-1 text-sm font-normal text-stone-500 focus:outline-none focus:bg-stone-100 dark:text-neutral-500 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+        <button id="hs-pro-eptca" type="button" class="px-4 py-2.5 text-start w-full flex items-center gap-x-1 text-sm font-normal text-stone-500 focus:outline-none focus:bg-stone-100 dark:text-neutral-500 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
           Created At
           <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg>
         </button>
 
         <!-- Dropdown -->
-        <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 w-40 transition-[opacity,margin] duration opacity-0 hidden z-10 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)] dark:bg-neutral-900" role="menu" aria-orientation="vertical" aria-labelledby="hs-pro-eptsts">
+        <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 w-40 transition-[opacity,margin] duration opacity-0 hidden z-10 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)] dark:bg-neutral-900" role="menu" aria-orientation="vertical" aria-labelledby="hs-pro-eptca">
           <div class="p-1">
             <button type="button" class="w-full flex items-center gap-x-3 py-1.5 px-2 rounded-lg text-[13px] font-normal text-stone-800 hover:bg-stone-100 disabled:opacity-50 disabled:pointer-events-none dark:text-neutral-300 focus:outline-none focus:bg-stone-100 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800">
               <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 7-7 7 7"/><path d="M12 19V5"/></svg>

--- a/src/copy_destination_sets/includes/table_header.html
+++ b/src/copy_destination_sets/includes/table_header.html
@@ -1,0 +1,54 @@
+<thead>
+  <tr>
+    <th scope="col" class="w-[30%]">
+      <!-- Sort Dropdown -->
+      <div class="hs-dropdown relative inline-flex w-full cursor-pointer">
+        <button id="hs-pro-eptits" type="button" class="px-5 py-2.5 text-start whitespace-nowrap w-full flex items-center gap-x-1 text-sm font-normal text-stone-500 focus:outline-none focus:bg-stone-100 dark:text-neutral-500 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+          Name
+        </button>
+      </div>
+    </th>
+
+    <th scope="col">
+      <div class="hs-dropdown relative inline-flex w-full cursor-pointer">
+        <button id="hs-pro-eptsts" type="button" class="px-4 py-2.5 text-start w-full flex items-center gap-x-1 text-sm font-normal text-stone-500 focus:outline-none focus:bg-stone-100 dark:text-neutral-500 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+          No. of Destinations
+        </button>
+      </div>
+    </th>
+
+    <th scope="col" >
+      <div class="hs-dropdown relative inline-flex w-full cursor-pointer">
+        <button id="hs-pro-eptai" type="button" class="px-5 py-2.5 text-start whitespace-nowrap w-full flex items-center gap-x-1 text-sm font-normal text-stone-500 focus:outline-none focus:bg-stone-100 dark:text-neutral-500 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+          Created By
+        </button>
+      </div>
+    </th>
+
+    <th scope="col">
+      <!-- Sort Dropdown -->
+      <div class="hs-dropdown relative inline-flex w-full cursor-pointer">
+        <button id="hs-pro-eptsts" type="button" class="px-4 py-2.5 text-start w-full flex items-center gap-x-1 text-sm font-normal text-stone-500 focus:outline-none focus:bg-stone-100 dark:text-neutral-500 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+          Created At
+          <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 15 5 5 5-5"/><path d="m7 9 5-5 5 5"/></svg>
+        </button>
+
+        <!-- Dropdown -->
+        <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 w-40 transition-[opacity,margin] duration opacity-0 hidden z-10 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)] dark:bg-neutral-900" role="menu" aria-orientation="vertical" aria-labelledby="hs-pro-eptsts">
+          <div class="p-1">
+            <button type="button" class="w-full flex items-center gap-x-3 py-1.5 px-2 rounded-lg text-[13px] font-normal text-stone-800 hover:bg-stone-100 disabled:opacity-50 disabled:pointer-events-none dark:text-neutral-300 focus:outline-none focus:bg-stone-100 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800">
+              <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 7-7 7 7"/><path d="M12 19V5"/></svg>
+              Latest
+            </button>
+            <button type="button" class="w-full flex items-center gap-x-3 py-1.5 px-2 rounded-lg text-[13px] font-normal text-stone-800 hover:bg-stone-100 disabled:opacity-50 disabled:pointer-events-none dark:text-neutral-300 focus:outline-none focus:bg-stone-100 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800">
+              <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" ><path d="M12 5v14"/><path d="m19 12-7 7-7-7"/></svg>
+              Oldest
+            </button>
+          </div>
+        </div>
+        <!-- End Dropdown -->
+      </div>
+      <!-- End Sort Dropdown -->
+    </th>
+  </tr>
+</thead>

--- a/src/copy_destination_sets/includes/table_header.html
+++ b/src/copy_destination_sets/includes/table_header.html
@@ -1,5 +1,9 @@
 <thead>
   <tr>
+    <th scope="col" class="pl-4 text-start">
+      <input type="checkbox" @change="toggleSelectAll($event)" :checked="isAllSelected()"
+        class="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-600 cursor-pointer">
+    </th>
     <th scope="col" class="w-[30%]">
       <!-- Sort Dropdown -->
       <div class="hs-dropdown relative inline-flex w-full cursor-pointer">
@@ -50,5 +54,6 @@
       </div>
       <!-- End Sort Dropdown -->
     </th>
+    <th scope="col" class="w-12"></th>
   </tr>
 </thead>

--- a/src/copy_destination_sets/includes/table_item.html
+++ b/src/copy_destination_sets/includes/table_item.html
@@ -31,9 +31,7 @@
   </td>
   <td class="size-px whitespace-nowrap px-4 py-1 text-start">
     <button @click="openDeleteModalForSingle('{{ destination_set.id }}')" type="button">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="shrink-0 size-3.5 text-red-500 hover:text-red-600">
-        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-      </svg>
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trash2-icon lucide-trash-2 text-red-500"><path d="M10 11v6"/><path d="M14 11v6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
     </button>
   </td>
 </tr>

--- a/src/copy_destination_sets/includes/table_item.html
+++ b/src/copy_destination_sets/includes/table_item.html
@@ -1,5 +1,9 @@
 {% for destination_set in copy_destination_set %}
-<tr>
+<tr x-show="!deletedDestinationSetIds.includes('{{ destination_set.id }}')">
+  <td class="size-px whitespace-nowrap px-4 py-3">
+    <input type="checkbox" x-model="selectedDestinationSetIds" value="{{ destination_set.id }}"
+      class="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-600 cursor-pointer">
+  </td>
   <td class="size-px whitespace-nowrap px-5 py-3">
     <div class="w-full flex items-center gap-x-3">
       <div class="grow flex space-x-2">
@@ -26,23 +30,11 @@
     </span>
   </td>
   <td class="size-px whitespace-nowrap px-4 py-1 text-start">
-    <div class="hs-dropdown [--auto-close:inside] [--placement:bottom-right] relative inline-flex">
-      <button id="hs-pro-{{ destination_set.id }}" type="button" class="size-7 inline-flex justify-center items-center gap-x-2 rounded-lg border border-stone-200 bg-white text-stone-800 shadow-sm hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-stone-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
-        <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle></svg>
-      </button>
-
-      <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 w-48 transition-[opacity,margin] duration opacity-0 hidden z-10 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)] dark:bg-neutral-900" role="menu" aria-orientation="vertical" aria-labelledby="hs-pro-1">
-        <div class="p-1">
-          <button type="button" class="w-full flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="shrink-0 size-3.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-            </svg>            
-            Delete
-          </button>
-        </div>
-      </div>
-    </div>
+    <button @click="openDeleteModalForSingle('{{ destination_set.id }}')" type="button">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="shrink-0 size-3.5 text-red-500 hover:text-red-600">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+      </svg>
+    </button>
   </td>
-  
 </tr>
 {% endfor %}

--- a/src/copy_destination_sets/includes/table_item.html
+++ b/src/copy_destination_sets/includes/table_item.html
@@ -1,0 +1,45 @@
+{% for destination_set in copy_destination_set %}
+<tr>
+  <td class="size-px whitespace-nowrap px-5 py-3">
+    <div class="w-full flex items-center gap-x-3">
+      <div class="grow flex space-x-2">
+        <a class="text-sm font-medium text-stone-800 hover:text-green-600 decoration-2 hover:underline focus:outline-none focus:underline focus:text-green-600 dark:text-neutral-200 dark:hover:text-green-500 dark:focus:text-green-500"
+          href="#">
+          {{ destination_set.name }}
+        </a>
+       </div>
+  </td>
+  <td class="size-px whitespace-nowrap px-4 py-3">
+    <span class="text-sm text-stone-600 dark:text-neutral-400">
+      {{ destination_set.number_of_destinations }}
+    </span>
+  </td>
+  <td class="size-px whitespace-nowrap px-4 py-1">
+    <span class="text-sm text-stone-600 dark:text-neutral-400">
+      {{ destination_set.created_by }}
+    </span>
+  </td>
+  <td class="size-px whitespace-nowrap px-4 py-1">
+    <span class="text-sm text-stone-600 dark:text-neutral-400">
+      {{ destination_set.created_at }}
+    </span>
+  </td>
+    <td class="size-px whitespace-nowrap px-4 py-1 text-start">
+    <div class="hs-dropdown [--auto-close:inside] [--placement:bottom-right] relative inline-flex">
+      <button id="hs-pro-1" type="button" class="size-7 inline-flex justify-center items-center gap-x-2 rounded-lg border border-stone-200 bg-white text-stone-800 shadow-sm hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-stone-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+        <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle></svg>
+      </button>
+
+      <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 w-48 transition-[opacity,margin] duration opacity-0 hidden z-10 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] dark:shadow-[0_10px_40px_10px_rgba(0,0,0,0.2)] dark:bg-neutral-900" role="menu" aria-orientation="vertical" aria-labelledby="hs-pro-1">
+        <div class="p-1">
+          <button type="button" class="w-full flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="shrink-0 size-3.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+            </svg>            
+            Delete
+          </button>
+    </div>
+  </div></td>
+  
+</tr>
+{% endfor %}

--- a/src/copy_destination_sets/includes/table_item.html
+++ b/src/copy_destination_sets/includes/table_item.html
@@ -7,7 +7,8 @@
           href="#">
           {{ destination_set.name }}
         </a>
-       </div>
+      </div>
+    </div>
   </td>
   <td class="size-px whitespace-nowrap px-4 py-3">
     <span class="text-sm text-stone-600 dark:text-neutral-400">
@@ -24,9 +25,9 @@
       {{ destination_set.created_at }}
     </span>
   </td>
-    <td class="size-px whitespace-nowrap px-4 py-1 text-start">
+  <td class="size-px whitespace-nowrap px-4 py-1 text-start">
     <div class="hs-dropdown [--auto-close:inside] [--placement:bottom-right] relative inline-flex">
-      <button id="hs-pro-1" type="button" class="size-7 inline-flex justify-center items-center gap-x-2 rounded-lg border border-stone-200 bg-white text-stone-800 shadow-sm hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-stone-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
+      <button id="hs-pro-{{ destination_set.id }}" type="button" class="size-7 inline-flex justify-center items-center gap-x-2 rounded-lg border border-stone-200 bg-white text-stone-800 shadow-sm hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:bg-stone-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
         <svg class="shrink-0 size-3.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle></svg>
       </button>
 
@@ -38,8 +39,10 @@
             </svg>            
             Delete
           </button>
+        </div>
+      </div>
     </div>
-  </div></td>
+  </td>
   
 </tr>
 {% endfor %}

--- a/src/copy_destination_sets/index.html
+++ b/src/copy_destination_sets/index.html
@@ -1,0 +1,16 @@
+---
+slug: copy-destination-sets
+tags: testpress
+title: Copy Destination Sets
+---
+
+{% extends "layouts/admin_base.html" %}
+
+{% block body_class %}overflow-y-scroll min-h-screen bg-gray-100{% endblock %}
+{% block content %}
+<div class="py-10 max-w-7xl mx-auto lg:px-8 px-4">
+  {% include "./includes/breadcrumbs.html" %}
+	{% include "./includes/header.html" %}
+  {% include "./includes/table.html" %}
+</div>
+{% endblock %}

--- a/src/copy_destination_sets/index.html
+++ b/src/copy_destination_sets/index.html
@@ -8,9 +8,65 @@ title: Copy Destination Sets
 
 {% block body_class %}overflow-y-scroll min-h-screen bg-gray-100{% endblock %}
 {% block content %}
-<div class="py-10 max-w-7xl mx-auto lg:px-8 px-4">
+<div class="py-10 max-w-7xl mx-auto lg:px-8 px-4"
+  x-data="copyDestinationSetsData([{% for destination_set in copy_destination_set %}'{{ destination_set.id }}'{% if not loop.last %}, {% endif %}{% endfor %}])">
   {% include "./includes/breadcrumbs.html" %}
 	{% include "./includes/header.html" %}
   {% include "./includes/table.html" %}
+  {% include "./includes/delete_modal.html" %}
 </div>
+{% endblock %}
+
+{% block script %}
+<script>
+  function copyDestinationSetsData(allDestinationSetIds = []) {
+    return {
+      showDeleteModal: false,
+      selectedDestinationSetIds: [],
+      deletedDestinationSetIds: [],
+      allDestinationSetIds,
+
+      getAvailableDestinationSetIds() {
+        return this.allDestinationSetIds.filter(id => !this.deletedDestinationSetIds.includes(id));
+      },
+
+      isAllSelected() {
+        const availableIds = this.getAvailableDestinationSetIds();
+        return availableIds.length > 0 && availableIds.every(id => this.selectedDestinationSetIds.includes(id));
+      },
+
+      toggleSelectAll(event) {
+        this.selectedDestinationSetIds = event.target.checked ? [...this.getAvailableDestinationSetIds()] : [];
+      },
+
+      openDeleteModalForSingle(id) {
+        this.selectedDestinationSetIds = [String(id)];
+        this.showDeleteModal = true;
+      },
+
+      deleteDestinationSets(force = false) {
+        const idsToRemove = [...this.selectedDestinationSetIds];
+
+        if (!idsToRemove.length) {
+          this.showDeleteModal = false;
+          return;
+        }
+
+        if (!force) {
+          this.showDeleteModal = true;
+          return;
+        }
+
+        idsToRemove.forEach(id => {
+          if (!this.deletedDestinationSetIds.includes(id)) {
+            this.deletedDestinationSetIds.push(id);
+          }
+        });
+
+        this.selectedDestinationSetIds = [];
+        this.showDeleteModal = false;
+      }
+    };
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
\- Add a list page to display all available destination sets for content copying.
\- Enable users to easily view and navigate between Copy Content and Destination Sets pages.