### PR TITLE
fix: Reflection form opens from bottom as sheet wrapper on mobile view

### DIFF
--- a/src/exam_review/answers/includes/question_reflection_sidebar.html
+++ b/src/exam_review/answers/includes/question_reflection_sidebar.html
@@ -83,7 +83,7 @@
 
   <!-- Hidden Template for Shared Form -->
   <div x-ref="reflectionForm" class="hidden">
-    <div class="p-4 space-y-6">
+    <div class="p-2 space-y-6">
       <div>
         <h4 class="text-sm font-medium text-gray-900 dark:text-neutral-200 mb-4 text-center">Why do you think you got this question wrong?</h4>
         <div class="mt-3">

--- a/src/exam_review/answers/includes/question_reflection_sidebar.html
+++ b/src/exam_review/answers/includes/question_reflection_sidebar.html
@@ -1,24 +1,89 @@
-<div id="hs-pro-mistake-reflection" 
-  class="hs-overlay hs-overlay-open:translate-x-0 translate-x-full fixed top-0 end-0 transition-all duration-300 transform h-full w-full md:w-1/5 z-[100] bg-white border-s dark:bg-neutral-800 dark:border-neutral-700 hidden" 
-  role="dialog" 
-  tabindex="-1" 
-  aria-labelledby="hs-pro-mistake-reflection-label" 
-  data-hs-overlay-backdrop="false"
-  x-data="questionReflection()"
-  @hs-overlay-opened="onSidebarOpen()">
-  <div class="flex flex-col h-full">
-    <div class="flex items-center justify-between border-b border-stone-200 px-4 py-3 dark:border-neutral-700">
-      <h3 id="hs-pro-mistake-reflection-label" class="font-medium text-stone-800 dark:text-neutral-200">Reasons for Mistakes</h3>
-      <button type="button" class="flex size-8 shrink-0 items-center justify-center gap-x-2 rounded-full border border-transparent bg-stone-100 text-stone-800 hover:bg-stone-200 focus:bg-stone-200 focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 dark:bg-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-600 dark:focus:bg-neutral-600" aria-label="Close" data-hs-overlay="#hs-pro-mistake-reflection">
-        <span class="sr-only">Close</span>
-        <svg class="size-4 shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M18 6 6 18" />
-          <path d="m6 6 12 12" />
-        </svg>
-      </button>
-    </div>
+<div x-data="questionReflection()" @hs-overlay-opened="onSidebarOpen()" class="contents">
+  <!-- Desktop Sidebar (Preline Overlay) -->
+  <div id="hs-pro-mistake-reflection" 
+    class="hs-overlay hs-overlay-open:translate-x-0 translate-x-full fixed top-0 end-0 transition-all duration-300 transform h-full w-full md:w-1/5 z-[100] bg-white border-s dark:bg-neutral-800 dark:border-neutral-700 hidden md:block" 
+    role="dialog" 
+    tabindex="-1" 
+    aria-labelledby="hs-pro-mistake-reflection-label" 
+    data-hs-overlay-backdrop="false">
+    <div class="flex flex-col h-full">
+      <div class="flex items-center justify-between border-b border-stone-200 px-4 py-3 dark:border-neutral-700">
+        <h3 id="hs-pro-mistake-reflection-label" class="font-medium text-stone-800 dark:text-neutral-200">Reasons for Mistakes</h3>
+        <button type="button" class="flex size-8 shrink-0 items-center justify-center gap-x-2 rounded-full border border-transparent bg-stone-100 text-stone-800 hover:bg-stone-200 focus:bg-stone-200 focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 dark:bg-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-600 dark:focus:bg-neutral-600" aria-label="Close" data-hs-overlay="#hs-pro-mistake-reflection">
+          <span class="sr-only">Close</span>
+          <svg class="size-4 shrink-0" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      </div>
 
