### PR TITLE
feat: Display tags in  batches table and enable inline tag editing

### DIFF
--- a/src/batches/batches.json
+++ b/src/batches/batches.json
@@ -6,6 +6,7 @@
       "modified": "April 20, 2024",
       "number_of_users": "23",
       "modified_by": "Hannah Mayer",
+      "tags": ["2024", "Priority", "Pro"],
       "members": [
         {
           "id": 1,
@@ -86,6 +87,7 @@
       "modified": "April 20, 2024",
       "number_of_users": "5",
       "modified_by": "John Doe",
+      "tags": ["UPSC", "History"],
       "members": [
         {
           "id": 2,
@@ -158,6 +160,7 @@
       "modified": "April 20, 2024",
       "number_of_users": "5",
       "modified_by": "Alice Johnson",
+      "tags": ["Economy"],
       "members": [
         {
           "id": 7,
@@ -230,6 +233,7 @@
       "modified": "April 20, 2024",
       "number_of_users": "5",
       "modified_by": "Sarah Thompson",
+      "tags": [],
       "members": [
         {
           "id": 12,
@@ -302,6 +306,7 @@
       "modified": "April 20, 2024",
       "number_of_users": "5",
       "modified_by": "Michael Brown",
+      "tags": ["Art", "Literature"],
       "members": [
         {
           "id": 17,

--- a/src/batches/list/includes/filter_script.html
+++ b/src/batches/list/includes/filter_script.html
@@ -1,12 +1,41 @@
 <script>
   function batchListScript() {
     return {
+      editingBatchId: null,
+      tempTags: '',
       applyOrdering(path, ordering) {
         const searchParams = new URLSearchParams(window.location.search);
         searchParams.set('o', ordering); 
         const newUrl = `${path}?${searchParams.toString()}`;
         window.location.href = newUrl;
       },
+      startEdit(batchId, currentTags) {
+        this.editingBatchId = batchId;
+        this.tempTags = currentTags.join(', ');
+      },
+      cancelEdit() {
+        this.editingBatchId = null;
+        this.tempTags = '';
+      },
+      saveTags(batchId, batch) {
+        const newTags = this.tempTags.split(',')
+          .map(t => t.trim())
+          .filter(t => t !== '');
+        // deduplicate
+        batch.tags = [...new Set(newTags)];
+
+        // Persist to LocalStorage for demonstration
+        const allSavedTags = JSON.parse(localStorage.getItem('batch_tags') || '{}');
+        allSavedTags[batchId] = batch.tags;
+        localStorage.setItem('batch_tags', JSON.stringify(allSavedTags));
+
+        this.editingBatchId = null;
+        this.tempTags = '';
+      },
+      getTags(batchId, initialTags) {
+        const allSavedTags = JSON.parse(localStorage.getItem('batch_tags') || '{}');
+        return allSavedTags[batchId] || initialTags;
+      }
     }
   }
 

--- a/src/batches/list/includes/filter_script.html
+++ b/src/batches/list/includes/filter_script.html
@@ -35,7 +35,13 @@
       getTags(batchId, initialTags) {
         const allSavedTags = JSON.parse(localStorage.getItem('batch_tags') || '{}');
         return allSavedTags[batchId] || initialTags;
+      },
+      updateBatchTags(batchId, tags) {
+        const allSavedTags = JSON.parse(localStorage.getItem('batch_tags') || '{}');
+        allSavedTags[batchId] = tags;
+        localStorage.setItem('batch_tags', JSON.stringify(allSavedTags));
       }
+
     }
   }
 

--- a/src/batches/list/includes/table_header.html
+++ b/src/batches/list/includes/table_header.html
@@ -33,7 +33,7 @@
           </div>
         </div>
       </div>
-    </th>
+
 
     {% if show_billing_category %}
       <!-- Billing -->
@@ -114,6 +114,17 @@
         </div>
       </div>
     </th>
+
+    <!-- Tags -->
+    <th scope="col">
+      <div class="hs-dropdown relative inline-flex w-full cursor-pointer">
+        <button type="button"
+          class="px-4 py-2.5 text-start w-full flex items-center gap-x-1 text-sm font-normal text-stone-500 focus:outline-none focus:bg-stone-100">
+          Tags
+        </button>
+      </div>
+    </th>
+
 
     <!-- Actions -->
     <th scope="col" class="text-end">

--- a/src/batches/list/includes/table_item.html
+++ b/src/batches/list/includes/table_item.html
@@ -96,7 +96,10 @@
             <svg class="shrink-0 size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
           </button>
 
-          <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 opacity-0 hidden z-[100] transition-[opacity,margin] duration-100 w-96 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] p-5 border border-stone-200" aria-labelledby="hs-dropdown-tags-{{ batch.id }}">
+          <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 opacity-0 hidden z-[100] transition-[opacity,margin] duration-100 w-96 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] p-5 pb-8 border border-stone-200 overflow-visible min-h-[310px]" aria-labelledby="hs-dropdown-tags-{{ batch.id }}">
+
+
+
             <div class="flex justify-between items-center mb-4">
               <h3 class="text-base font-bold text-stone-800">Tags</h3>
               <button type="button" class="hs-dropdown-toggle text-stone-400 hover:text-stone-600 focus:outline-none transition-colors">
@@ -121,7 +124,8 @@
               <!-- Suggestions Dropdown -->
               <div x-show="isInputFocused || tagSearch.trim().length > 0" 
                    @click.stop
-                   class="absolute z-[110] w-full mt-2 max-h-72 p-1 space-y-0.5 bg-white border border-gray-200 rounded-lg shadow-xl overflow-hidden overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300">
+                   class="absolute z-[110] w-full mt-2 max-h-[185px] p-1 space-y-0.5 bg-white border border-gray-200 rounded-lg shadow-xl overflow-hidden overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300">
+
 
                 <div class="flex flex-col">
                   <template x-for="tag in filteredTags" :key="tag">
@@ -135,11 +139,17 @@
 
                   <template x-if="tagSearch.trim().length > 0 && !allTags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim()) && !batch.tags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim())">
                     <button 
-                      @click="addTag(tagSearch)"
+                      @click.stop="addTag(tagSearch)"
                       class="py-2 px-4 w-full text-start text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-none focus:bg-gray-100 border-t border-gray-100 transition-colors"
                     >
                       Add "<span x-text="tagSearch"></span>"
                     </button>
+                  </template>
+
+                  <template x-if="tagSearch.trim().length === 0 && filteredTags.length === 0">
+                    <div class="py-2 px-4 text-sm text-gray-400 italic">
+                      No more tags available
+                    </div>
                   </template>
 
                   <template x-if="tagSearch.trim().length > 0 && filteredTags.length === 0 && (allTags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim()) || batch.tags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim()))">
@@ -151,12 +161,13 @@
               </div>
             </div>
 
+
             <!-- Existing Tags -->
-            <div class="flex flex-wrap gap-1.5">
+            <div class="flex flex-wrap gap-1.5" @click.stop>
               <template x-for="(tag, index) in batch.tags" :key="tag">
                 <span class="inline-flex items-center gap-x-1 py-0.5 px-2 rounded-full text-[11px] font-medium bg-stone-100 text-stone-600 border border-stone-200">
                   <span x-text="tag"></span>
-                  <button @click="removeTag(index)" class="text-stone-400 hover:text-stone-600 focus:outline-none transition-colors">
+                  <button @click.stop="removeTag(index)" class="text-stone-400 hover:text-stone-600 focus:outline-none transition-colors">
                     <svg class="size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
                   </button>
                 </span>

--- a/src/batches/list/includes/table_item.html
+++ b/src/batches/list/includes/table_item.html
@@ -42,11 +42,13 @@
           </template>
           
           <template x-if="batch.tags.length > 2">
-            <div class="hs-tooltip inline-block [--placement:bottom]">
-              <span class="hs-tooltip-toggle cursor-pointer font-medium text-stone-500 hover:text-stone-800 text-[11px] py-1 px-0.5 transition-colors">
+            <div class="hs-dropdown relative inline-block [--strategy:fixed] [--placement:bottom]">
+              <button id="hs-dropdown-more-{{ batch.id }}" type="button" 
+                      class="hs-dropdown-toggle cursor-pointer font-medium text-stone-500 hover:text-stone-800 text-[11px] py-1 px-0.5 transition-colors focus:outline-none">
                 +<span x-text="batch.tags.length - 2"></span> more
-              </span>
-              <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-20 w-48 bg-white border border-stone-200 text-start rounded-xl shadow-lg p-3" role="tooltip">
+              </button>
+              
+              <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 opacity-0 hidden z-[100] transition-[opacity,margin] duration-100 w-48 bg-white border border-stone-200 text-start rounded-xl shadow-lg p-3 max-h-60 overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300" aria-labelledby="hs-dropdown-more-{{ batch.id }}">
                 <div class="flex flex-col gap-y-1">
                   <template x-for="tag in batch.tags.slice(2)" :key="tag">
                     <span class="text-xs font-medium text-stone-600 bg-stone-50 px-2 py-1.5 rounded border border-stone-100 whitespace-nowrap" x-text="tag"></span>
@@ -62,19 +64,22 @@
           </template>
         </div>
 
-        <!-- Tags Trigger & Popover -->
-        <div class="relative inline-block" 
+        <!-- Tags Trigger & Popover (Preline Dropdown) -->
+        <div class="hs-dropdown relative inline-flex [--strategy:fixed] [--placement:bottom-right]" 
              x-data="{ 
-               showTagsPopover: false, 
                tagSearch: '', 
+               isInputFocused: false,
                allTags: ['Priority', '2024', 'UPSC', 'History', 'Economy', 'Art', 'Literature', 'Exam', 'Mock', 'Practice'],
                get filteredTags() {
-                 if (this.tagSearch.trim() === '') return [];
-                 return this.allTags.filter(t => t.toLowerCase().startsWith(this.tagSearch.toLowerCase().trim()) && !batch.tags.includes(t));
+                 const search = this.tagSearch.trim().toLowerCase();
+                 return this.allTags.filter(t => 
+                   t.toLowerCase().startsWith(search) && 
+                   !batch.tags.map(bt => bt.toLowerCase()).includes(t.toLowerCase())
+                 );
                },
                addTag(tag) {
                  const trimmed = tag.trim();
-                 if (trimmed && !batch.tags.includes(trimmed)) {
+                 if (trimmed && !batch.tags.map(bt => bt.toLowerCase()).includes(trimmed.toLowerCase())) {
                    batch.tags.push(trimmed);
                    updateBatchTags(batch.id, batch.tags);
                  }
@@ -85,41 +90,28 @@
                  updateBatchTags(batch.id, batch.tags);
                }
              }">
-          <div class="hs-tooltip inline-block [--placement:bottom]">
-            <button type="button" 
-                    @click="showTagsPopover = !showTagsPopover"
-                    class="hs-tooltip-toggle inline-flex items-center gap-x-1 py-0.5 px-1.5 rounded-full border border-stone-200 bg-white text-stone-500 text-[11px] font-medium shadow-sm hover:bg-stone-50 focus:outline-none transition-colors">
-              <svg class="shrink-0 size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
-            </button>
-            <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-50 py-1 px-2 bg-stone-800 text-white text-[11px] rounded shadow-sm" role="tooltip">
-              Edit tags
-            </div>
-          </div>
+          
+          <button id="hs-dropdown-tags-{{ batch.id }}" type="button" 
+                  class="hs-dropdown-toggle inline-flex items-center gap-x-1 py-0.5 px-1.5 rounded-full border border-stone-200 bg-white text-stone-500 text-[11px] font-medium shadow-sm hover:bg-stone-50 focus:outline-none transition-colors">
+            <svg class="shrink-0 size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
+          </button>
 
-          <!-- Popover -->
-          <div x-show="showTagsPopover" 
-               x-transition:enter="transition ease-out duration-100"
-               x-transition:enter-start="opacity-0 scale-95"
-               x-transition:enter-end="opacity-100 scale-100"
-               x-transition:leave="transition ease-in duration-75"
-               x-transition:leave-start="opacity-100 scale-100"
-               x-transition:leave-end="opacity-0 scale-95"
-               @click.away="showTagsPopover = false"
-               class="absolute right-0 top-full mt-2 w-96 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] z-50 p-5 border border-stone-200">
-            
+          <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 opacity-0 hidden z-[100] transition-[opacity,margin] duration-100 w-96 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] p-5 border border-stone-200" aria-labelledby="hs-dropdown-tags-{{ batch.id }}">
             <div class="flex justify-between items-center mb-4">
               <h3 class="text-base font-bold text-stone-800">Tags</h3>
-              <button @click="showTagsPopover = false" class="text-stone-400 hover:text-stone-600 focus:outline-none transition-colors">
+              <button type="button" class="hs-dropdown-toggle text-stone-400 hover:text-stone-600 focus:outline-none transition-colors">
                 <svg class="size-5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
               </button>
             </div>
 
             <!-- Tag Search/Input -->
-            <div class="relative mb-4">
+            <div class="relative mb-4" @click.stop>
               <div class="w-full min-h-[44px] px-3 py-2 border border-stone-200 rounded-lg bg-white flex flex-wrap gap-1.5 items-center cursor-text focus-within:border-green-500 focus-within:ring-1 focus-within:ring-green-500 transition-all">
                 <input 
                   type="text" 
                   x-model="tagSearch" 
+                  @focus="isInputFocused = true"
+                  @blur="setTimeout(() => isInputFocused = false, 200)"
                   @keydown.enter.prevent="addTag(tagSearch)"
                   placeholder="Type to search or add tag..." 
                   class="flex-1 min-w-[120px] border-none focus:ring-0 p-0 text-sm placeholder:text-stone-400 bg-transparent"
@@ -127,37 +119,36 @@
               </div>
 
               <!-- Suggestions Dropdown -->
-              <div x-show="tagSearch.trim().length > 0" 
-                   class="absolute z-[60] w-full mt-1 bg-white border border-stone-200 rounded-lg shadow-xl py-1">
+              <div x-show="isInputFocused || tagSearch.trim().length > 0" 
+                   @click.stop
+                   class="absolute z-[110] w-full mt-2 max-h-72 p-1 space-y-0.5 bg-white border border-gray-200 rounded-lg shadow-xl overflow-hidden overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300">
+
                 <div class="flex flex-col">
                   <template x-for="tag in filteredTags" :key="tag">
                     <button 
                       @click="addTag(tag)"
-                      class="w-full text-start px-4 py-2 text-sm text-stone-700 hover:bg-stone-50 focus:outline-none transition-colors"
+                      class="py-2 px-4 w-full text-start text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-none focus:bg-gray-100 transition-colors"
                     >
                       <span x-text="tag"></span>
                     </button>
                   </template>
-                  
+
                   <template x-if="tagSearch.trim().length > 0 && !allTags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim()) && !batch.tags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim())">
                     <button 
                       @click="addTag(tagSearch)"
-                      class="w-full text-start px-4 py-2 text-sm text-stone-700 hover:bg-stone-50 focus:outline-none transition-colors border-t border-stone-100"
+                      class="py-2 px-4 w-full text-start text-sm text-gray-800 cursor-pointer hover:bg-gray-100 rounded-lg focus:outline-none focus:bg-gray-100 border-t border-gray-100 transition-colors"
                     >
                       Add "<span x-text="tagSearch"></span>"
                     </button>
                   </template>
 
-
                   <template x-if="tagSearch.trim().length > 0 && filteredTags.length === 0 && (allTags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim()) || batch.tags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim()))">
-                    <div class="px-4 py-2 text-sm text-stone-400 italic">
+                    <div class="py-2 px-4 text-sm text-gray-400 italic">
                       Tag already exists or added
                     </div>
                   </template>
                 </div>
               </div>
-
-
             </div>
 
             <!-- Existing Tags -->
@@ -175,8 +166,6 @@
                 <span class="text-xs text-stone-400 italic">No tags added</span>
               </template>
             </div>
-
-
           </div>
         </div>
       </div>

--- a/src/batches/list/includes/table_item.html
+++ b/src/batches/list/includes/table_item.html
@@ -1,14 +1,50 @@
 {% for batch in batches_list %}
-  <tr>
+  <tr x-data='{ batch: { id: {{ batch.id }}, name: {{ batch.name | dump | safe }}, tags: getTags({{ batch.id }}, {{ batch.tags | dump | safe }}) } }'>
 
     <!-- Batch Name -->
-    <td class="size-px whitespace-nowrap px-5 py-3">
-      <div class="w-full flex items-center gap-x-3">
-        <div class="grow">
+    <td class="size-px whitespace-nowrap px-5 py-3 align-top">
+      <div class="w-full flex flex-col group">
+        <div class="grow flex items-center gap-x-2">
           <a class="text-sm font-medium text-stone-800 hover:text-green-600 decoration-2 hover:underline"
             href="{{ '/batches/detail'|url }}">
             {{ batch.name }}
           </a>
+        </div>
+        
+        <!-- Tags Display -->
+        <div class="mt-1.5 flex flex-wrap items-center gap-1" x-show="editingBatchId !== batch.id">
+          <template x-if="batch.tags.length === 0">
+            <span class="text-[11px] text-stone-400 italic">No tags</span>
+          </template>
+          <template x-for="tag in batch.tags" :key="tag">
+            <span class="inline-flex items-center gap-x-1.5 py-0.5 px-2 rounded-full text-[11px] font-medium bg-stone-100 text-stone-600 border border-stone-200">
+              <span x-text="tag"></span>
+            </span>
+          </template>
+          <button @click="startEdit(batch.id, batch.tags); $nextTick(() => $refs.tagInput.focus())" 
+                  class="p-1 text-stone-400 hover:text-stone-600 focus:outline-none"
+                  title="Edit Tags">
+            <svg class="shrink-0 size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
+          </button>
+        </div>
+
+        <!-- Edit Mode -->
+        <div x-show="editingBatchId === batch.id" x-cloak class="mt-2 flex flex-col gap-y-2">
+          <input x-ref="tagInput" type="text" x-model="tempTags" 
+                 @keydown.enter="saveTags(batch.id, batch)"
+                 @keydown.escape="cancelEdit()"
+                 class="py-1 px-2 block w-full border-stone-200 rounded-md text-xs focus:border-green-500 focus:ring-green-500 disabled:opacity-50 disabled:pointer-events-none" 
+                 placeholder="Enter tags (comma separated)">
+          <div class="flex items-center gap-x-2">
+            <button @click="saveTags(batch.id, batch)" 
+                    class="py-1 px-2 inline-flex items-center gap-x-1 text-[11px] font-medium rounded-md border border-transparent bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:ring-2 focus:ring-green-500">
+              Save
+            </button>
+            <button @click="cancelEdit()" 
+                    class="py-1 px-2 inline-flex items-center gap-x-1 text-[11px] font-medium rounded-md border border-stone-200 bg-white text-stone-800 shadow-sm hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:ring-2 focus:ring-stone-500">
+              Cancel
+            </button>
+          </div>
         </div>
       </div>
     </td>

--- a/src/batches/list/includes/table_item.html
+++ b/src/batches/list/includes/table_item.html
@@ -1,5 +1,5 @@
 {% for batch in batches_list %}
-  <tr x-data="{ batch: { id: {{ batch.id }}, name: {{ batch.name | dump }}, tags: getTags({{ batch.id }}, {{ batch.tags | dump }}) } }">
+  <tr class="group" x-data="{ batch: { id: {{ batch.id }}, name: {{ batch.name | dump }}, tags: getTags({{ batch.id }}, {{ batch.tags | dump }}) } }">
 
     <!-- Batch Name -->
     <td class="size-px whitespace-nowrap px-5 py-3 align-top">
@@ -92,7 +92,7 @@
              }">
           
           <button id="hs-dropdown-tags-{{ batch.id }}" type="button" 
-                  class="hs-dropdown-toggle inline-flex items-center gap-x-1 py-0.5 px-1.5 rounded-full border border-stone-200 bg-white text-stone-500 text-[11px] font-medium shadow-sm hover:bg-stone-50 focus:outline-none transition-colors">
+                  class="hs-dropdown-toggle invisible group-hover:visible inline-flex items-center gap-x-1 py-0.5 px-1.5 rounded-full border border-stone-200 bg-white text-stone-500 text-[11px] font-medium shadow-sm hover:bg-stone-50 focus:outline-none transition-colors">
             <svg class="shrink-0 size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
           </button>
 

--- a/src/batches/list/includes/table_item.html
+++ b/src/batches/list/includes/table_item.html
@@ -1,5 +1,5 @@
 {% for batch in batches_list %}
-  <tr x-data='{ batch: { id: {{ batch.id }}, name: {{ batch.name | dump | safe }}, tags: getTags({{ batch.id }}, {{ batch.tags | dump | safe }}) } }'>
+  <tr x-data="{ batch: { id: {{ batch.id }}, name: {{ batch.name | dump }}, tags: getTags({{ batch.id }}, {{ batch.tags | dump }}) } }">
 
     <!-- Batch Name -->
     <td class="size-px whitespace-nowrap px-5 py-3 align-top">

--- a/src/batches/list/includes/table_item.html
+++ b/src/batches/list/includes/table_item.html
@@ -11,43 +11,10 @@
           </a>
         </div>
         
-        <!-- Tags Display -->
-        <div class="mt-1.5 flex flex-wrap items-center gap-1" x-show="editingBatchId !== batch.id">
-          <template x-if="batch.tags.length === 0">
-            <span class="text-[11px] text-stone-400 italic">No tags</span>
-          </template>
-          <template x-for="tag in batch.tags" :key="tag">
-            <span class="inline-flex items-center gap-x-1.5 py-0.5 px-2 rounded-full text-[11px] font-medium bg-stone-100 text-stone-600 border border-stone-200">
-              <span x-text="tag"></span>
-            </span>
-          </template>
-          <button @click="startEdit(batch.id, batch.tags); $nextTick(() => $refs.tagInput.focus())" 
-                  class="p-1 text-stone-400 hover:text-stone-600 focus:outline-none"
-                  title="Edit Tags">
-            <svg class="shrink-0 size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
-          </button>
-        </div>
-
-        <!-- Edit Mode -->
-        <div x-show="editingBatchId === batch.id" x-cloak class="mt-2 flex flex-col gap-y-2">
-          <input x-ref="tagInput" type="text" x-model="tempTags" 
-                 @keydown.enter="saveTags(batch.id, batch)"
-                 @keydown.escape="cancelEdit()"
-                 class="py-1 px-2 block w-full border-stone-200 rounded-md text-xs focus:border-green-500 focus:ring-green-500 disabled:opacity-50 disabled:pointer-events-none" 
-                 placeholder="Enter tags (comma separated)">
-          <div class="flex items-center gap-x-2">
-            <button @click="saveTags(batch.id, batch)" 
-                    class="py-1 px-2 inline-flex items-center gap-x-1 text-[11px] font-medium rounded-md border border-transparent bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:ring-2 focus:ring-green-500">
-              Save
-            </button>
-            <button @click="cancelEdit()" 
-                    class="py-1 px-2 inline-flex items-center gap-x-1 text-[11px] font-medium rounded-md border border-stone-200 bg-white text-stone-800 shadow-sm hover:bg-stone-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus:ring-2 focus:ring-stone-500">
-              Cancel
-            </button>
-          </div>
-        </div>
       </div>
     </td>
+
+
 
     <!-- Users -->
     <td class="size-px whitespace-nowrap px-4 py-3 text-start">
@@ -61,6 +28,160 @@
       <span class="text-sm text-stone-600">
         {{ batch.assigned_courses.length }}
       </span>
+    </td>
+
+    <!-- Tags -->
+    <td class="size-px whitespace-nowrap px-4 py-3 align-top">
+      <div class="flex items-center gap-x-2">
+        <!-- Tags Display (Simba Style) -->
+        <div class="flex flex-wrap gap-1 items-center">
+          <template x-for="(tag, index) in batch.tags.slice(0, 2)" :key="tag">
+            <span class="py-1 px-2.5 bg-stone-100 text-stone-800 text-[11px] font-medium rounded-md border border-stone-200 truncate max-w-[140px]">
+              <span x-text="tag"></span>
+            </span>
+          </template>
+          
+          <template x-if="batch.tags.length > 2">
+            <div class="hs-tooltip inline-block [--placement:bottom]">
+              <span class="hs-tooltip-toggle cursor-pointer font-medium text-stone-500 hover:text-stone-800 text-[11px] py-1 px-0.5 transition-colors">
+                +<span x-text="batch.tags.length - 2"></span> more
+              </span>
+              <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-20 w-48 bg-white border border-stone-200 text-start rounded-xl shadow-lg p-3" role="tooltip">
+                <div class="flex flex-col gap-y-1">
+                  <template x-for="tag in batch.tags.slice(2)" :key="tag">
+                    <span class="text-xs font-medium text-stone-600 bg-stone-50 px-2 py-1.5 rounded border border-stone-100 whitespace-nowrap" x-text="tag"></span>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </template>
+
+
+          <template x-if="batch.tags.length === 0">
+            <span class="text-[11px] text-stone-400 italic">No tags</span>
+          </template>
+        </div>
+
+        <!-- Tags Trigger & Popover -->
+        <div class="relative inline-block" 
+             x-data="{ 
+               showTagsPopover: false, 
+               tagSearch: '', 
+               allTags: ['Priority', '2024', 'UPSC', 'History', 'Economy', 'Art', 'Literature', 'Exam', 'Mock', 'Practice'],
+               get filteredTags() {
+                 if (this.tagSearch.trim() === '') return [];
+                 return this.allTags.filter(t => t.toLowerCase().startsWith(this.tagSearch.toLowerCase().trim()) && !batch.tags.includes(t));
+               },
+               addTag(tag) {
+                 const trimmed = tag.trim();
+                 if (trimmed && !batch.tags.includes(trimmed)) {
+                   batch.tags.push(trimmed);
+                   updateBatchTags(batch.id, batch.tags);
+                 }
+                 this.tagSearch = '';
+               },
+               removeTag(index) {
+                 batch.tags.splice(index, 1);
+                 updateBatchTags(batch.id, batch.tags);
+               }
+             }">
+          <div class="hs-tooltip inline-block [--placement:bottom]">
+            <button type="button" 
+                    @click="showTagsPopover = !showTagsPopover"
+                    class="hs-tooltip-toggle inline-flex items-center gap-x-1 py-0.5 px-1.5 rounded-full border border-stone-200 bg-white text-stone-500 text-[11px] font-medium shadow-sm hover:bg-stone-50 focus:outline-none transition-colors">
+              <svg class="shrink-0 size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
+            </button>
+            <div class="hs-tooltip-content hs-tooltip-shown:opacity-100 hs-tooltip-shown:visible hidden opacity-0 transition-opacity absolute invisible z-50 py-1 px-2 bg-stone-800 text-white text-[11px] rounded shadow-sm" role="tooltip">
+              Edit tags
+            </div>
+          </div>
+
+          <!-- Popover -->
+          <div x-show="showTagsPopover" 
+               x-cloak
+               x-transition:enter="transition ease-out duration-100"
+               x-transition:enter-start="opacity-0 scale-95"
+               x-transition:enter-end="opacity-100 scale-100"
+               x-transition:leave="transition ease-in duration-75"
+               x-transition:leave-start="opacity-100 scale-100"
+               x-transition:leave-end="opacity-0 scale-95"
+               @click.away="showTagsPopover = false"
+               class="absolute right-0 top-full mt-2 w-96 bg-white rounded-xl shadow-[0_10px_40px_10px_rgba(0,0,0,0.08)] z-50 p-5 border border-stone-200">
+            
+            <div class="flex justify-between items-center mb-4">
+              <h3 class="text-base font-bold text-stone-800">Tags</h3>
+              <button @click="showTagsPopover = false" class="text-stone-400 hover:text-stone-600 focus:outline-none transition-colors">
+                <svg class="size-5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+              </button>
+            </div>
+
+            <!-- Tag Search/Input -->
+            <div class="relative mb-4">
+              <div class="w-full min-h-[44px] px-3 py-2 border border-stone-200 rounded-lg bg-white flex flex-wrap gap-1.5 items-center cursor-text focus-within:border-green-500 focus-within:ring-1 focus-within:ring-green-500 transition-all">
+                <input 
+                  type="text" 
+                  x-model="tagSearch" 
+                  @keydown.enter.prevent="addTag(tagSearch)"
+                  placeholder="Type to search or add tag..." 
+                  class="flex-1 min-w-[120px] border-none focus:ring-0 p-0 text-sm placeholder:text-stone-400 bg-transparent"
+                >
+              </div>
+
+              <!-- Suggestions Dropdown -->
+              <div x-show="tagSearch.trim().length > 0" 
+                   x-cloak
+                   class="absolute z-[60] w-full mt-1 bg-white border border-stone-200 rounded-lg shadow-xl py-1">
+                <div class="flex flex-col">
+                  <template x-for="tag in filteredTags" :key="tag">
+                    <button 
+                      @click="addTag(tag)"
+                      class="w-full text-start px-4 py-2 text-sm text-stone-700 hover:bg-stone-50 focus:outline-none transition-colors"
+                    >
+                      <span x-text="tag"></span>
+                    </button>
+                  </template>
+                  
+                  <template x-if="tagSearch.trim().length > 0 && !allTags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim()) && !batch.tags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim())">
+                    <button 
+                      @click="addTag(tagSearch)"
+                      class="w-full text-start px-4 py-2 text-sm text-stone-700 hover:bg-stone-50 focus:outline-none transition-colors border-t border-stone-100"
+                    >
+                      Add "<span x-text="tagSearch"></span>"
+                    </button>
+                  </template>
+
+
+                  <template x-if="tagSearch.trim().length > 0 && filteredTags.length === 0 && (allTags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim()) || batch.tags.map(t => t.toLowerCase()).includes(tagSearch.toLowerCase().trim()))">
+                    <div class="px-4 py-2 text-sm text-stone-400 italic">
+                      Tag already exists or added
+                    </div>
+                  </template>
+                </div>
+              </div>
+
+
+            </div>
+
+            <!-- Existing Tags -->
+            <div class="flex flex-wrap gap-1.5">
+              <template x-for="(tag, index) in batch.tags" :key="tag">
+                <span class="inline-flex items-center gap-x-1 py-0.5 px-2 rounded-full text-[11px] font-medium bg-stone-100 text-stone-600 border border-stone-200">
+                  <span x-text="tag"></span>
+                  <button @click="removeTag(index)" class="text-stone-400 hover:text-stone-600 focus:outline-none transition-colors">
+                    <svg class="size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                  </button>
+                </span>
+              </template>
+
+              <template x-if="batch.tags.length === 0">
+                <span class="text-xs text-stone-400 italic">No tags added</span>
+              </template>
+            </div>
+
+
+          </div>
+        </div>
+      </div>
     </td>
 
     <!-- Actions -->

--- a/src/batches/list/includes/table_item.html
+++ b/src/batches/list/includes/table_item.html
@@ -98,7 +98,6 @@
 
           <!-- Popover -->
           <div x-show="showTagsPopover" 
-               x-cloak
                x-transition:enter="transition ease-out duration-100"
                x-transition:enter-start="opacity-0 scale-95"
                x-transition:enter-end="opacity-100 scale-100"
@@ -129,7 +128,6 @@
 
               <!-- Suggestions Dropdown -->
               <div x-show="tagSearch.trim().length > 0" 
-                   x-cloak
                    class="absolute z-[60] w-full mt-1 bg-white border border-stone-200 rounded-lg shadow-xl py-1">
                 <div class="flex flex-col">
                   <template x-for="tag in filteredTags" :key="tag">

--- a/tailwind.css
+++ b/tailwind.css
@@ -41,4 +41,8 @@
   .dark ::-webkit-scrollbar-thumb:hover {
     @apply bg-neutral-500;
   }
+
+  [x-cloak] {
+    display: none !important;
+  }
 }

--- a/tailwind.css
+++ b/tailwind.css
@@ -41,8 +41,4 @@
   .dark ::-webkit-scrollbar-thumb:hover {
     @apply bg-neutral-500;
   }
-
-  [x-cloak] {
-    display: none !important;
-  }
 }


### PR DESCRIPTION
Display tags below the batch name in the "Name" column
- Added inline edit (pencil) icon for each batch row
- Implemented inline tag editing UI:
  - Switch to edit mode on click
  - Allow adding/removing tags
  - Save/Cancel actions
- Handled empty state ("No tags")
- Ensured tags wrap properly for long lists

Basecamp Link:
https://3.basecamp.com/4160028/buckets/47045307/todos/9827969085