### PR TITLE
feat: Implement dynamic sticky header offset calculation for notes content.

### DIFF
--- a/src/content_detail_page/includes/content_scripts.html
+++ b/src/content_detail_page/includes/content_scripts.html
@@ -3,7 +3,6 @@
     Alpine.data('contents', () => ({
       contentPage: 'VIDEO',
       isOpen: false,
-      expanded: false,
       expanded: [],
       section: 'ATTEMPT',
       showExamModeModal: false,
@@ -17,6 +16,8 @@
       isFeedbackSubmitted: false,
       stickyOffset: 0,
       globalHeaderHeight: 0,
+      observer: null,
+      resizeHandler: null,
 
       exam: {
         ['x-html']() {
@@ -39,19 +40,27 @@
           else window.location = "{{ '/content_detail_page/discussions'|url }}"
         })
 
+        this.resizeHandler = () => this.setStickyOffset()
+        window.addEventListener('resize', this.resizeHandler)
+
         this.$nextTick(() => {
           this.setStickyOffset()
 
           // Recalculate if any stackable header changes size (e.g. icon hidden/shown)
-          const observer = new ResizeObserver(() => this.setStickyOffset())
+          this.observer = new ResizeObserver(() => this.setStickyOffset())
           document
             .querySelectorAll('.js-stackable-header')
-            .forEach((el) => observer.observe(el))
+            .forEach((el) => this.observer.observe(el))
         })
+      },
 
-        window.addEventListener('resize', () => {
-          this.setStickyOffset()
-        })
+      destroy() {
+        if (this.resizeHandler) {
+          window.removeEventListener('resize', this.resizeHandler)
+        }
+        if (this.observer) {
+          this.observer.disconnect()
+        }
       },
 
       setStickyOffset() {

--- a/src/content_detail_page/includes/content_scripts.html
+++ b/src/content_detail_page/includes/content_scripts.html
@@ -1,38 +1,72 @@
 <script>
-  document.addEventListener("alpine:init", () => {
-    Alpine.data("contents", () => ({
-      contentPage: "VIDEO",
+  document.addEventListener('alpine:init', () => {
+    Alpine.data('contents', () => ({
+      contentPage: 'VIDEO',
       isOpen: false,
-      expanded: false, 
+      expanded: false,
       expanded: [],
-      section:"ATTEMPT",
-      showExamModeModal:false,
-      showResultModal:false,
-      showPreTestModal:false,
+      section: 'ATTEMPT',
+      showExamModeModal: false,
+      showResultModal: false,
+      showPreTestModal: false,
       tab: 'running',
       activeTab: '{{ tab }}',
       isCustomizeOpen: false,
       contentType: 'topics',
       isFeedbackModalOpen: false,
       isFeedbackSubmitted: false,
-      
+      stickyOffset: 0,
+      globalHeaderHeight: 0,
+
       exam: {
-        ["x-html"](){
-          if(this.section === "ATTEMPT") return `{% include "./previous_attempts.html" %}`;
-          else return `{% include "./leaderboard.html" %}`;
-        }
+        ['x-html']() {
+          if (this.section === 'ATTEMPT')
+            return `{% include "./previous_attempts.html" %}`
+          else return `{% include "./leaderboard.html" %}`
+        },
       },
-      
-      init(){
+
+      init() {
         this.$watch('activeTab', (value) => {
-          if(value == 'running') window.location="{{ '/content_detail_page/running'|url }}" 
-          else if (value== 'upcoming') window.location="{{ '/content_detail_page/upcoming'|url }}"
-          else if (value== 'history') window.location="{{ '/content_detail_page/history'|url }}"
-          else if (value== 'leaderboard') window.location="{{ '/content_detail_page/leaderboard'|url }}"
-          else window.location="{{ '/content_detail_page/discussions'|url }}"
-        });
-      }
-      
-    }));
-  });
+          if (value == 'running')
+            window.location = "{{ '/content_detail_page/running'|url }}"
+          else if (value == 'upcoming')
+            window.location = "{{ '/content_detail_page/upcoming'|url }}"
+          else if (value == 'history')
+            window.location = "{{ '/content_detail_page/history'|url }}"
+          else if (value == 'leaderboard')
+            window.location = "{{ '/content_detail_page/leaderboard'|url }}"
+          else window.location = "{{ '/content_detail_page/discussions'|url }}"
+        })
+
+        this.$nextTick(() => {
+          this.setStickyOffset()
+
+          // Recalculate if any stackable header changes size (e.g. icon hidden/shown)
+          const observer = new ResizeObserver(() => this.setStickyOffset())
+          document
+            .querySelectorAll('.js-stackable-header')
+            .forEach((el) => observer.observe(el))
+        })
+
+        window.addEventListener('resize', () => {
+          this.setStickyOffset()
+        })
+      },
+
+      setStickyOffset() {
+        const globalHeader =
+          document.getElementById('global-header') ||
+          document.querySelector('header') ||
+          document.querySelector('.page-header')
+        const mobileBar = document.getElementById('mobile-sticky-bar')
+
+        const gHeight = (globalHeader && globalHeader.offsetHeight) || 0
+        const mHeight = (mobileBar && mobileBar.offsetHeight) || 0
+
+        this.globalHeaderHeight = gHeight
+        this.stickyOffset = gHeight + mHeight
+      },
+    }))
+  })
 </script>

--- a/src/content_detail_page/includes/mobile_sidebar.html
+++ b/src/content_detail_page/includes/mobile_sidebar.html
@@ -193,8 +193,7 @@
 <div
   id="mobile-sticky-bar"
   class="js-stackable-header sticky z-30 flex items-center gap-x-6 bg-white px-4 py-3 shadow-sm sm:px-6 xl:hidden dark:bg-neutral-800 dark:border-b dark:border-neutral-700"
-  :style="{ top: globalHeaderHeight + 'px' }"
->
+  :style="{ top: globalHeaderHeight + 'px' }">
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/src/content_detail_page/includes/mobile_sidebar.html
+++ b/src/content_detail_page/includes/mobile_sidebar.html
@@ -9,7 +9,18 @@
       From: "opacity-100"
       To: "opacity-0"
   -->
-  <div class="fixed inset-0 bg-gray-900/80 dark:bg-neutral-900/80" x-transition:enter="transition-opacity ease-linear duration-300" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="transition-opacity ease-linear duration-300" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" x-show="isOpen" @click="isOpen = !isOpen" x-cloak></div>
+  <div
+    class="fixed inset-0 bg-gray-900/80 dark:bg-neutral-900/80"
+    x-transition:enter="transition-opacity ease-linear duration-300"
+    x-transition:enter-start="opacity-0"
+    x-transition:enter-end="opacity-100"
+    x-transition:leave="transition-opacity ease-linear duration-300"
+    x-transition:leave-start="opacity-100"
+    x-transition:leave-end="opacity-0"
+    x-show="isOpen"
+    @click="isOpen = !isOpen"
+    x-cloak
+  ></div>
 
   <div class="fixed inset-0 pointer-events-none flex">
     <!--
@@ -22,7 +33,17 @@
         From: "translate-x-0"
         To: "-translate-x-full"
     -->
-    <div class="relative mr-16 flex w-full max-w-xs flex-1 pointer-events-auto" x-transition:enter="transition ease-in-out duration-300 transform" x-transition:enter-start="-translate-x-full" x-transition:enter-end="translate-x-0" x-transition:leave="transition ease-in-out duration-300 transform" x-transition:leave-start="translate-x-0" x-transition:leave-end="-translate-x-full" x-show="isOpen" x-cloak>
+    <div
+      class="relative mr-16 flex w-full max-w-xs flex-1 pointer-events-auto"
+      x-transition:enter="transition ease-in-out duration-300 transform"
+      x-transition:enter-start="-translate-x-full"
+      x-transition:enter-end="translate-x-0"
+      x-transition:leave="transition ease-in-out duration-300 transform"
+      x-transition:leave-start="translate-x-0"
+      x-transition:leave-end="-translate-x-full"
+      x-show="isOpen"
+      x-cloak
+    >
       <!--
         Close button, show/hide based on off-canvas menu state.
 
@@ -33,61 +54,133 @@
           From: "opacity-100"
           To: "opacity-0"
       -->
-      <div class="absolute left-full top-0 flex w-16 justify-center pt-5" x-transition:enter="ease-in-out duration-300" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="ease-in-out duration-300" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" x-show="isOpen" x-cloak>
+      <div
+        class="absolute left-full top-0 flex w-16 justify-center pt-5"
+        x-transition:enter="ease-in-out duration-300"
+        x-transition:enter-start="opacity-0"
+        x-transition:enter-end="opacity-100"
+        x-transition:leave="ease-in-out duration-300"
+        x-transition:leave-start="opacity-100"
+        x-transition:leave-end="opacity-0"
+        x-show="isOpen"
+        x-cloak
+      >
         <button type="button" class="-m-2.5 p-2.5" @click="isOpen = !isOpen">
           <span class="sr-only">Close sidebar</span>
-          <svg class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          <svg
+            class="h-6 w-6 text-white"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M6 18L18 6M6 6l12 12"
+            />
           </svg>
         </button>
       </div>
 
       <!-- Sidebar component, swap this element with another sidebar if you like -->
-      <div class="flex grow flex-col gap-y-2 bg-white pb-2 dark:bg-neutral-900" x-data="search">
+      <div
+        class="flex grow flex-col gap-y-2 bg-white pb-2 dark:bg-neutral-900"
+        x-data="search"
+      >
         <div class="px-6">
           <div class="flex h-16 shrink-0 items-center hover:cursor-pointer">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-emerald-500 dark:text-emerald-400">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-            </svg> 
-            <p class="ml-2 text-md text-emerald-500 dark:text-emerald-400">back</p>           
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="w-5 h-5 text-emerald-500 dark:text-emerald-400"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M15.75 19.5L8.25 12l7.5-7.5"
+              />
+            </svg>
+            <p class="ml-2 text-md text-emerald-500 dark:text-emerald-400">
+              back
+            </p>
           </div>
           {% include "./heading_section.html" %}
         </div>
-        <nav class="px-6 flex flex-1 flex-col mt-3 px-6 overflow-y-auto
-            [&::-webkit-scrollbar]:w-2 
-            [&::-webkit-scrollbar-thumb]:rounded-full
-            [&::-webkit-scrollbar-track]:bg-gray-100
-            dark:[&::-webkit-scrollbar-track]:bg-neutral-700
-            [&::-webkit-scrollbar-thumb]:bg-gray-300
-            dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500"
-          @scroll.debounce.300ms="scrolledbottom = ($el.scrollTop + $el.clientHeight >= $el.scrollHeight)">
-          <ul role="list" class="flex flex-1 flex-col gap-y-7 ">
-            <div x-show="showSearchResults" >
+        <nav
+          class="px-6 flex flex-1 flex-col mt-3 px-6 overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500"
+          @scroll.debounce.300ms="scrolledbottom = ($el.scrollTop + $el.clientHeight >= $el.scrollHeight)"
+        >
+          <ul role="list" class="flex flex-1 flex-col gap-y-7">
+            <div x-show="showSearchResults">
               <div class="flow-root">
-                <ul x-show="!searching && !noResults" x-ref="search" role="list" class="-mb-8">
-                  {% for content in contents_list_page1 %}
-                  {% include "./content.html" %}
-                  {% endfor %}
+                <ul
+                  x-show="!searching && !noResults"
+                  x-ref="search"
+                  role="list"
+                  class="-mb-8"
+                >
+                  {% for content in contents_list_page1 %} {% include
+                  "./content.html" %} {% endfor %}
                 </ul>
-                <div x-show="noResults && !searching" class="mx-auto text-center mt-20 mb-20 py-5 sm:p-6">
+                <div
+                  x-show="noResults && !searching"
+                  class="mx-auto text-center mt-20 mb-20 py-5 sm:p-6"
+                >
                   <div class="hidden mx-auto flex items-center justify-center">
-                    <object class="hidden h-32 w-32" data="https://dhmmnd775wlnp.cloudfront.net/e09c53a5bc/images/huzzah/hs-huzzah-33.svg" type="image/svg+xml"></object>
+                    <object
+                      class="hidden h-32 w-32"
+                      data="https://dhmmnd775wlnp.cloudfront.net/e09c53a5bc/images/huzzah/hs-huzzah-33.svg"
+                      type="image/svg+xml"
+                    ></object>
                   </div>
-                  <h3 class="mt-2 text-lg leading-6 font-semibold text-gray-700 dark:text-neutral-300">No results found</h3>
-                  <p class="mt-1 text-gray-600 dark:text-neutral-400">We can’t find anything with that term at the moment, try searching something else.</p>
+                  <h3
+                    class="mt-2 text-lg leading-6 font-semibold text-gray-700 dark:text-neutral-300"
+                  >
+                    No results found
+                  </h3>
+                  <p class="mt-1 text-gray-600 dark:text-neutral-400">
+                    We can’t find anything with that term at the moment, try
+                    searching something else.
+                  </p>
                 </div>
-                <div x-show="searching" class="pt-6 mt-4 mb-2 flex justify-center items-center space-x-2" role="status" style="display: none;">
-                  <svg aria-hidden="true" class="w-8 h-8 text-gray-200 animate-spin fill-emerald-600 dark:fill-emerald-400 dark:text-neutral-400" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"></path>
-                      <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"></path>
+                <div
+                  x-show="searching"
+                  class="pt-6 mt-4 mb-2 flex justify-center items-center space-x-2"
+                  role="status"
+                  style="display: none"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="w-8 h-8 text-gray-200 animate-spin fill-emerald-600 dark:fill-emerald-400 dark:text-neutral-400"
+                    viewBox="0 0 100 101"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+                      fill="currentColor"
+                    ></path>
+                    <path
+                      d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+                      fill="currentFill"
+                    ></path>
                   </svg>
                 </div>
+              </div>
             </div>
-          </div>
             <li>
-              <ul role="list" x-show="!searching && !showSearchResults"  class="-mx-2">
+              <ul
+                role="list"
+                x-show="!searching && !showSearchResults"
+                class="-mx-2"
+              >
                 <!-- Current: "bg-gray-50 text-emerald-600", Default: "text-gray-700 hover:text-emerald-600 hover:bg-gray-50" -->
-                {% include "./chapters.html" %}  
+                {% include "./chapters.html" %}
               </ul>
             </li>
           </ul>
@@ -97,23 +190,82 @@
   </div>
 </div>
 
-<div class="sticky top-16 z-30 flex items-center gap-x-6 bg-white px-4 py-3 shadow-sm sm:px-6 xl:hidden dark:bg-neutral-800 dark:border-b dark:border-neutral-700">
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 dark:text-neutral-400">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+<div
+  id="mobile-sticky-bar"
+  class="js-stackable-header sticky z-30 flex items-center gap-x-6 bg-white px-4 py-3 shadow-sm sm:px-6 xl:hidden dark:bg-neutral-800 dark:border-b dark:border-neutral-700"
+  :style="{ top: globalHeaderHeight + 'px' }"
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="w-6 h-6 dark:text-neutral-400"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M15.75 19.5L8.25 12l7.5-7.5"
+    />
   </svg>
-  <div class="flex-1 text-sm font-semibold leading-6 text-gray-900 line-clamp-2"></div>
+  <div
+    class="flex-1 text-sm font-semibold leading-6 text-gray-900 line-clamp-2"
+  ></div>
   <div class="flex justify-end space-x-2">
-    <a class="inline-flex items-center gap-x-1.5 rounded-md px-2 py-2 text-sm font-semibold text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300">
-      <svg class="h-5 w-5" viewBox="0 0 56 56" fill="currentColor" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M21.871 15.566c.281 0 .422-.164.469-.421.797-3.75.75-3.891 4.664-4.688.281-.047.445-.21.445-.469 0-.281-.164-.445-.445-.492-3.914-.797-3.867-.937-4.664-4.664-.047-.258-.188-.445-.469-.445-.281 0-.422.187-.492.445-.774 3.727-.727 3.867-4.664 4.664-.258.047-.445.211-.445.492 0 .258.187.422.445.469 3.937.797 3.89.938 4.664 4.688.07.257.21.421.492.421Zm19.36 8.274c.328 0 .515-.211.562-.516.82-4.453.844-4.734 5.554-5.555.305-.046.54-.257.54-.585 0-.329-.235-.516-.54-.586-4.71-.797-4.734-1.078-5.554-5.532-.047-.304-.234-.539-.562-.539-.329 0-.54.235-.586.54-.797 4.453-.82 4.734-5.532 5.53-.328.071-.539.258-.539.587 0 .328.211.539.54.585 4.71.82 4.734 1.102 5.53 5.555.047.305.258.516.587.516ZM9.027 30.566c.329 0 .516-.234.563-.539.82-4.453.844-4.734 5.555-5.53.304-.071.539-.259.539-.587 0-.328-.235-.539-.54-.586-4.71-.82-4.734-1.101-5.554-5.555-.047-.304-.235-.515-.563-.515-.328 0-.539.21-.585.515-.82 4.454-.82 4.735-5.532 5.555-.328.047-.539.258-.539.586 0 .328.211.516.54.586 4.71.797 4.71 1.078 5.53 5.531.047.305.258.54.586.54Zm40.032 20.04c.984 1.007 2.671 1.007 3.609 0 .938-1.055.96-2.626 0-3.61l-22.289-22.36c-.984-.984-2.672-.984-3.61 0-.96 1.055-.96 2.65 0 3.634Zm-28.899.374c.422 0 .727-.304.774-.75.773-6.257 1.078-6.421 7.43-7.453.515-.093.82-.328.82-.797 0-.445-.305-.726-.727-.796-6.398-1.22-6.75-1.196-7.523-7.453-.047-.446-.352-.75-.774-.75-.445 0-.75.304-.797.726-.82 6.352-1.054 6.563-7.523 7.477-.422.047-.727.351-.727.797 0 .445.305.703.727.796 6.469 1.242 6.68 1.242 7.523 7.5a.774.774 0 0 0 .797.703Zm29.743-1.992L35.44 34.504l1.149-1.125 14.46 14.484c.423.399.516.867.141 1.29-.422.35-.867.28-1.288-.165Z"/></svg>
+    <a
+      class="inline-flex items-center gap-x-1.5 rounded-md px-2 py-2 text-sm font-semibold text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
+    >
+      <svg
+        class="h-5 w-5"
+        viewBox="0 0 56 56"
+        fill="currentColor"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21.871 15.566c.281 0 .422-.164.469-.421.797-3.75.75-3.891 4.664-4.688.281-.047.445-.21.445-.469 0-.281-.164-.445-.445-.492-3.914-.797-3.867-.937-4.664-4.664-.047-.258-.188-.445-.469-.445-.281 0-.422.187-.492.445-.774 3.727-.727 3.867-4.664 4.664-.258.047-.445.211-.445.492 0 .258.187.422.445.469 3.937.797 3.89.938 4.664 4.688.07.257.21.421.492.421Zm19.36 8.274c.328 0 .515-.211.562-.516.82-4.453.844-4.734 5.554-5.555.305-.046.54-.257.54-.585 0-.329-.235-.516-.54-.586-4.71-.797-4.734-1.078-5.554-5.532-.047-.304-.234-.539-.562-.539-.329 0-.54.235-.586.54-.797 4.453-.82 4.734-5.532 5.53-.328.071-.539.258-.539.587 0 .328.211.539.54.585 4.71.82 4.734 1.102 5.53 5.555.047.305.258.516.587.516ZM9.027 30.566c.329 0 .516-.234.563-.539.82-4.453.844-4.734 5.555-5.53.304-.071.539-.259.539-.587 0-.328-.235-.539-.54-.586-4.71-.82-4.734-1.101-5.554-5.555-.047-.304-.235-.515-.563-.515-.328 0-.539.21-.585.515-.82 4.454-.82 4.735-5.532 5.555-.328.047-.539.258-.539.586 0 .328.211.516.54.586 4.71.797 4.71 1.078 5.53 5.531.047.305.258.54.586.54Zm40.032 20.04c.984 1.007 2.671 1.007 3.609 0 .938-1.055.96-2.626 0-3.61l-22.289-22.36c-.984-.984-2.672-.984-3.61 0-.96 1.055-.96 2.65 0 3.634Zm-28.899.374c.422 0 .727-.304.774-.75.773-6.257 1.078-6.421 7.43-7.453.515-.093.82-.328.82-.797 0-.445-.305-.726-.727-.796-6.398-1.22-6.75-1.196-7.523-7.453-.047-.446-.352-.75-.774-.75-.445 0-.75.304-.797.726-.82 6.352-1.054 6.563-7.523 7.477-.422.047-.727.351-.727.797 0 .445.305.703.727.796 6.469 1.242 6.68 1.242 7.523 7.5a.774.774 0 0 0 .797.703Zm29.743-1.992L35.44 34.504l1.149-1.125 14.46 14.484c.423.399.516.867.141 1.29-.422.35-.867.28-1.288-.165Z"
+        />
+      </svg>
     </a>
-    <a class="inline-flex items-center gap-x-1.5 rounded-md px-2 py-2 text-sm font-semibold text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.438 60.438 0 0 0-.491 6.347A48.62 48.62 0 0 1 12 20.904a48.62 48.62 0 0 1 8.232-4.41 60.46 60.46 0 0 0-.491-6.347m-15.482 0a50.636 50.636 0 0 0-2.658-.813A59.906 59.906 0 0 1 12 3.493a59.903 59.903 0 0 1 10.399 5.84 51.39 51.39 0 0 0-2.658.814m-15.482 0A50.717 50.717 0 0 1 12 13.489a50.702 50.702 0 0 1 7.74-3.342M6.75 15a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 0v-3.675A55.378 55.378 0 0 1 12 8.443m-7.007 11.55A5.981 5.981 0 0 0 6.75 15.75v-1.5"/></svg>
+    <a
+      class="inline-flex items-center gap-x-1.5 rounded-md px-2 py-2 text-sm font-semibold text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="w-5 h-5"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M4.26 10.147a60.438 60.438 0 0 0-.491 6.347A48.62 48.62 0 0 1 12 20.904a48.62 48.62 0 0 1 8.232-4.41 60.46 60.46 0 0 0-.491-6.347m-15.482 0a50.636 50.636 0 0 0-2.658-.813A59.906 59.906 0 0 1 12 3.493a59.903 59.903 0 0 1 10.399 5.84 51.39 51.39 0 0 0-2.658.814m-15.482 0A50.717 50.717 0 0 1 12 13.489a50.702 50.702 0 0 1 7.74-3.342M6.75 15a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 0v-3.675A55.378 55.378 0 0 1 12 8.443m-7.007 11.55A5.981 5.981 0 0 0 6.75 15.75v-1.5"
+        />
+      </svg>
     </a>
   </div>
-  <button type="button" class="-m-2.5 p-2.5 text-gray-700 lg:hidden dark:text-neutral-400" @click="isOpen = !isOpen">
+  <button
+    type="button"
+    class="-m-2.5 p-2.5 text-gray-700 lg:hidden dark:text-neutral-400"
+    @click="isOpen = !isOpen"
+  >
     <span class="sr-only">Open sidebar</span>
-    <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+    <svg
+      class="h-6 w-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+      />
     </svg>
   </button>
 </div>

--- a/src/content_detail_page/includes/mobile_sidebar.html
+++ b/src/content_detail_page/includes/mobile_sidebar.html
@@ -112,7 +112,7 @@
           {% include "./heading_section.html" %}
         </div>
         <nav
-          class="px-6 flex flex-1 flex-col mt-3 px-6 overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500"
+          class="flex flex-1 flex-col mt-3 px-6 overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 dark:[&::-webkit-scrollbar-track]:bg-neutral-700 [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500"
           @scroll.debounce.300ms="scrolledbottom = ($el.scrollTop + $el.clientHeight >= $el.scrollHeight)"
         >
           <ul role="list" class="flex flex-1 flex-col gap-y-7">

--- a/src/content_detail_page/includes/viewer_header.html
+++ b/src/content_detail_page/includes/viewer_header.html
@@ -1,47 +1,113 @@
-  <header class="lg:ms-[24rem] fixed top-0 inset-x-0 flex flex-wrap md:justify-start md:flex-nowrap z-[50] bg-white border-b border-gray-200 dark:bg-neutral-900 dark:border-neutral-700">
-    <div class="flex justify-between xl:grid xl:grid-cols-3 basis-full items-center w-full py-3 px-2 sm:px-5">
-      <div class="xl:col-span-1 flex items-center md:gap-x-3">
-
-        <div class="hidden lg:block min-w-80 xl:w-full">
-          <!-- Search Input -->
-          <div class="relative">
-            <div class="absolute inset-y-0 start-0 flex items-center pointer-events-none z-[20] ps-3.5">
-              <svg class="shrink-0 size-4 text-gray-400 dark:text-white/60" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="11" cy="11" r="8" />
-                <path d="m21 21-4.3-4.3" />
-              </svg>
-            </div>
-            <input type="text" class="py-2 ps-10 pe-16 block w-full bg-white border-gray-200 rounded-lg text-sm focus:border-transparent focus:border-b-stone-200 focus:outline-none focus:ring-0 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-400 dark:placeholder:text-neutral-400 dark:focus:ring-neutral-600" placeholder="Search" data-hs-overlay="#hs-pro-dnsm">
-            <div class="hidden absolute inset-y-0 end-0 flex items-center z-[20] pe-1">
-              <button type="button" class="inline-flex shrink-0 justify-center items-center size-6 rounded-full text-gray-500 hover:text-primary-600 focus:outline-hidden focus:text-primary-600 dark:text-neutral-500 dark:hover:text-primary-500 dark:focus:text-primary-500" aria-label="Close">
-                <span class="sr-only">Close</span>
-                <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <circle cx="12" cy="12" r="10" />
-                  <path d="m15 9-6 6" />
-                  <path d="m9 9 6 6" />
-                </svg>
-              </button>
-            </div>
-            <div class="absolute inset-y-0 end-0 flex items-center pointer-events-none z-[20] pe-3 text-gray-400">
-              <svg class="shrink-0 size-3 text-gray-400 dark:text-white/60" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
-              </svg>
-              <span class="mx-1">
-                <svg class="shrink-0 size-3 text-gray-400 dark:text-white/60" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M5 12h14" />
-                  <path d="M12 5v14" />
-                </svg>
-              </span>
-              <span class="text-xs">/</span>
-            </div>
+<header
+  id="global-header"
+  class="js-stackable-header lg:ms-[24rem] fixed top-0 inset-x-0 flex flex-wrap md:justify-start md:flex-nowrap z-[50] bg-white border-b border-gray-200 dark:bg-neutral-900 dark:border-neutral-700"
+>
+  <div
+    class="flex justify-between xl:grid xl:grid-cols-3 basis-full items-center w-full py-3 px-2 sm:px-5"
+  >
+    <div class="xl:col-span-1 flex items-center md:gap-x-3">
+      <div class="hidden lg:block min-w-80 xl:w-full">
+        <!-- Search Input -->
+        <div class="relative">
+          <div
+            class="absolute inset-y-0 start-0 flex items-center pointer-events-none z-[20] ps-3.5"
+          >
+            <svg
+              class="shrink-0 size-4 text-gray-400 dark:text-white/60"
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
           </div>
-          <!-- End Search Input -->
+          <input
+            type="text"
+            class="py-2 ps-10 pe-16 block w-full bg-white border-gray-200 rounded-lg text-sm focus:border-transparent focus:border-b-stone-200 focus:outline-none focus:ring-0 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-400 dark:placeholder:text-neutral-400 dark:focus:ring-neutral-600"
+            placeholder="Search"
+            data-hs-overlay="#hs-pro-dnsm"
+          />
+          <div
+            class="hidden absolute inset-y-0 end-0 flex items-center z-[20] pe-1"
+          >
+            <button
+              type="button"
+              class="inline-flex shrink-0 justify-center items-center size-6 rounded-full text-gray-500 hover:text-primary-600 focus:outline-hidden focus:text-primary-600 dark:text-neutral-500 dark:hover:text-primary-500 dark:focus:text-primary-500"
+              aria-label="Close"
+            >
+              <span class="sr-only">Close</span>
+              <svg
+                class="shrink-0 size-4"
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="m15 9-6 6" />
+                <path d="m9 9 6 6" />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="absolute inset-y-0 end-0 flex items-center pointer-events-none z-[20] pe-3 text-gray-400"
+          >
+            <svg
+              class="shrink-0 size-3 text-gray-400 dark:text-white/60"
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3"
+              />
+            </svg>
+            <span class="mx-1">
+              <svg
+                class="shrink-0 size-3 text-gray-400 dark:text-white/60"
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M5 12h14" />
+                <path d="M12 5v14" />
+              </svg>
+            </span>
+            <span class="text-xs">/</span>
+          </div>
         </div>
+        <!-- End Search Input -->
       </div>
+    </div>
 
-      <div class="xl:col-span-2 flex justify-end items-center gap-x-2">
-        <div class="hs-dropdown [--placement:bottom-right] relative inline-flex" 
-          x-data="{ 
+    <div class="xl:col-span-2 flex justify-end items-center gap-x-2">
+      <div
+        class="hs-dropdown [--placement:bottom-right] relative inline-flex"
+        x-data="{ 
               currentTheme: localStorage.getItem('hs_theme') || 'default',
               systemDark: window.matchMedia('(prefers-color-scheme: dark)').matches,
               
@@ -70,115 +136,277 @@
                       document.documentElement.classList.remove('dark');
                   }
               }
