### PR TITLE
feat: Add dark mode support for overall analytics for student

### DIFF
--- a/src/analytics/includes/analytics_scripts.html
+++ b/src/analytics/includes/analytics_scripts.html
@@ -37,6 +37,8 @@
           {
             data: percentages,
             backgroundColor: ['#22c55e', '#ef4444', '#f59e0b'], // Tailwind colours of strength 500
+            borderColor: 'transparent',
+            borderWidth: 1,
             label: 'Percentage',
           },
         ]
@@ -48,6 +50,12 @@
             display: true,
             labels: {
               boxWidth: 10,
+              color: getComputedStyle(document.documentElement)
+                .getPropertyValue('--tw-text-neutral-100') || '#f5f5f5',
+              font: {
+                size: 12,
+                weight: '500'
+              }
             }
           }
         }

--- a/src/analytics/includes/analytics_scripts.html
+++ b/src/analytics/includes/analytics_scripts.html
@@ -50,8 +50,7 @@
             display: true,
             labels: {
               boxWidth: 10,
-              color: getComputedStyle(document.documentElement)
-                .getPropertyValue('--tw-text-neutral-100') || '#f5f5f5',
+              color: document.documentElement.classList.contains('dark') ? '#f5f5f5' : '#666',
               font: {
                 size: 12,
                 weight: '500'

--- a/src/analytics/includes/breadcrumbs.html
+++ b/src/analytics/includes/breadcrumbs.html
@@ -18,7 +18,7 @@
         <svg class="h-5 w-5 flex-shrink-0 text-gray-400 dark:text-neutral-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
         </svg>
-        <a href="{{ '/analytics/'|url }}?parent=1" class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover-text-neutral-200">Maths</a>
+        <a href="{{ '/analytics/'|url }}?parent=1" class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200">Maths</a>
       </div>
     </li>
   </ol>

--- a/src/analytics/includes/breadcrumbs.html
+++ b/src/analytics/includes/breadcrumbs.html
@@ -1,6 +1,6 @@
 <nav class="sm:hidden" aria-label="Back">
-  <a href="{{ '/analytics/'|url }}" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700">
-    <svg class="-ml-1 mr-1 h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+  <a href="{{ '/analytics/'|url }}" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200">
+    <svg class="-ml-1 mr-1 h-5 w-5 flex-shrink-0 text-gray-400 dark:text-neutral-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
       <path fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd" />
     </svg>
     Back
@@ -10,15 +10,15 @@
   <ol role="list" class="flex items-center space-x-4">
     <li>
       <div class="flex">
-        <a href="{{ '/analytics/'|url }}" class="text-sm font-medium text-gray-500 hover:text-gray-700">Overall Analytics</a>
+        <a href="{{ '/analytics/'|url }}" class="text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200">Overall Analytics</a>
       </div>
     </li>
     <li>
       <div class="flex items-center">
-        <svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <svg class="h-5 w-5 flex-shrink-0 text-gray-400 dark:text-neutral-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
         </svg>
-        <a href="{{ '/analytics/'|url }}?parent=1" class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700">Maths</a>
+        <a href="{{ '/analytics/'|url }}?parent=1" class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover-text-neutral-200">Maths</a>
       </div>
     </li>
   </ol>

--- a/src/analytics/includes/empty.html
+++ b/src/analytics/includes/empty.html
@@ -1,7 +1,7 @@
 <div class="mx-auto text-center px-4 py-5 sm:p-6">
-  <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-emerald-100">
+  <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-emerald-100 dark:bg-emerald-900/30">
     <svg
-      class="h-6 w-6 text-emerald-600"
+      class="h-6 w-6 text-emerald-600 dark:text-emerald-500"
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
@@ -15,7 +15,7 @@
       ></path>
     </svg>
   </div>
-  <h3 class="mt-2 text-lg leading-6 font-semibold text-gray-900">No data available</h3>
+  <h3 class="mt-2 text-lg leading-6 font-semibold text-gray-900 dark:text-neutral-100">No data available</h3>
   <p class="mt-1" x-cloak x-show="isFilteredByParent()">Looks like you have not attempted any question from this subject.</p>
   <p class="mt-1" x-cloak x-show="!isFilteredByParent()">Looks like you have not attempted any question belonging to a subject.</p>
 </div>

--- a/src/analytics/includes/graphical_reports.html
+++ b/src/analytics/includes/graphical_reports.html
@@ -5,18 +5,18 @@
 <div class="mt-8 flow-root">
   <ul role="list" class="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
     {% for stats in subject_analytics %}
-      <li class="col-span-1 flex flex-col divide-y divide-gray-200 rounded-lg bg-white text-center"
+      <li class="col-span-1 flex flex-col divide-y divide-gray-200 rounded-lg bg-white text-center dark:bg-neutral-800 dark:divide-neutral-700"
         x-cloak x-show="canShowStatsItem({{stats.parent_id}})">
         <div class="flex flex-1 flex-col">
-          <canvas id="chart_{{stats.id}}" x-init="createChartForSubject({{stats.correct_answers_count}}, {{stats.incorrect_answers_count}}, {{stats.unanswered_count}}, 'chart_{{stats.id}}')"></canvas>
-          <h3 class="mt-6 text-sm font-medium text-gray-900">{{stats.subject}}</h3>
+          <canvas id="chart_{{stats.id}}" x-init="createChartForSubject({{stats.correct_answers_count}}, {{stats.incorrect_answers_count}}, {{stats.unanswered_count}}, 'chart_{{stats.id}}')"></canvas>    
+          <h3 class="mt-6 text-sm font-medium text-gray-900 dark:text-neutral-100">{{stats.subject}}</h3>
 
           {% if stats.children %}
             <dl class="flex flex-grow flex-col justify-end">
-              <dd class="text-sm text-gray-500">
-                <span class="relative inline-flex flex-1 items-center justify-end rounded-br-lg border border-transparent text-sm font-semibold text-gray-900">
+              <dd class="text-sm text-gray-500 dark:text-neutral-500">
+                <span class="relative inline-flex flex-1 items-center justify-end rounded-br-lg border border-transparent text-sm font-semibold text-gray-900 dark:text-neutral-100">
                   <a href="{{ '/analytics/'|url }}?parent={{stats.id}}">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-400">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-400 dark:text-neutral-500 transition-colors">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25L21 12m0 0l-3.75 3.75M21 12H3" />
                     </svg>
                   </a>

--- a/src/analytics/includes/page_heading.html
+++ b/src/analytics/includes/page_heading.html
@@ -4,7 +4,7 @@
   </div>
   <div class="mt-2 md:flex md:items-center md:justify-between">
     <div class="min-w-0 flex-1">
-      <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight" x-text="isFilteredByParent() ? 'Maths' : 'Overall Analytics'"></h2>
+      <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight dark:text-neutral-100" x-text="isFilteredByParent() ? 'Maths' : 'Overall Analytics'"></h2>
     </div>
   </div>
 </div>

--- a/src/analytics/includes/pagination.html
+++ b/src/analytics/includes/pagination.html
@@ -1,8 +1,8 @@
-<nav class="border-t border-gray-200 px-4 flex items-center justify-between sm:px-0" aria-label="Pagination">
+<nav class="border-t border-gray-200 px-4 flex items-center justify-between sm:px-0 dark:border-neutral-700" aria-label="Pagination">
   <div class="-mt-px w-0 flex-1 flex">
     <a href="#"
-      class="border-t-2 border-transparent pt-4 pr-1 inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-200">
-      <svg class="mr-3 h-5 w-5 text-gray-400" x-description="Heroicon name: solid/arrow-narrow-left"
+      class="border-t-2 border-transparent pt-4 pr-1 inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-200 dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-600">
+      <svg class="mr-3 h-5 w-5 text-gray-400 dark:text-neutral-500" x-description="Heroicon name: solid/arrow-narrow-left"
         xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd"
           d="M7.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l2.293 2.293a1 1 0 010 1.414z"
@@ -13,36 +13,36 @@
   </div>
   <div class="hidden md:-mt-px md:flex">
     <a href="#"
-      class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium">
+      class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-600">
       1
     </a>
     <a href="#"
-      class="border-indigo-500 text-indigo-600 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium"
+      class="border-indigo-500 text-indigo-600 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium dark:text-emerald-400 dark:border-emerald-400"
       aria-current="page">
       2
     </a>
     <a href="#"
-      class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium">
+      class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-600">
       3
     </a>
     <a href="#"
-      class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium">
+      class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-600">
       4
     </a>
     <a href="#"
-      class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium">
+      class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-600">
       5
     </a>
     <a href="#"
-      class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium">
+      class="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200 border-t-2 pt-4 px-4 inline-flex items-center text-sm font-medium dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-600">
       6
     </a>
   </div>
   <div class="-mt-px w-0 flex-1 flex justify-end">
     <a href="#"
-      class="border-t-2 border-transparent pt-4 pl-1 inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-200">
+      class="border-t-2 border-transparent pt-4 pl-1 inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-200 dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-600">
       Next
-      <svg class="ml-3 h-5 w-5 text-gray-400" x-description="Heroicon name: solid/arrow-narrow-right"
+      <svg class="ml-3 h-5 w-5 text-gray-400 dark:text-neutral-500" x-description="Heroicon name: solid/arrow-narrow-right"
         xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd"
           d="M12.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-2.293-2.293a1 1 0 010-1.414z"

--- a/src/analytics/includes/tabs.html
+++ b/src/analytics/includes/tabs.html
@@ -2,35 +2,39 @@
   <div class="sm:hidden">
     <label for="tabs" class="sr-only">Select a tab</label>
     <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
-    <select id="tabs" name="tabs" class="block w-full rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500"
+    <select id="tabs" name="tabs" class="block w-full rounded-md border-gray-300 focus:border-emerald-500 focus:ring-emerald-500 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:focus:border-emerald-400 dark:focus:ring-emerald-400"
       @change="activeTab = $event.target.value">
       <option :selected="activeTab == 'tabular'" value="tabular">Tabular Reports</option>
       <option :selected="activeTab == 'graphical'" value="graphical">Graphical Reports</option>
     </select>
   </div>
   <div class="hidden sm:block">
-    <div class="border-b border-gray-200">
+    <div class="border-b border-gray-200 dark:border-neutral-700">
       <nav class="-mb-px flex space-x-8" aria-label="Tabs">
-        <!-- Current: "border-indigo-500 text-indigo-600", Default: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700" -->
+        
         <a href="#"
-          class="group inline-flex items-center border-b-2 py-4 px-1 text-sm font-medium"
-          :class="activeTab == 'tabular' ? 'border-indigo-500 text-indigo-600': 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'"
+          class="group inline-flex items-center border-b-2 py-4 px-1 text-sm font-medium transition-colors"
+          :class="activeTab == 'tabular' 
+            ? 'border-indigo-500 text-indigo-600 dark:border-emerald-600 dark:text-emerald-400' 
+            : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-500'"
           @click.prevent="activeTab = 'tabular'">
           <!-- Current: "text-indigo-500", Default: "text-gray-400 group-hover:text-gray-500" -->
           <svg viewBox="0 0 24 24" fill="currentColor"
-              class="-ml-0.5 mr-2 h-5 w-5"
-              :class="activeTab == 'tabular' ? 'text-indigo-500' : 'text-gray-400 group-hover:text-gray-500 '">
+              class="-ml-0.5 mr-2 h-5 w-5 transition-colors"
+              :class="activeTab == 'tabular' ? 'text-indigo-500 dark:text-emerald-400' : 'text-gray-400 group-hover:text-gray-500 dark:text-neutral-500 dark:group-hover:text-neutral-300'">
             <path fill-rule="evenodd" d="M1.5 5.625c0-1.036.84-1.875 1.875-1.875h17.25c1.035 0 1.875.84 1.875 1.875v12.75c0 1.035-.84 1.875-1.875 1.875H3.375A1.875 1.875 0 0 1 1.5 18.375V5.625zM21 9.375A.375.375 0 0 0 20.625 9h-7.5a.375.375 0 0 0-.375.375v1.5c0 .207.168.375.375.375h7.5a.375.375 0 0 0 .375-.375v-1.5zm0 3.75a.375.375 0 0 0-.375-.375h-7.5a.375.375 0 0 0-.375.375v1.5c0 .207.168.375.375.375h7.5a.375.375 0 0 0 .375-.375v-1.5zm0 3.75a.375.375 0 0 0-.375-.375h-7.5a.375.375 0 0 0-.375.375v1.5c0 .207.168.375.375.375h7.5a.375.375 0 0 0 .375-.375v-1.5zM10.875 18.75a.375.375 0 0 0 .375-.375v-1.5a.375.375 0 0 0-.375-.375h-7.5a.375.375 0 0 0-.375.375v1.5c0 .207.168.375.375.375h7.5zM3.375 15h7.5a.375.375 0 0 0 .375-.375v-1.5a.375.375 0 0 0-.375-.375h-7.5a.375.375 0 0 0-.375.375v1.5c0 .207.168.375.375.375zm0-3.75h7.5a.375.375 0 0 0 .375-.375v-1.5A.375.375 0 0 0 10.875 9h-7.5A.375.375 0 0 0 3 9.375v1.5c0 .207.168.375.375.375z" clip-rule="evenodd"/>
           </svg>
           <span>Tabular Reports</span>
         </a>
         <a href="#"
-          class="group inline-flex items-center border-b-2 py-4 px-1 text-sm font-medium"
-          :class="activeTab == 'graphical' ? 'border-indigo-500 text-indigo-600': 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'"
+          class="group inline-flex items-center border-b-2 py-4 px-1 text-sm font-medium transition-colors"
+          :class="activeTab == 'graphical' 
+            ? 'border-indigo-500 text-indigo-600 dark:border-emerald-600 dark:text-emerald-400' 
+            : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:border-neutral-500'"
           @click.prevent="activeTab = 'graphical'">
           <svg viewBox="0 0 24 24" fill="currentColor"
-              class="-ml-0.5 mr-2 h-5 w-5"
-              :class="activeTab == 'graphical' ? 'text-indigo-500' : 'text-gray-400 group-hover:text-gray-500 '">
+              class="-ml-0.5 mr-2 h-5 w-5 transition-colors"
+              :class="activeTab == 'graphical' ? 'text-indigo-500 dark:text-emerald-400' : 'text-gray-400 group-hover:text-gray-500 dark:text-neutral-500 dark:group-hover:text-neutral-300'">
             <path fill-rule="evenodd" d="M2.25 13.5a8.25 8.25 0 0 1 8.25-8.25.75.75 0 0 1 .75.75v6.75H18a.75.75 0 0 1 .75.75 8.25 8.25 0 0 1-16.5 0z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M12.75 3a.75.75 0 0 1 .75-.75 8.25 8.25 0 0 1 8.25 8.25.75.75 0 0 1-.75.75h-7.5a.75.75 0 0 1-.75-.75V3z" clip-rule="evenodd"/>
           </svg>
           <span>Graphical Reports</span>

--- a/src/analytics/includes/tabular_reports.html
+++ b/src/analytics/includes/tabular_reports.html
@@ -1,28 +1,28 @@
 <div class="mt-3 flow-root">
   <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
     <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-      <table class="min-w-full divide-y divide-gray-300">
+      <table class="min-w-full divide-y divide-gray-300 dark:divide-neutral-700">
         <thead>
           <tr>
-            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0">Subject</th>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Correct</th>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Incorrect</th>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Unanswered</th>
+            <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-neutral-100 sm:pl-0">Subject</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-100">Correct</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-100">Incorrect</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-neutral-100">Unanswered</th>
             <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0">
               <span class="sr-only">Detail</span>
             </th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-200">
+        <tbody class="divide-y divide-gray-200 dark:divide-neutral-700">
           {% for stats in subject_analytics %}
-            <tr x-cloak x-show="canShowStatsItem({{stats.parent_id}})">
-              <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-0">{{stats.subject}}</td>
-              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{stats.correct_answers_count}}</td>
-              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{stats.incorrect_answers_count}}</td>
-              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{{stats.unanswered_count}}</td>
+            <tr x-cloak x-show="canShowStatsItem({{stats.parent_id}})" class="hover:bg-gray-50 dark:hover:bg-neutral-700/50 transition-colors">
+              <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 dark:text-neutral-200 sm:pl-0">{{stats.subject}}</td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{stats.correct_answers_count}}</td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{stats.incorrect_answers_count}}</td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-neutral-400">{{stats.unanswered_count}}</td>
               <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
                 {% if stats.children %}
