### PR TITLE
feat: Add dark theme support for student certificates

### DIFF
--- a/src/certificates/student/exam/exam_list.html
+++ b/src/certificates/student/exam/exam_list.html
@@ -1,25 +1,30 @@
-<ul x-cloak x-show="getFilteredExams()" role="list" class="divide-y divide-gray-100">
+<ul x-cloak x-show="getFilteredExams()" role="list" class="divide-y divide-gray-100 dark:divide-neutral-700">
   <template x-for="exam in getFilteredExams">
     <li class="relative flex justify-between gap-x-6 py-5">
       <div class="flex min-w-0 gap-x-4">
-        <img class="h-12 w-12 flex-none rounded-full bg-gray-50" src="https://d36vpug2b5drql.cloudfront.net/static/courses/general/1442850373_115.png" alt="">
+        <img class="h-12 w-12 flex-none rounded-full bg-gray-50 dark:bg-neutral-700" src="https://d36vpug2b5drql.cloudfront.net/static/courses/general/1442850373_115.png" alt="">
         <div class="min-w-0 flex-auto">
-          <p class="text-sm font-semibold leading-6 text-gray-900">
-            <a href="#">
+          <p class="text-sm font-semibold leading-6 text-gray-900 dark:text-neutral-100">
+            <a href="#" class="hover:text-emerald-600 dark:hover:text-emerald-400">
               <span x-text="exam.title"></span>
             </a>
           </p>
-          <p class="mt-1 flex text-xs leading-5 text-gray-500">Issued&nbsp;<span x-text="exam.certificate_available_date"></span></p>
+          <p class="mt-1 flex text-xs leading-5 text-gray-500 dark:text-neutral-400">
+            <span class="dark:text-neutral-500">Issued&nbsp;</span>
+            <span x-text="exam.certificate_available_date"></span>
+          </p>
         </div>
       </div>
       <div class="flex shrink-0 items-center gap-x-4">
         <a x-cloak x-show="exam.certificate_download_url" 
           :href="exam.certificate_download_url"
           target="blank"
-          class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+          class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-700 dark:hover:bg-neutral-700 dark:hover:text-white">
           Download<span class="sr-only">, Download Certificate</span>
         </a>
-        <button @click="generateCertificate()" x-cloak x-show="!exam.certificate_download_url" class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+        
+        <button @click="generateCertificate()" x-cloak x-show="!exam.certificate_download_url" 
+          class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-700 dark:hover:bg-neutral-700 dark:hover:text-white">
           Generate<span class="sr-only">, Generate Certificate</span>
         </button>
       </div>

--- a/src/certificates/student/exam/header.html
+++ b/src/certificates/student/exam/header.html
@@ -1,16 +1,16 @@
 <div class="lg:flex lg:items-center lg:justify-between px-4 lg:px-0">
   <div class="min-w-0 flex-1">
     <nav aria-label="Back">
-      <a href="#" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700">
-        <svg class="-ml-1 mr-1 h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <a href="#" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200">
+        <svg class="-ml-1 mr-1 h-5 w-5 flex-shrink-0 text-gray-400 dark:text-neutral-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd" />
         </svg>
         Back
       </a>
     </nav>
-    <h2 class="mt-2 text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">Certificates</h2>
+    <h2 class="mt-2 text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight dark:text-neutral-100">Certificates</h2>
     <div class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
-      <p class="mt-2 max-w-4xl text-sm text-gray-500">Certificates have been issued for the following exams. Click the download button next to each exam to get your certificate PDF.</p>
+      <p class="mt-2 max-w-4xl text-sm text-gray-500 dark:text-neutral-400">Certificates have been issued for the following exams. Click the download button next to each exam to get your certificate PDF.</p>
     </div>
   </div>
   <div class="mt-5 flex lg:ml-4 lg:mt-0">
@@ -20,7 +20,7 @@
           <label for="search" class="sr-only">Search</label>
           <div class="relative">
           <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-              <svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <svg class="h-5 w-5 text-gray-400 dark:text-neutral-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z" clip-rule="evenodd"></path>
               </svg>
           </div>