-          }">
-          
-        <button id="hs-pro-theme-dropdown" type="button" class="hs-dropdown-toggle inline-flex items-center justify-center rounded-full p-2 text-gray-600 hover:bg-gray-100 dark:text-neutral-200 dark:hover:bg-neutral-700">
-          <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          }"
+      >
+        <button
+          id="hs-pro-theme-dropdown"
+          type="button"
+          class="hs-dropdown-toggle inline-flex items-center justify-center rounded-full p-2 text-gray-600 hover:bg-gray-100 dark:text-neutral-200 dark:hover:bg-neutral-700"
+        >
+          <svg
+            class="w-5 h-5"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
             <circle cx="12" cy="12" r="4"></circle>
-            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"></path>
+            <path
+              d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"
+            ></path>
           </svg>
         </button>
 
-        <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 start-2.5 w-48 transition-[opacity,margin] duration opacity-0 hidden z-50 bg-white rounded-xl shadow-xl dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800" role="menu">
+        <div
+          class="hs-dropdown-menu hs-dropdown-open:opacity-100 start-2.5 w-48 transition-[opacity,margin] duration opacity-0 hidden z-50 bg-white rounded-xl shadow-xl dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800"
+          role="menu"
+        >
           <div class="p-1 space-y-0.5">
-            <template x-for="theme in [{name: 'default', label: 'System Default'}, {name: 'light', label: 'Light'}, {name: 'dark', label: 'Dark'}]" :key="theme.name">
-                <button type="button" 
-                        @click="apply(theme.name)"
-                        :class="currentTheme === theme.name ? 'bg-gray-100 dark:bg-neutral-800' : ''"
-                        class="w-full flex items-center justify-between py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 focus:outline-hidden dark:text-neutral-300 dark:hover:bg-neutral-800">
-                  <span class="flex items-center gap-x-3" x-text="theme.label"></span>
-                  <svg x-show="currentTheme === theme.name" class="shrink-0 size-3.5 text-gray-600 dark:text-neutral-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
-                </button>
-              </template>
+            <template
+              x-for="theme in [{name: 'default', label: 'System Default'}, {name: 'light', label: 'Light'}, {name: 'dark', label: 'Dark'}]"
+              :key="theme.name"
+            >
+              <button
+                type="button"
+                @click="apply(theme.name)"
+                :class="currentTheme === theme.name ? 'bg-gray-100 dark:bg-neutral-800' : ''"
+                class="w-full flex items-center justify-between py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 focus:outline-hidden dark:text-neutral-300 dark:hover:bg-neutral-800"
+              >
+                <span
+                  class="flex items-center gap-x-3"
+                  x-text="theme.label"
+                ></span>
+                <svg
+                  x-show="currentTheme === theme.name"
+                  class="shrink-0 size-3.5 text-gray-600 dark:text-neutral-400"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="3"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M20 6 9 17l-5-5" />
+                </svg>
+              </button>
+            </template>
           </div>
         </div>
       </div>