-    <div id="hs-modal-mistake-reflection-body" class="flex-1 space-y-6 overflow-y-auto p-4 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-stone-300 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500 [&::-webkit-scrollbar-track]:bg-stone-100 dark:[&::-webkit-scrollbar-track]:bg-neutral-700">
+      <div class="flex-1 overflow-y-auto" x-ref="sidebarBody">
+        <div x-html="$refs.reflectionForm.innerHTML"></div>
+      </div>
+
+      <div class="flex justify-between gap-x-2 border-t border-stone-200 px-4 sm:px-6 py-3 dark:border-neutral-700 bg-white dark:bg-neutral-800">
+        <div class="flex flex-1 items-center justify-end gap-2">
+          <button type="button" class="inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white py-2 px-3 text-start align-middle text-sm font-medium text-nowrap whitespace-nowrap text-gray-800 shadow-2xs hover:bg-gray-50 focus:bg-gray-50 focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700/50 dark:focus:bg-neutral-700" data-hs-overlay="#hs-pro-mistake-reflection">Skip</button>
+          <button type="button" @click="saveAndClose()" class="inline-flex items-center justify-center gap-x-2 rounded-lg border border-emerald-600 bg-emerald-600 py-2 px-3 text-start align-middle text-sm font-medium text-nowrap whitespace-nowrap text-white shadow-2xs hover:bg-emerald-700 focus:ring-1 focus:ring-emerald-300 focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 dark:focus:ring-emerald-500">Save Reflection</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mobile Bottom Sheet Wrapper -->
+  <div class="md:hidden fixed inset-x-0 bottom-0 z-[100] pointer-events-none" x-show="state !== 'closed'" x-cloak>
+    <div class="mx-auto w-full bg-white rounded-t-2xl shadow-lg pointer-events-auto transition-all duration-300 flex flex-col dark:bg-neutral-800"
+         :class="{
+           'h-0': state === 'closed',
+           'h-[50dvh] border-t border-gray-200 dark:border-neutral-700': state === 'half',
+           'h-[100dvh]': state === 'full'
+         }">
+      <!-- Grabber Handle -->
+      <div class="px-4 pt-3 pb-2 cursor-pointer select-none touch-none"
+           @click="state === 'half' ? snapUp() : snapDown()" 
+           @touchstart.stop="dragStart($event)"
+           @touchend.stop="dragEnd($event)">
+        <div class="w-12 h-1.5 bg-gray-300 rounded-full mx-auto dark:bg-neutral-600"></div>
+      </div>
+      
+      <!-- Fixed Header -->
+      <div class="px-4 py-3 border-b border-gray-100 dark:border-neutral-700">
+        <div class="flex items-center justify-between">
+          <h3 class="font-semibold text-stone-800 dark:text-neutral-200">Reasons for Mistakes</h3>
+          <button type="button" @click="state = 'closed'" 
+                  class="flex size-8 shrink-0 items-center justify-center rounded-full text-gray-500 hover:bg-gray-100 focus:outline-none dark:text-neutral-400 dark:hover:bg-neutral-700">
+            <svg class="size-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- Scrollable Content -->
+      <div class="flex-1 overflow-y-auto px-4">
+        <div x-html="$refs.reflectionForm.innerHTML"></div>
+      </div>
+
+      <!-- Fixed Footer -->
+      <div class="p-4 border-t border-gray-100 dark:border-neutral-700 bg-white dark:bg-neutral-800">
+        <div class="flex justify-end gap-3">
+          <button type="button" @click="state = 'closed'" 
+                  class="flex-1 md:flex-none inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white py-2 px-4 text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700">
+            Skip
+          </button>
+          <button type="button" @click="saveAndClose()" 
+                  class="flex-1 md:flex-none inline-flex items-center justify-center rounded-lg border border-emerald-600 bg-emerald-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-emerald-700 focus:outline-none dark:bg-emerald-500 dark:border-emerald-500 dark:hover:bg-emerald-600">
+            Save Reflection
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Hidden Template for Shared Form -->
+  <div x-ref="reflectionForm" class="hidden">
+    <div class="p-4 space-y-6">
       <div>
         <h4 class="text-sm font-medium text-gray-900 dark:text-neutral-200 mb-4 text-center">Why do you think you got this question wrong?</h4>
         <div class="mt-3">
@@ -27,21 +92,19 @@
               <div class="flex gap-3 items-start">
                 <div class="flex h-6 shrink-0 items-center">
                   <input
-                    id="hs-pro-mistake-reason-{{ reason.value }}"
+                    id="reason-{{ reason.value }}"
                     type="radio"
-                    name="hs-pro-mistake-reason"
+                    name="mistake-reason"
                     value="{{ reason.value }}"
                     x-model="selectedReason"
-                    aria-describedby="hs-pro-mistake-desc-{{ reason.value }}"
-                    class="h-4 w-4 border-gray-300 text-emerald-600 focus:ring-emerald-600"
+                    class="h-4 w-4 border-gray-300 text-emerald-600 focus:ring-emerald-600 dark:bg-neutral-900 dark:border-neutral-700"
                   />
                 </div>
-
                 <div class="text-sm/6 flex-1">
-                  <label for="hs-pro-mistake-reason-{{ reason.value }}" class="font-medium text-gray-900 dark:text-neutral-200 cursor-pointer">
+                  <label for="reason-{{ reason.value }}" class="font-medium text-gray-900 dark:text-neutral-200 cursor-pointer">
                     {{ reason.name }}
                   </label>
-                  <p id="hs-pro-mistake-desc-{{ reason.value }}" class="text-gray-500 dark:text-neutral-400">
+                  <p class="text-gray-500 dark:text-neutral-400">
                     {{ reason.description }}
                   </p>
                 </div>