@@ -28,7 +28,7 @@
             <input 
               id="search" 
               name="search" 
-              class="block w-80 rounded-md border-0 bg-white py-1.5 pl-10 pr-3 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6" 
+              class="block w-80 rounded-md border-0 bg-white py-1.5 pl-10 pr-3 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-800 dark:text-neutral-100 dark:ring-neutral-700 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500" 
               placeholder="Search for exams" 
               x-model="examSearchText"
               type="search">

--- a/src/certificates/student/exam/index.html
+++ b/src/certificates/student/exam/index.html
@@ -4,21 +4,19 @@ tags: certificates
 title: Student UI
 ---
 
-{% extends "layouts/student_base.html" %}
+{% extends "src/testpress/layout/student_layout.html" %}
 
-{% block body_class %}overflow-y-scroll min-h-screen bg-gray-100{% endblock %}
+{% block body_class %}overflow-y-scroll min-h-screen bg-gray-100 dark:bg-neutral-900{% endblock %}
 
-{% block content %}
-  {% include "partials/student_navbar.html" %}
-
+{% block main_content %}
   <div class="py-10 max-w-7xl mx-auto xl:px-8" x-data="studentCertificatesData()">
     {% include "./header.html" %}
     <div class="flex justify-center">
       {% include "../includes/certificate_alert.html" %}
     </div>
     <main class="pt-6">
-      <div class="pb-6 overflow-hidden bg-white sm:rounded-lg">
-      <div class="bg-white">
+      <div class="pb-6 overflow-hidden bg-white sm:rounded-lg dark:bg-neutral-900">
+      <div class="bg-white dark:bg-neutral-900">
         <div>          
           <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <section aria-labelledby="products-heading">

--- a/src/certificates/student/exam/tabs.html
+++ b/src/certificates/student/exam/tabs.html
@@ -3,24 +3,24 @@
     <label for="tabs" class="sr-only">Select a tab</label>
     <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
     <select id="tabs" name="tabs" onchange="window.location.href=this.value;"
-      class="mt-4 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md">
+      class="mt-4 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200">
       <option value="/certificates/student/">Course Certificates</option>
       <option value="/certificates/student/exam/" selected>Exam Certificates</option>
     </select>
   </div>
   <div class="hidden sm:block">
-    <div class="border-b border-gray-200">
+    <div class="border-b border-gray-200 dark:border-neutral-700">
       <nav class="-mb-px flex space-x-8 mt-2" aria-label="Tabs">
-        <!-- Current: "border-emerald-500 text-emerald-600", Default: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700" -->
-        <a href="/certificates/student/" class="group inline-flex items-center border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="-ml-0.5 mr-2 size-5 text-gray-400 group-hover:text-gray-500">
+        <a href="/certificates/student/" class="group inline-flex items-center border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-500">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="-ml-0.5 mr-2 size-5 text-gray-400 group-hover:text-gray-500 dark:text-neutral-500 dark:group-hover:text-neutral-300">
             <path d="M11.7 2.805a.75.75 0 0 1 .6 0A60.65 60.65 0 0 1 22.83 8.72a.75.75 0 0 1-.231 1.337 49.948 49.948 0 0 0-9.902 3.912l-.003.002c-.114.06-.227.119-.34.18a.75.75 0 0 1-.707 0A50.88 50.88 0 0 0 7.5 12.173v-.224c0-.131.067-.248.172-.311a54.615 54.615 0 0 1 4.653-2.52.75.75 0 0 0-.65-1.352 56.123 56.123 0 0 0-4.78 2.589 1.858 1.858 0 0 0-.859 1.228 49.803 49.803 0 0 0-4.634-1.527.75.75 0 0 1-.231-1.337A60.653 60.653 0 0 1 11.7 2.805Z" />
             <path d="M13.06 15.473a48.45 48.45 0 0 1 7.666-3.282c.134 1.414.22 2.843.255 4.284a.75.75 0 0 1-.46.711 47.87 47.87 0 0 0-8.105 4.342.75.75 0 0 1-.832 0 47.87 47.87 0 0 0-8.104-4.342.75.75 0 0 1-.461-.71c.035-1.442.121-2.87.255-4.286.921.304 1.83.634 2.726.99v1.27a1.5 1.5 0 0 0-.14 2.508c-.09.38-.222.753-.397 1.11.452.213.901.434 1.346.66a6.727 6.727 0 0 0 .551-1.607 1.5 1.5 0 0 0 .14-2.67v-.645a48.549 48.549 0 0 1 3.44 1.667 2.25 2.25 0 0 0 2.12 0Z" />
             <path d="M4.462 19.462c.42-.419.753-.89 1-1.395.453.214.902.435 1.347.662a6.742 6.742 0 0 1-1.286 1.794.75.75 0 0 1-1.06-1.06Z" />
           </svg>
           <span>Course Certificates</span>
         </a>
