### PR TITLE
fix: Overflowing content in report card tooltips in admin UI list view

### DIFF
--- a/src/testpress/report_cards/admin/list/draft_reports.html
+++ b/src/testpress/report_cards/admin/list/draft_reports.html
@@ -73,14 +73,16 @@
                   <div x-show="(report.exams || []).length > 2" class="hs-tooltip [--trigger:click] sm:[--placement:right]">
                     <button type="button" class="hs-tooltip-toggle cursor-pointer font-medium p-2 text-gray-800 text-xs rounded-md whitespace-nowrap">
                       +<span x-text="(report.exams || []).length - 2"></span> more
-                      <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-10 max-w-xs w-auto bg-white border border-gray-100 text-start rounded-xl shadow-md after:absolute after:top-0 after:-start-4 after:w-4 after:h-full" role="tooltip">
-                        <ul class="py-3 px-4 space-y-1 list-disc list-inside text-sm text-gray-800">
-                          <template x-for="exam in (report.exams || []).slice(2)" :key="exam.id">
-                            <li>
+                      <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-10 max-w-xs w-auto bg-white border border-gray-100 text-start rounded-xl shadow-md p-1.5 after:absolute after:top-0 after:-start-4 after:w-4 after:h-full">
+                        <div class="max-h-60 overflow-y-auto overflow-x-hidden rounded-lg [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full">
+                          <ul class="py-2 px-3 space-y-1 list-disc list-inside text-sm text-gray-800">
+                            <template x-for="exam in (report.exams || []).slice(2)" :key="exam.id">
+                              <li>
                               <span class="hover:text-blue-600 decoration-2 hover:underline hover:cursor-pointer" x-text="exam.name"></span>
-                            </li>
-                          </template>
-                        </ul>
+                              </li>
+                            </template>
+                          </ul>
+                        </div>  
                       </div>
                     </button>
                   </div>
@@ -97,14 +99,16 @@
                   <div x-show="(report.chapter_content || []).length > 2" class="hs-tooltip [--trigger:click] sm:[--placement:right]">
                     <button type="button" class="hs-tooltip-toggle cursor-pointer font-medium p-2 text-gray-800 text-xs rounded-md whitespace-nowrap">
                       +<span x-text="(report.chapter_content || []).length - 2"></span> more
-                      <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-10 max-w-xs w-auto bg-white border border-gray-100 text-start rounded-xl shadow-md after:absolute after:top-0 after:-start-4 after:w-4 after:h-full" role="tooltip">
-                        <ul class="py-3 px-4 space-y-1 list-disc list-inside text-sm text-gray-800">
-                          <template x-for="content in (report.chapter_content || []).slice(2)" :key="content.id">
-                            <li>
+                      <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-10 max-w-xs w-auto bg-white border border-gray-100 text-start rounded-xl shadow-md p-1.5 after:absolute after:top-0 after:-start-4 after:w-4 after:h-full">
+                        <div class="max-h-60 overflow-y-auto overflow-x-hidden rounded-lg [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full">
+                          <ul class="py-2 px-3 space-y-1 list-disc list-inside text-sm text-gray-800">
+                            <template x-for="content in (report.chapter_content || []).slice(2)" :key="content.id">
+                              <li>
                               <span class="hover:text-blue-600 decoration-2 hover:underline hover:cursor-pointer" x-text="content.name"></span>
-                            </li>
-                          </template>
-                        </ul>
+                              </li>
+                            </template>
+                          </ul>
+                        </div>  
                       </div>
                     </button>
                   </div>

--- a/src/testpress/report_cards/admin/list/published_reports.html
+++ b/src/testpress/report_cards/admin/list/published_reports.html
@@ -73,14 +73,16 @@
                   <div x-show="(report.exams || []).length > 2" class="hs-tooltip [--trigger:click] sm:[--placement:right]">
                     <button type="button" class="hs-tooltip-toggle cursor-pointer font-medium p-2 text-gray-800 text-xs rounded-md whitespace-nowrap">
                       +<span x-text="(report.exams || []).length - 2"></span> more
-                      <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-10 max-w-xs w-auto bg-white border border-gray-100 text-start rounded-xl shadow-md after:absolute after:top-0 after:-start-4 after:w-4 after:h-full" role="tooltip">
-                        <ul class="py-3 px-4 space-y-1 list-disc list-inside text-sm text-gray-800">
-                          <template x-for="exam in (report.exams || []).slice(2)" :key="exam.id">
-                            <li>
+                      <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-10 max-w-xs w-auto bg-white border border-gray-100 text-start rounded-xl shadow-md p-1.5 after:absolute after:top-0 after:-start-4 after:w-4 after:h-full">
+                        <div class="max-h-60 overflow-y-auto overflow-x-hidden rounded-lg [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full">
+                          <ul class="py-2 px-3 space-y-1 list-disc list-inside text-sm text-gray-800">
+                            <template x-for="exam in (report.exams || []).slice(2)" :key="exam.id">
+                              <li>
                               <span class="hover:text-blue-600 decoration-2 hover:underline hover:cursor-pointer" x-text="exam.name"></span>
-                            </li>
-                          </template>
-                        </ul>
+                              </li>
+                            </template>
+                          </ul>
+                        </div>  
                       </div>
                     </button>
                   </div>
@@ -97,14 +99,16 @@
                   <div x-show="(report.chapter_content || []).length > 2" class="hs-tooltip [--trigger:click] sm:[--placement:right]">
                     <button type="button" class="hs-tooltip-toggle cursor-pointer font-medium p-2 text-gray-800 text-xs rounded-md whitespace-nowrap">
                       +<span x-text="(report.chapter_content || []).length - 2"></span> more
-                      <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-10 max-w-xs w-auto bg-white border border-gray-100 text-start rounded-xl shadow-md after:absolute after:top-0 after:-start-4 after:w-4 after:h-full" role="tooltip">
-                        <ul class="py-3 px-4 space-y-1 list-disc list-inside text-sm text-gray-800">
-                          <template x-for="content in (report.chapter_content || []).slice(2)" :key="content.id">
-                            <li>
+                      <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-10 max-w-xs w-auto bg-white border border-gray-100 text-start rounded-xl shadow-md p-1.5 after:absolute after:top-0 after:-start-4 after:w-4 after:h-full">
+                        <div class="max-h-60 overflow-y-auto overflow-x-hidden rounded-lg [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full">
+                          <ul class="py-2 px-3 space-y-1 list-disc list-inside text-sm text-gray-800">
+                            <template x-for="content in (report.chapter_content || []).slice(2)" :key="content.id">
+                              <li>
                               <span class="hover:text-blue-600 decoration-2 hover:underline hover:cursor-pointer" x-text="content.name"></span>
-                            </li>
-                          </template>
-                        </ul>
+                              </li>
+                            </template>
+                          </ul>
+                        </div>  
                       </div>
                     </button>
                   </div>


### PR DESCRIPTION
- Tooltips in both draft and published report card lists extend beyond the screen height when a report is associated with numerous exams or chapters.
- This layout issue occurs because the tooltip containers lacked a defined maximum height and scroll behavior, resulting in inaccessible links for users.
- The unreachable content prevents administrators from viewing or interacting with the full list of associated items, degrading the usability of the report management dashboard.
- A scrollable area with a 240px (max-h-60) height limit is now applied to these tooltips, ensuring all items are reachable regardless of list length.