@@ -51,22 +114,15 @@
         </div>
 
         <div class="mt-8">
-          <label for="reflection-notes" class="block text-sm font-medium text-gray-900 dark:text-neutral-200 mb-2">Additional Notes (Optional)</label>
+          <label for="reflection-notes-textarea" class="block text-sm font-medium text-gray-900 dark:text-neutral-200 mb-2">Additional Notes (Optional)</label>
           <textarea 
-            id="reflection-notes" 
+            id="reflection-notes-textarea" 
             x-model="notes" 
             rows="5" 
             class="block w-full rounded-lg border-0 py-2.5 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 text-sm leading-6 dark:bg-neutral-900 dark:ring-neutral-700 dark:text-neutral-200 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500" 
             placeholder="Add any specific thoughts about this mistake...">
           </textarea>
         </div>
-      </div>
-    </div>
-
-    <div class="flex justify-between gap-x-2 border-t border-stone-200 px-4 sm:px-6 py-3 dark:border-neutral-700">
-      <div class="flex flex-1 items-center justify-end gap-2">
-        <button type="button" class="inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white py-2 px-3 text-start align-middle text-sm font-medium text-nowrap whitespace-nowrap text-gray-800 shadow-2xs hover:bg-gray-50 focus:bg-gray-50 focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700/50 dark:focus:bg-neutral-700" data-hs-overlay="#hs-pro-mistake-reflection">Skip</button>
-        <button type="button" @click="saveReflection(selectedReason, notes)" data-hs-overlay="#hs-pro-mistake-reflection" class="inline-flex items-center justify-center gap-x-2 rounded-lg border border-emerald-600 bg-emerald-600 py-2 px-3 text-start align-middle text-sm font-medium text-nowrap whitespace-nowrap text-white shadow-2xs hover:bg-emerald-700 focus:ring-1 focus:ring-emerald-300 focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 dark:focus:ring-emerald-500">Save Reflection</button>
       </div>
     </div>
   </div>
@@ -78,16 +134,73 @@
       selectedReason: null,
       notes: '',
       reasons: {{ question_mistake_reflection | dump | safe }},
+      state: 'closed',
+      isMobile: window.innerWidth < 768,
+      threshold: 50,
+      startY: 0,
+
+      init() {
+        window.addEventListener('resize', () => {
+          this.isMobile = window.innerWidth < 768;
+        });
+
+        const overlay = document.querySelector('#hs-pro-mistake-reflection');
+        if (overlay) {
+          overlay.addEventListener('open.hs.overlay', () => {
+             if (this.isMobile) {
+                this.onSidebarOpen();
+             }
+          });
+        }
+      },
+
       onSidebarOpen() {
         this.selectedReason = this.currentQuestion?.reflection?.reason || null;
         this.notes = this.currentQuestion?.reflection?.notes || '';
+        if (this.isMobile) {
+          this.state = 'half';
+          const backdrop = document.querySelector('.hs-overlay-backdrop');
+          if (backdrop) backdrop.classList.add('hidden');
+        }
+      },
+
+      snapUp() { this.state = 'full' },
+      snapDown() {
+        if (this.state === 'full') this.state = 'half';
+        else this.state = 'closed';
+      },
+      dragStart(e) { this.startY = (e.touches ? e.touches[0].clientY : e.clientY) },
+      dragEnd(e) {
+        const endY = (e.changedTouches ? e.changedTouches[0].clientY : e.clientY);
+        const delta = endY - this.startY;
+        if (delta <= -this.threshold) { this.snapUp() }
+        else if (delta >= this.threshold) { this.snapDown() }
+      },
+
+      saveAndClose() {
+        this.saveReflection(this.selectedReason, this.notes);
+        if (this.isMobile) {
+          this.state = 'closed';
+        } else {
+          HSOverlay.close('#hs-pro-mistake-reflection');
+        }
       }
     }
   }
 </script>
 
 <style>
-  .hs-overlay-backdrop {
-    display: none !important;
+  [x-cloak] { display: none !important; }
+  
+  @media (max-width: 767px) {
+    .hs-overlay-backdrop {
+      background-color: transparent !important;
+      pointer-events: none !important;
+      visibility: hidden !important;
+      display: none !important;
+    }
+    #hs-pro-mistake-reflection {
+        display: none !important;
+    }
   }
 </style>


### PR DESCRIPTION
- The desktop-optimized sidebar for question reflections was not user-friendly on smaller screens, often appearing cramped or difficult to navigate.
- This PR update introduces a mobile-specific "bottom sheet" experience that slides up from the bottom of the screen on devices on and under mobile width.
- Implemented a multi-state sheet system allowing users to drag the form into "half" or "full" view using touch gestures, mimicking native mobile app behaviors.