-        <a href="/certificates/student/exam/" class="group inline-flex items-center border-b-2 border-emerald-500 px-1 py-4 text-sm font-medium text-emerald-600" aria-current="page">
+
+        <a href="/certificates/student/exam/" class="group inline-flex items-center border-b-2 border-emerald-500 px-1 py-4 text-sm font-medium text-emerald-600 dark:text-emerald-500" aria-current="page">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="-ml-0.5 mr-2 size-5 text-emerald-500">
             <path fill-rule="evenodd" d="M7.502 6h7.128A3.375 3.375 0 0 1 18 9.375v9.375a3 3 0 0 0 3-3V6.108c0-1.505-1.125-2.811-2.664-2.94a48.972 48.972 0 0 0-.673-.05A3 3 0 0 0 15 1.5h-1.5a3 3 0 0 0-2.663 1.618c-.225.015-.45.032-.673.05C8.662 3.295 7.554 4.542 7.502 6ZM13.5 3A1.5 1.5 0 0 0 12 4.5h4.5A1.5 1.5 0 0 0 15 3h-1.5Z" clip-rule="evenodd" />
             <path fill-rule="evenodd" d="M3 9.375C3 8.339 3.84 7.5 4.875 7.5h9.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 0 1 3 20.625V9.375ZM6 12a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V12Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 15a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V15Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 18a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V18Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd" />

--- a/src/certificates/student/includes/certificate_alert.html
+++ b/src/certificates/student/includes/certificate_alert.html
@@ -1,14 +1,16 @@
-<div x-show="showCertificateAlert" x-cloak class="fixed top-3 rounded-md bg-emerald-50 p-2 z-40">
+<div x-show="showCertificateAlert" x-cloak class="fixed top-3 rounded-md bg-emerald-50 p-2 z-40 dark:bg-emerald-900/20 dark:ring-1 dark:ring-emerald-500/50 dark:backdrop-blur-sm">
   <div class="flex items-center">
     <div class="flex-shrink-0">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5 text-emerald-400"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/></svg>
-      </div>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5 text-emerald-400 dark:text-emerald-500">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/>
+      </svg>
+    </div>
     <div class="ml-2">
-      <span x-text="alertMessage" class="text-sm font-medium text-emerald-800"></span>
+      <span x-text="alertMessage" class="text-sm font-medium text-emerald-800 dark:text-emerald-200"></span>
     </div>
     <div class="ml-auto pl-3">
       <div class="-mx-1.5 -my-1.5">
-        <button @click="showCertificateAlert=false" type="button" class="inline-flex rounded-md bg-emerald-50 p-1.5 text-emerald-500 hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2 focus:ring-offset-emerald-50">
+        <button @click="showCertificateAlert=false" type="button" class="inline-flex rounded-md bg-emerald-50 p-1.5 text-emerald-500 hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2 focus:ring-offset-emerald-50 dark:bg-transparent dark:text-emerald-400 dark:hover:bg-emerald-500/20 dark:focus:ring-offset-neutral-900">
           <span class="sr-only">Dismiss</span>
           <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />

