### PR TITLE
feat: Use consistent thumbnail sizing for chapter content in course Home tab

### DIFF
--- a/src/testpress/course/detail/recent_activity.html
+++ b/src/testpress/course/detail/recent_activity.html
@@ -3,10 +3,11 @@
   <div class="mt-2 divide-y divide-gray-100 dark:divide-neutral-700 border-b border-gray-100 dark:border-neutral-700">
     <!-- Item 1 -->
     <div class="py-4 px-4 sm:px-6  transition-colors hover:bg-gray-50 dark:hover:bg-neutral-700">
-      <a href="#" class="flex gap-x-3 items-center focus:outline-none">
-        <div class="size-10 flex shrink-0 items-center justify-center">
-          <img class="size-10 object-contain"
-            src="https://d36vpug2b5drql.cloudfront.net/static/courses/general/1442850373_115.png" alt="Exam" />
+      <a href="#" class="flex gap-x-4 items-start focus:outline-none">
+        <div class="relative w-32 h-18 flex flex-shrink-0 mt-0.5 justify-center">
+          <img class="w-32 h-18 object-cover rounded"
+            src="{{'/img/content_thumbnails/exam.png'|url}}" alt="Exam" />
+          <span class="absolute bottom-0 right-0 bg-black bg-opacity-50 text-white text-xs px-2 py-0.5 rounded">Exam</span>
         </div>
         <div class="min-w-0 flex-1">
           <h2 class="font-medium text-gray-800 dark:text-neutral-200">
@@ -29,9 +30,10 @@
 
     <!-- Item 2 -->
     <div class="py-4 px-4 sm:px-6  transition-colors hover:bg-gray-50 dark:hover:bg-neutral-700">
-      <a href="#" class="flex gap-x-3 items-center focus:outline-none">
-        <div class="size-10 flex shrink-0 items-center justify-center">
-          <img class="size-10 object-contain" src="https://static.testpress.in/static/img/videoicon.png" alt="Video" />
+      <a href="#" class="flex gap-x-4 items-start focus:outline-none">
+        <div class="relative w-32 h-18 flex flex-shrink-0 mt-0.5 justify-center">
+          <img class="w-32 h-18 object-cover rounded" src="{{'/img/content_thumbnails/video.png'|url}}" alt="Video" />
+          <span class="absolute bottom-0 right-0 bg-black bg-opacity-50 text-white text-xs px-2 py-0.5 rounded">Video</span>
         </div>
         <div class="min-w-0 flex-1">
           <h2 class="font-medium text-gray-800 dark:text-neutral-200">
@@ -54,9 +56,10 @@
 
     <!-- Item 3 -->
     <div class="py-4 px-4 sm:px-6  transition-colors hover:bg-gray-50 dark:hover:bg-neutral-700">
-      <a href="#" class="flex gap-x-3 items-center focus:outline-none">
-        <div class="size-10 flex shrink-0 items-center justify-center">
-          <img class="size-10 object-contain" src="https://static.testpress.in/static/img/bookicon.png" alt="PDF" />
+      <a href="#" class="flex gap-x-4 items-start focus:outline-none">
+        <div class="relative w-32 h-18 flex flex-shrink-0 mt-0.5 justify-center">
+          <img class="w-32 h-18 object-cover rounded" src="{{'/img/content_thumbnails/pdf.png'|url}}" alt="PDF" />
+          <span class="absolute bottom-0 right-0 bg-black bg-opacity-50 text-white text-xs px-2 py-0.5 rounded">PDF</span>
         </div>
         <div class="min-w-0 flex-1">
           <h2 class="font-medium text-gray-800 dark:text-neutral-200">
@@ -79,9 +82,9 @@
 
     <!-- Item 4 -->
     <div class="py-4 px-4 sm:px-6  transition-colors hover:bg-gray-50 dark:hover:bg-neutral-700">
-      <a href="#" class="flex gap-x-3 items-center focus:outline-none">
-        <div class="size-10 flex shrink-0 items-center justify-center">
-          <img class="size-10 object-contain" src="https://static.testpress.in/static/img/live_conference.png" alt="Live" />
+      <a href="#" class="flex gap-x-4 items-start focus:outline-none">
+        <div class="relative w-32 h-18 flex flex-shrink-0 mt-0.5 justify-center">
+          <img class="w-16 h-16 object-cover rounded" src="{{'/img/content_thumbnails/default_zoom.png'|url}}" alt="Live" />
         </div>
         <div class="min-w-0 flex-1">
           <h2 class="font-medium text-gray-800 dark:text-neutral-200">

--- a/src/testpress/course/detail/whats_next.html
+++ b/src/testpress/course/detail/whats_next.html
@@ -2,13 +2,12 @@
   <h2 class="px-4 text-sm font-medium text-gray-900 dark:text-neutral-100 sm:px-6 sm:text-base">Continue Learning</h2>
   <div class="mt-2">
     <div class="pt-4 px-4 sm:px-6">
-      <div class="flex gap-x-3">
-        <!-- Icon column -->
-        <div class="size-10 flex shrink-0 items-center justify-center">
-          <img class="size-10 object-contain"
-            src="https://d36vpug2b5drql.cloudfront.net/static/courses/general/1442850373_115.png" alt="Exam" />
+      <div class="flex items-start gap-x-4">
+        <div class="relative w-32 h-18 flex flex-shrink-0 mt-0.5 justify-center">
+          <img class="w-32 h-18 object-cover rounded"
+            src="{{'/img/content_thumbnails/exam.png'|url}}" alt="Exam" />
+          <span class="absolute bottom-0 right-0 bg-black bg-opacity-50 text-white text-xs px-2 py-0.5 rounded">Exam</span>
         </div>
-        <!-- Title + meta + buttons: row on all screens, button at end -->
         <div class="min-w-0 flex-1 flex flex-row justify-between items-start gap-2">
           <div class="min-w-0">
             <h2 class="text-sm font-medium text-gray-800 dark:text-neutral-200 sm:text-base min-w-0 truncate">


### PR DESCRIPTION
- Updated chapter thumbnail image sizing in the Home tab.
- Aligned thumbnail/container size with Running, History, and Upcoming tabs.
- Reused the existing design pattern from the Running tab for consistency.

**Todo**
https://3.basecamp.com/4160028/buckets/46316535/card_tables/cards/9736692429