-      <div class="border-e border-gray-200 w-px h-6 mx-1.5 dark:border-neutral-200"></div>
-        <div class="h-9.5">
-          <!-- Account Dropdown -->
-        <div class="hs-dropdown [--placement:top-right] [--strategy:absolute] [--auto-close:inside] relative inline-flex">
+      <div
+        class="border-e border-gray-200 w-px h-6 mx-1.5 dark:border-neutral-200"
+      ></div>
+      <div class="h-9.5">
+        <!-- Account Dropdown -->
+        <div
+          class="hs-dropdown [--placement:top-right] [--strategy:absolute] [--auto-close:inside] relative inline-flex"
+        >
           <!-- Account Avatar -->
-          <button id="hs-pro-fadm" type="button" class="px-1.5 py-[5px] min-h-9.5 hs-dropdown-toggle flex shrink-0 items-center gap-x-1 text-start text-gray-800 hover:bg-gray-100 rounded-lg focus:outline-hidden focus:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700" aria-haspopup="menu" aria-expanded="false" aria-label="Dropdown">
-            <img class="shrink-0 size-7 rounded-full" src="https://images.unsplash.com/photo-1568602471122-7832951cc4c5?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=facearea&amp;facepad=2.5&amp;w=320&amp;h=320&amp;q=80" alt="Avatar">
+          <button
+            id="hs-pro-fadm"
+            type="button"
+            class="px-1.5 py-[5px] min-h-9.5 hs-dropdown-toggle flex shrink-0 items-center gap-x-1 text-start text-gray-800 hover:bg-gray-100 rounded-lg focus:outline-hidden focus:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            aria-label="Dropdown"
+          >
+            <img
+              class="shrink-0 size-7 rounded-full"
+              src="https://images.unsplash.com/photo-1568602471122-7832951cc4c5?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=facearea&amp;facepad=2.5&amp;w=320&amp;h=320&amp;q=80"
+              alt="Avatar"
+            />
             <span class="grow hidden sm:block mx-1 max-w-32 truncate">
               <span class="block truncate text-sm font-medium">
                 James Collison
               </span>
             </span>