--- a/src/certificates/student/includes/courses_list.html
+++ b/src/certificates/student/includes/courses_list.html
@@ -1,25 +1,30 @@
-<ul x-cloak x-show="getFilteredCourses()" role="list" class="divide-y divide-gray-100">
+<ul x-cloak x-show="getFilteredCourses()" role="list" class="divide-y divide-gray-100 dark:divide-neutral-700">
   <template x-for="course in getFilteredCourses">
     <li class="relative flex justify-between gap-x-6 py-5">
       <div class="flex min-w-0 gap-x-4">
-        <img class="h-12 w-12 flex-none rounded-full bg-gray-50" :src="course.image_url" alt="">
+        <img class="h-12 w-12 flex-none rounded-full bg-gray-50 dark:bg-neutral-800" :src="course.image_url" alt="">
         <div class="min-w-0 flex-auto">
-          <p class="text-sm font-semibold leading-6 text-gray-900">
+          <p class="text-sm font-semibold leading-6 text-gray-900 dark:text-neutral-100">
             <a href="#">
               <span x-text="course.title"></span>
             </a>
           </p>
-          <p class="mt-1 flex text-xs leading-5 text-gray-500">Issued&nbsp;<span x-text="course.certificate_available_date"></span></p>
+          <p class="mt-1 flex text-xs leading-5 text-gray-500 dark:text-neutral-400">
+            <span class="dark:text-neutral-500">Issued&nbsp;</span>
+            <span x-text="course.certificate_available_date"></span>
+          </p>
         </div>
       </div>
       <div class="flex shrink-0 items-center gap-x-4">
         <a x-cloak x-show="course.certificate_download_url" 
           :href="course.certificate_download_url"
           target="blank"
-          class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+          class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-700 dark:hover:bg-neutral-700 dark:hover:text-white">
           Download<span class="sr-only">, Download Certificate</span>
         </a>
-        <button @click="generateCertificate()" x-cloak x-show="!course.certificate_download_url" class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+
+        <button @click="generateCertificate()" x-cloak x-show="!course.certificate_download_url" 
+          class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-700 dark:hover:bg-neutral-700 dark:hover:text-white">
           Generate<span class="sr-only">, Generate Certificate</span>
         </button>
       </div>

--- a/src/certificates/student/includes/courses_list_empty.html
+++ b/src/certificates/student/includes/courses_list_empty.html
@@ -1,7 +1,7 @@
-<div x-cloak x-show="!getFilteredCourses()" class="mx-auto text-center px-4 py-5 sm:p-6">
-  <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-emerald-100">
+<div x-cloak x-show="!getFilteredCourses()" class="mx-auto text-center px-4 py-12 sm:p-12">
+  <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-emerald-100 dark:bg-emerald-900/30">
     <svg
-      class="h-6 w-6 text-emerald-600"
+      class="h-6 w-6 text-emerald-600 dark:text-emerald-500"
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
@@ -15,6 +15,6 @@
       ></path>
     </svg>
   </div>
-  <h3 class="mt-2 text-lg leading-6 font-semibold text-gray-900">No certificates available</h3>
-  <p class="mt-1">Looks like no course has issued certificates yet.</p>
+  <h3 class="mt-2 text-lg leading-6 font-semibold text-gray-900 dark:text-neutral-100">No certificates available</h3>
+  <p class="mt-1 text-gray-500 dark:text-neutral-400">Looks like no course has issued certificates yet.</p>
 </div>

--- a/src/certificates/student/includes/header.html
+++ b/src/certificates/student/includes/header.html
@@ -1,16 +1,16 @@
 <div class="lg:flex lg:items-center lg:justify-between px-4 lg:px-0">
   <div class="min-w-0 flex-1">
     <nav aria-label="Back">
-      <a href="#" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700">
-        <svg class="-ml-1 mr-1 h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <a href="#" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200">
+        <svg class="-ml-1 mr-1 h-5 w-5 flex-shrink-0 text-gray-400 dark:text-neutral-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd" />
         </svg>
         Back
       </a>
     </nav>