-                  <a href="{{ '/analytics/'|url }}?parent={{stats.id}}" class="text-indigo-600 hover:text-indigo-900">Detail</a>
+                  <a href="{{ '/analytics/'|url }}?parent={{stats.id}}" class="text-indigo-600 hover:text-indigo-900 dark:text-emerald-400 dark:hover:text-emerald-300">Detail</a>
                 {% endif %}
               </td>
             </tr>

--- a/src/analytics/index.html
+++ b/src/analytics/index.html
@@ -4,18 +4,16 @@ tags: testpress
 title: Overall Analytics
 ---
 
-{% extends "layouts/student_base.html" %}
+{% extends "src/testpress/layout/student_layout.html" %}
 
-{% block body_class %}overflow-y-scroll min-h-screen bg-gray-100{% endblock %}
+{% block body_class %}overflow-y-scroll min-h-screen bg-gray-100 dark:bg-neutral-900{% endblock %}
 
-{% block content %}
-  {% include "partials/student_navbar.html" %}
-
+{% block main_content %}
   <div class="py-10 max-w-7xl mx-auto lg:px-8" x-data="getAnalyticsUIData()">
     {% include './includes/page_heading.html' %}
 
     <main class="pt-8">
-      <div class="px-4 py-6 sm:px-6 lg:px-8 overflow-hidden bg-white border-b border-gray-200 shadow sm:rounded-lg">
+      <div class="px-4 py-6 sm:px-6 lg:px-8 overflow-hidden bg-white border-b border-gray-200 shadow sm:rounded-lg dark:bg-neutral-800 dark:border-neutral-700">
 
         {% if subject_analytics.length %}
           {% include './includes/tabs_content.html' %}


### PR DESCRIPTION
- This commit adds dark mode support for overall analytics.
- Updates analytics tables, charts, breadcrumbs, tabs, pagination, and empty states for dark mode.
- Adds Tailwind dark classes and dynamic text colors for better readability.
- Adds base layout of student with sidebar and navbar.