### PR TITLE
ui: Add original and transcoded size breakdown to video details

### DIFF
--- a/src/tpstreams/assets/includes/asset_detail_basic_info.html
+++ b/src/tpstreams/assets/includes/asset_detail_basic_info.html
@@ -49,7 +49,12 @@
             d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
         </svg>
       </dt>
-      <dd class="text-sm leading-6 text-gray-500">This video takes up about <strong>2.3 GB</strong> of space</dd>
+      <dd class="text-sm leading-6 text-gray-500">
+        This video takes up about <strong>2.3 GB</strong> of space
+        <div class="mt-1">
+          (1.2 GB original • 1.1 GB transcoded)
+        </div>
+      </dd>
     </div>
     <div class="flex flex-none w-full gap-x-4" x-show="!disableAnalytics">
       <dt class="flex-none">


### PR DESCRIPTION
#### Why this change is made? ####
Currently the asset detail page shows the total video size as a sum of source and transcoded file sizes.Showing only the total size hides important context about how much is the original video size.

This change makes the storage information on the video detail page more useful by showing how the total file size is split between the original upload and the transcoded output. This gives users a clearer view of the asset storage breakdown and makes the size information easier to understand at a glance.

#### What Changed ####
- added a second line showing the original size and transcoded size breakdown