-    <h2 class="mt-2 text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">Certificates</h2>
+    <h2 class="mt-2 text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight dark:text-neutral-100">Certificates</h2>
     <div class="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
-      <p class="mt-2 max-w-4xl text-sm text-gray-500">Certificates have been issued for the following courses. Click the download button next to each course to get your certificate PDF.</p>
+      <p class="mt-2 max-w-4xl text-sm text-gray-500 dark:text-neutral-400">Certificates have been issued for the following courses. Click the download button next to each course to get your certificate PDF.</p>
     </div>
   </div>
   <div class="mt-5 flex lg:ml-4 lg:mt-0">
@@ -20,7 +20,7 @@
           <label for="search" class="sr-only">Search</label>
           <div class="relative">
           <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-              <svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <svg class="h-5 w-5 text-gray-400 dark:text-neutral-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z" clip-rule="evenodd"></path>
               </svg>
           </div>
@@ -28,7 +28,7 @@
             <input 
               id="search" 
               name="search" 
-              class="block w-80 rounded-md border-0 bg-white py-1.5 pl-10 pr-3 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6" 
+              class="block w-80 rounded-md border-0 bg-white py-1.5 pl-10 pr-3 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-emerald-600 sm:text-sm sm:leading-6 dark:bg-neutral-800 dark:text-neutral-100 dark:ring-neutral-700 dark:placeholder:text-neutral-500 dark:focus:ring-emerald-500" 
               placeholder="Search for courses" 
               x-model="courseSearchText"
               type="search">

--- a/src/certificates/student/includes/tabs.html
+++ b/src/certificates/student/includes/tabs.html
@@ -3,28 +3,29 @@
     <label for="tabs" class="sr-only">Select a tab</label>
     <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
     <select id="tabs" name="tabs" onchange="this.selectedIndex=this.selectedIndex; window.location.href=this.value;"
-    class="mt-4 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md">
-    <option value="/certificates/student/" selected>Course Certificates</option>
-    <option value="/certificates/student/exam/">Exam Certificates</option>
-  </select>
+      class="mt-4 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm rounded-md dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200">
+      <option value="/certificates/student/" selected>Course Certificates</option>
+      <option value="/certificates/student/exam/">Exam Certificates</option>
+    </select>
   </div>
   <div class="hidden sm:block">
-    <div class="border-b border-gray-200">
+    <div class="border-b border-gray-200 dark:border-neutral-700">
       <nav class="-mb-px flex space-x-8 mt-2" aria-label="Tabs">
         <!-- Current: "border-emerald-500 text-emerald-600", Default: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700" -->
-        <a href="/certificates/student/" class="group inline-flex items-center border-b-2 border-emerald-500 px-1 py-4 text-sm font-medium text-emerald-600" aria-current="page">
+        <a href="/certificates/student/" class="group inline-flex items-center border-b-2 border-emerald-500 px-1 py-4 text-sm font-medium text-emerald-600 dark:text-emerald-500" aria-current="page">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="-ml-0.5 mr-2 size-5 text-emerald-500">
             <path d="M11.7 2.805a.75.75 0 0 1 .6 0A60.65 60.65 0 0 1 22.83 8.72a.75.75 0 0 1-.231 1.337 49.948 49.948 0 0 0-9.902 3.912l-.003.002c-.114.06-.227.119-.34.18a.75.75 0 0 1-.707 0A50.88 50.88 0 0 0 7.5 12.173v-.224c0-.131.067-.248.172-.311a54.615 54.615 0 0 1 4.653-2.52.75.75 0 0 0-.65-1.352 56.123 56.123 0 0 0-4.78 2.589 1.858 1.858 0 0 0-.859 1.228 49.803 49.803 0 0 0-4.634-1.527.75.75 0 0 1-.231-1.337A60.653 60.653 0 0 1 11.7 2.805Z" />
             <path d="M13.06 15.473a48.45 48.45 0 0 1 7.666-3.282c.134 1.414.22 2.843.255 4.284a.75.75 0 0 1-.46.711 47.87 47.87 0 0 0-8.105 4.342.75.75 0 0 1-.832 0 47.87 47.87 0 0 0-8.104-4.342.75.75 0 0 1-.461-.71c.035-1.442.121-2.87.255-4.286.921.304 1.83.634 2.726.99v1.27a1.5 1.5 0 0 0-.14 2.508c-.09.38-.222.753-.397 1.11.452.213.901.434 1.346.66a6.727 6.727 0 0 0 .551-1.607 1.5 1.5 0 0 0 .14-2.67v-.645a48.549 48.549 0 0 1 3.44 1.667 2.25 2.25 0 0 0 2.12 0Z" />
             <path d="M4.462 19.462c.42-.419.753-.89 1-1.395.453.214.902.435 1.347.662a6.742 6.742 0 0 1-1.286 1.794.75.75 0 0 1-1.06-1.06Z" />