-            <svg class="shrink-0 size-4 text-gray-500 dark:text-neutral-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg
+              class="shrink-0 size-4 text-gray-500 dark:text-neutral-400"
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
               <path d="m6 9 6 6 6-6" />
             </svg>
           </button>
           <!-- End Account Avatar -->
 
           <!-- Account Dropdown -->
-          <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 start-2.5 w-56 transition-[opacity,margin] duration opacity-0 hidden z-[10] bg-white rounded-xl shadow-xl dark:bg-neutral-900" role="menu" aria-orientation="vertical" aria-labelledby="hs-pro-fadm">
-          <div class="p-1 border-b border-gray-200 dark:border-neutral-800">
-            <a class="py-2 px-3 flex items-center gap-x-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
-              href="">
-              <img class="shrink-0 size-8 rounded-full"
-                src="https://images.unsplash.com/photo-1568602471122-7832951cc4c5?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=facearea&amp;facepad=2.5&amp;w=320&amp;h=320&amp;q=80"
-                alt="Avatar">
+          <div
+            class="hs-dropdown-menu hs-dropdown-open:opacity-100 start-2.5 w-56 transition-[opacity,margin] duration opacity-0 hidden z-[10] bg-white rounded-xl shadow-xl dark:bg-neutral-900"
+            role="menu"
+            aria-orientation="vertical"
+            aria-labelledby="hs-pro-fadm"
+          >
+            <div class="p-1 border-b border-gray-200 dark:border-neutral-800">
+              <a
+                class="py-2 px-3 flex items-center gap-x-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+                href=""
+              >
+                <img
+                  class="shrink-0 size-8 rounded-full"
+                  src="https://images.unsplash.com/photo-1568602471122-7832951cc4c5?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=facearea&amp;facepad=2.5&amp;w=320&amp;h=320&amp;q=80"
+                  alt="Avatar"
+                />
 
