### PR TITLE
feat: Add empty view for payout runlist

### DIFF
--- a/src/payout_runs/list/empty/index.html
+++ b/src/payout_runs/list/empty/index.html
@@ -1,0 +1,30 @@
+---
+tags: testpress
+title: Payout Runs – Empty
+---
+{% extends "layouts/staff_base.html" %}
+
+{% block body_class %}bg-gray-100 {% endblock %}
+
+{% block content %}
+
+<div class="py-10 max-w-7xl mx-auto lg:px-8 px-4 space-y-5">
+  {% include "../header.html" %}
+  {% include "../create_payout_run_modal.html" %}
+
+  <!-- Empty State Card -->
+  <div class="bg-white border border-gray-200 shadow-sm rounded-xl">
+    <div class="flex flex-col items-center justify-center text-center px-6 py-24 sm:py-32 md:py-40">
+      <h2 class="text-lg font-semibold text-gray-800">No payout runs yet</h2>
+      <p class="mt-2 text-sm text-gray-500 max-w-sm">
+        Payout runs will appear here once they are created.
+      </p>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block script %}
+{% include "../payout_script.html" %}
+{% endblock script %}


### PR DESCRIPTION
- Added a separate empty state page for Payout Runs when no data is available.
- Displays a clear message indicating no payout runs exist yet.
- Hides status counters and table in empty state.

**Todo** 
https://3.basecamp.com/4160028/buckets/45752257/todos/9740452625