-          </svg>                             
+          </svg>
           <span>Course Certificates</span>
         </a>
-        <a href="/certificates/student/exam/" class="group inline-flex items-center border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="-ml-0.5 mr-2 size-5 text-gray-400 group-hover:text-gray-500">
+
+        <a href="/certificates/student/exam/" class="group inline-flex items-center border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-500">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="-ml-0.5 mr-2 size-5 text-gray-400 group-hover:text-gray-500 dark:text-neutral-500 dark:group-hover:text-neutral-300">
             <path fill-rule="evenodd" d="M7.502 6h7.128A3.375 3.375 0 0 1 18 9.375v9.375a3 3 0 0 0 3-3V6.108c0-1.505-1.125-2.811-2.664-2.94a48.972 48.972 0 0 0-.673-.05A3 3 0 0 0 15 1.5h-1.5a3 3 0 0 0-2.663 1.618c-.225.015-.45.032-.673.05C8.662 3.295 7.554 4.542 7.502 6ZM13.5 3A1.5 1.5 0 0 0 12 4.5h4.5A1.5 1.5 0 0 0 15 3h-1.5Z" clip-rule="evenodd" />
             <path fill-rule="evenodd" d="M3 9.375C3 8.339 3.84 7.5 4.875 7.5h9.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 0 1 3 20.625V9.375ZM6 12a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V12Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 15a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V15Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 18a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V18Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd" />
-          </svg>  
+          </svg>
           <span>Exam Certificates</span>
         </a>
       </nav>

--- a/src/certificates/student/index.html
+++ b/src/certificates/student/index.html
@@ -4,21 +4,19 @@ tags: certificates
 title: Student UI
 ---
 
-{% extends "layouts/student_base.html" %}
+{% extends "src/testpress/layout/student_layout.html" %}
 
-{% block body_class %}overflow-y-scroll min-h-screen bg-gray-100{% endblock %}
+{% block body_class %}overflow-y-scroll min-h-screen bg-gray-100 dark:bg-neutral-900{% endblock %}
 
-{% block content %}
-  {% include "partials/student_navbar.html" %}
-
+{% block main_content %}
   <div class="py-10 max-w-7xl mx-auto xl:px-8" x-data="studentCertificatesData()">
     {% include "./includes/header.html" %}
     <div class="flex justify-center">
       {% include "./includes/certificate_alert.html" %}
     </div>
     <main class="pt-6">
-      <div class="pb-6 overflow-hidden bg-white sm:rounded-lg">
-      <div class="bg-white">
+      <div class="pb-6 overflow-hidden bg-white sm:rounded-lg dark:bg-neutral-900">
+      <div class="bg-white dark:bg-neutral-900">
         <div>          
           <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <section aria-labelledby="products-heading">


### PR DESCRIPTION
- This PR adds dark theme support across certificate-related templates to ensure proper styling in dark mode.
- Updates UI elements including:
    - Certificate lists
    - Headers
    - Tabs
    - Search inputs
    - Alert notifications
    - Empty states
    - Download and Generate buttons
- Adjusts backgrounds, borders, text colors, and hover states for improved contrast in dark mode.
- Updates page layouts to use the new student_layout.html.