-              <div class="grow">
-                <span class="text-sm font-semibold text-gray-800 dark:text-neutral-300">
-                  James Collison
-                </span>
-                <p class="text-xs text-gray-500 dark:text-neutral-500">
-                  James@testpress.in
-                </p>
-              </div>
-            </a>
-          </div>
-          <div class="p-1">
-            <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
-              href="#">
-              <svg class="shrink-0 mt-0.5 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                stroke-linejoin="round">
-                <rect width="20" height="14" x="2" y="5" rx="2" />
-                <line x1="2" x2="22" y1="10" y2="10" />
-              </svg>
-              Order & Billing
-            </a>
-            <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
-            href="#">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 mt-0.5 size-4"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M8 18v-2"/><path d="M12 18v-4"/><path d="M16 18v-6"/></svg>
-            My Report
-          </a>
-            <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
-            href="#">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 mt-0.5 size-4"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M7 16c.5-2 1.5-7 4-7 2 0 2 3 4 3 2.5 0 4.5-5 5-7"/></svg>
-            Analytics
-          </a>
-          <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
-          href="#">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 mt-0.5 size-4"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"/></svg>
-          Bookmarks
-        </a>
-        <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
-        href="#">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 mt-0.5 size-4"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></svg>
-        Certificates
-      </a>
-
-          </div>
-          <div class="border-b border-gray-200 dark:border-neutral-800"></div>
-          <div class="p-1">
-            <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
-              href="#">
-              Login Activity
-            </a>
-            <a class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
-              href="#">
-              Log out
-            </a>
-          </div>
+                <div class="grow">
+                  <span
+                    class="text-sm font-semibold text-gray-800 dark:text-neutral-300"
+                  >
+                    James Collison
+                  </span>
+                  <p class="text-xs text-gray-500 dark:text-neutral-500">
+                    James@testpress.in
+                  </p>
+                </div>
+              </a>
+            </div>
+            <div class="p-1">
+              <a
+                class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+                href="#"
+              >
+                <svg
+                  class="shrink-0 mt-0.5 size-4"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect width="20" height="14" x="2" y="5" rx="2" />
+                  <line x1="2" x2="22" y1="10" y2="10" />
+                </svg>
+                Order & Billing
+              </a>
+              <a
+                class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+                href="#"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="shrink-0 mt-0.5 size-4"
+                >
+                  <path
+                    d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"
+                  />
+                  <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+                  <path d="M8 18v-2" />
+                  <path d="M12 18v-4" />
+                  <path d="M16 18v-6" />
+                </svg>
+                My Report
+              </a>
+              <a
+                class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+                href="#"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="shrink-0 mt-0.5 size-4"
+                >
+                  <path d="M3 3v16a2 2 0 0 0 2 2h16" />
+                  <path d="M7 16c.5-2 1.5-7 4-7 2 0 2 3 4 3 2.5 0 4.5-5 5-7" />
+                </svg>
+                Analytics
+              </a>
+              <a
+                class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+                href="#"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="shrink-0 mt-0.5 size-4"
+                >
+                  <path
+                    d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"
+                  />
+                </svg>
+                Bookmarks
+              </a>
+              <a
+                class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+                href="#"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="shrink-0 mt-0.5 size-4"
+                >
+                  <path
+                    d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"
+                  />
+                  <path d="M22 10v6" />
+                  <path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5" />
+                </svg>
+                Certificates
+              </a>
+            </div>
+            <div class="border-b border-gray-200 dark:border-neutral-800"></div>
+            <div class="p-1">
+              <a
+                class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+                href="#"
+              >
+                Login Activity
+              </a>
+              <a
+                class="flex items-center gap-x-3 py-2 px-3 rounded-lg text-sm text-gray-800 hover:bg-gray-100 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-100 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus:bg-neutral-800"
+                href="#"
+              >
+                Log out
+              </a>
+            </div>
           </div>
           <!-- End Account Dropdown -->
         </div>
-          <!-- End Account Dropdown -->
-        </div>
+        <!-- End Account Dropdown -->
       </div>
     </div>
-  </header>
+  </div>
+</header>

--- a/src/content_detail_page/includes/viewer_header.html
+++ b/src/content_detail_page/includes/viewer_header.html
@@ -1,7 +1,6 @@
 <header
   id="global-header"
-  class="js-stackable-header lg:ms-[24rem] fixed top-0 inset-x-0 flex flex-wrap md:justify-start md:flex-nowrap z-[50] bg-white border-b border-gray-200 dark:bg-neutral-900 dark:border-neutral-700"
->
+  class="js-stackable-header lg:ms-[24rem] fixed top-0 inset-x-0 flex flex-wrap md:justify-start md:flex-nowrap z-[50] bg-white border-b border-gray-200 dark:bg-neutral-900 dark:border-neutral-700">
   <div
     class="flex justify-between xl:grid xl:grid-cols-3 basis-full items-center w-full py-3 px-2 sm:px-5"
   >

--- a/src/content_detail_page/notes.html
+++ b/src/content_detail_page/notes.html
@@ -9,12 +9,16 @@
 {% endblock extra_head %}
 
 {% block content %}
-<div x-data="contents">
+<div x-data="contents" x-init="setStickyOffset()">
 	{% include "./includes/mobile_sidebar.html" %}  
 	{% include "./includes/desktop_sidebar.html" %}  
 	<main class="lg:pl-96 dark:bg-neutral-800">
 		{% include "./includes/navigate_content.html" %}
-    <div class="sticky top-28 xl:top-16 z-30 bg-white p-2 shadow dark:bg-neutral-800 dark:border-b dark:border-neutral-700"  x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}">
+    <div 
+        class="sticky z-30 bg-white p-2 shadow dark:bg-neutral-800 dark:border-b dark:border-neutral-700" 
+        :style="{ top: stickyOffset + 'px' }"
+        x-data="{toggleSVG : true, isBookmarked:false, is_renderable:false}"
+    >
       {% include "./includes/content_heading.html" %}
     </div>
     <div class="lg:px-8">


### PR DESCRIPTION
**Problem**
Previously, the notes content header relied on static utility classes (e.g., top-[123px]) to determine its sticky offset.This caused:
- Layout gaps on small and medium devices when elements such as the custom test generation icon were conditionally hidden, while the offset remained unchanged.
- High maintenance overhead, as any addition or removal of header elements required manual recalculation and hardcoded updates across multiple templates.

**Solution**
This PR replaces hardcoded sticky offsets with a dynamic calculation system to resolve layout inconsistencies when notes content header elements are conditionally rendered.