### PR TITLE
fix: Show validation error message for invalid folder name in bookmarks page

### DIFF
--- a/src/testpress/bookmarks/add_folder_modal.html
+++ b/src/testpress/bookmarks/add_folder_modal.html
@@ -45,22 +45,25 @@
             <label for="folder-name" class="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">Folder Name</label>
             <input 
               x-model="newFolderName"
-              @keyup.enter="showAddFolderModal = false; console.log('Creating folder:', newFolderName); newFolderName = ''"
+              @keyup.enter="if (isValidFolderName() && newFolderName.trim() !== '') { showAddFolderModal = false; console.log('Creating folder:', newFolderName); newFolderName = '' }"
               type="text" 
               id="folder-name" 
-              class="block w-full rounded-xl border-gray-200 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-200 dark:placeholder-neutral-500" 
+              class="block w-full rounded-xl px-4 py-3 text-sm focus:ring-blue-500 dark:bg-neutral-800 dark:text-neutral-200 dark:placeholder-neutral-500"
+              :class="!isValidFolderName() ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : 'border-gray-200 focus:border-blue-500 dark:border-neutral-700'"
               placeholder="e.g. Physics Formula Sheets"
               autofocus
             >
-            <p class="mt-2 text-xs text-gray-500 dark:text-neutral-500">Pick a name that helps you organize your bookmarks.</p>
+            <p x-show="!isValidFolderName()" x-cloak class="mt-2 text-xs text-red-500">Use only letters, numbers, spaces, -, _ and &</p>
+            <p x-show="isValidFolderName()" class="mt-2 text-xs text-gray-500 dark:text-neutral-500">Pick a name that helps you organize your bookmarks.</p>
           </div>
         </div>
         
         <div class="bg-gray-50 px-6 py-4 flex flex-row-reverse gap-x-3 dark:bg-neutral-800/50">
           <button 
             @click="showAddFolderModal = false; console.log('Creating folder:', newFolderName); newFolderName = ''"
+            :disabled="!isValidFolderName() || newFolderName.trim() === ''"
             type="button" 
-            class="inline-flex justify-center rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus:outline-hidden transition-all"
+            class="inline-flex justify-center rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus:outline-hidden transition-all disabled:opacity-50 disabled:pointer-events-none"
           >
             Create Folder
           </button>

--- a/src/testpress/bookmarks/bookmark_filter_component.html
+++ b/src/testpress/bookmarks/bookmark_filter_component.html
@@ -11,6 +11,12 @@
     showAddFolderModal: false,
     newFolderName: '',
 
+    isValidFolderName() {
+      if (this.newFolderName.trim() === '') return true;
+      const regex = /^[a-zA-Z0-9\s\-_&]+$/;
+      return regex.test(this.newFolderName);
+    },
+
     setType(id) {  
       this.selectedType = id;
     },

--- a/src/testpress/bookmarks/bookmark_filter_component.html
+++ b/src/testpress/bookmarks/bookmark_filter_component.html
@@ -9,6 +9,8 @@
 
     mobileFoldersOpen: false,
     showAddFolderModal: false,
+    showRenameFolderModal: false,
+    showDeleteFolderModal: false,
     newFolderName: '',
 
     isValidFolderName() {
@@ -71,6 +73,16 @@
 
     moveToFolder(bookmarkId, folderId) {
         console.log(`Moving bookmark ${bookmarkId} to folder: ${folderId}`);
+    },
+
+    openRenameModal(folderName) {
+        this.newFolderName = folderName;
+        this.showRenameFolderModal = true;
+    },
+
+    openDeleteModal(folderName) {
+        this.newFolderName = folderName;
+        this.showDeleteFolderModal = true;
     }
   };
 }

--- a/src/testpress/bookmarks/delete_folder_modal.html
+++ b/src/testpress/bookmarks/delete_folder_modal.html
@@ -1,0 +1,80 @@
+<!-- Delete Folder Modal (Pure Alpine) -->
+<template x-teleport="body">
+  <div 
+    x-show="showDeleteFolderModal" 
+    x-cloak
+    x-init="console.log('Delete Folder Modal Rendering')"
+    class="fixed inset-0 z-[10001] overflow-y-auto"
+    role="dialog" 
+    aria-modal="true"
+  >
+    <!-- Backdrop -->
+    <div 
+      x-show="showDeleteFolderModal"
+      x-transition:enter="ease-out duration-300"
+      x-transition:enter-start="opacity-0"
+      x-transition:enter-end="opacity-100"
+      x-transition:leave="ease-in duration-200"
+      x-transition:leave-start="opacity-100"
+      x-transition:leave-end="opacity-0"
+      @click="showDeleteFolderModal = false"
+      class="fixed inset-0 bg-gray-900/60 backdrop-blur-sm transition-opacity"
+    ></div>
+
+    <!-- Modal Content -->
+    <div class="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
+      <div 
+        x-show="showDeleteFolderModal"
+        x-transition:enter="ease-out duration-300"
+        x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+        x-transition:leave="ease-in duration-200"
+        x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+        x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        class="relative transform overflow-hidden rounded-xl bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-md dark:bg-neutral-800"
+      >
+        <!-- Close Button -->
+        <div class="absolute top-3 end-3 z-10">
+          <button @click="showDeleteFolderModal = false" type="button" class="size-8 shrink-0 flex justify-center items-center gap-x-2 rounded-full border border-transparent bg-gray-100 text-gray-800 hover:bg-gray-200 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:text-neutral-400 dark:focus:bg-neutral-600" aria-label="Close">
+            <span class="sr-only">Close</span>
+            <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M18 6 6 18"/>
+              <path d="m6 6 12 12"/>
+            </svg>
+          </button>
+        </div>
+        <!-- End Close Button -->
+
+        <!-- Body -->
+        <div class="p-4">
+          <h3 class="text-lg font-medium text-gray-800 dark:text-neutral-200">
+            Delete Folder
+          </h3>
+          <p class="mt-1 text-sm text-gray-600 dark:text-neutral-400">
+            Are you sure you want to delete the folder <span class="font-bold text-gray-900 dark:text-neutral-200" x-text="newFolderName"></span>? This action cannot be undone and all bookmarks in this folder will be moved to Uncategorized.
+          </p>
+
+          <!-- Button Group -->
+          <div class="mt-5 flex flex-wrap justify-end gap-2">
+            <button 
+              @click="showDeleteFolderModal = false"
+              type="button" 
+              class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-medium rounded-lg border border-gray-200 bg-white text-gray-800 shadow-2xs hover:bg-gray-50 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-gray-50 dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-700 dark:focus:bg-neutral-700"
+            >
+              Cancel
+            </button>
+            <button 
+              @click="showDeleteFolderModal = false; console.log('Deleting folder:', newFolderName); newFolderName = ''"
+              type="button" 
+              class="py-2 px-3 inline-flex items-center gap-x-2 text-xs font-medium rounded-lg border border-transparent bg-red-500 text-white hover:bg-red-600 disabled:opacity-50 disabled:pointer-events-none"
+            >
+              Delete
+            </button>
+          </div>
+          <!-- End Button Group -->
+        </div>
+        <!-- End Body -->
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/testpress/bookmarks/folder_list.html
+++ b/src/testpress/bookmarks/folder_list.html
@@ -4,7 +4,7 @@
             <ul role="list" class="relative z-0 divide-y divide-gray-100 dark:divide-neutral-800">
               <!-- All Bookmarks -->
               <!-- All Bookmarks -->
-              <li @click="setFolder('all')" class="relative flex items-center space-x-3 px-6 py-4 focus-within:ring-2 focus-within:ring-primary-500 focus-within:ring-inset cursor-pointer transition-colors duration-150" :class="isFolderSelected('all') ? 'bg-primary-50 dark:bg-primary-500/10' : 'hover:bg-gray-50 dark:hover:bg-neutral-800'">
+              <li @click="setFolder('all')" class="relative flex items-center space-x-3 px-6 py-4 cursor-pointer transition-colors duration-150" :class="isFolderSelected('all') ? 'bg-primary-50 dark:bg-primary-500/10' : 'hover:bg-gray-50 dark:hover:bg-neutral-800'">
                 <div class="shrink-0">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-8 text-primary-500">
                     <path d="M19.5 21a3 3 0 003-3v-4.5a3 3 0 00-3-3h-15a3 3 0 00-3 3V18a3 3 0 003 3h15zM1.5 10.146V6a3 3 0 013-3h5.379a2.25 2.25 0 011.59.659l2.122 2.121c.14.141.331.22.53.22H19.5a3 3 0 013 3v1.146A4.483 4.483 0 0019.5 9h-15a4.483 4.483 0 00-3 1.146z"></path>
@@ -23,7 +23,7 @@
               </li>
 
               <!-- Uncategorized -->
-              <li @click="setFolder('uncategorized')" class="relative flex items-center space-x-3 px-6 py-4 focus-within:ring-2 focus-within:ring-primary-500 focus-within:ring-inset cursor-pointer transition-colors duration-150" :class="isFolderSelected('uncategorized') ? 'bg-primary-50 dark:bg-primary-500/10' : 'hover:bg-gray-50 dark:hover:bg-neutral-800'">
+              <li @click="setFolder('uncategorized')" class="relative flex items-center space-x-3 px-6 py-4 cursor-pointer transition-colors duration-150" :class="isFolderSelected('uncategorized') ? 'bg-primary-50 dark:bg-primary-500/10' : 'hover:bg-gray-50 dark:hover:bg-neutral-800'">
                 <div class="shrink-0">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-8 text-gray-400">
                     <path d="M19.5 21a3 3 0 003-3v-4.5a3 3 0 00-3-3h-15a3 3 0 00-3 3V18a3 3 0 003 3h15zM1.5 10.146V6a3 3 0 013-3h5.379a2.25 2.25 0 011.59.659l2.122 2.121c.14.141.331.22.53.22H19.5a3 3 0 013 3v1.146A4.483 4.483 0 0019.5 9h-15a4.483 4.483 0 00-3 1.146z"></path>
@@ -45,7 +45,7 @@
               <!-- Dynamic Folders -->
               {% for folder in bookmark_folders %}
                 <li @click="setFolder({{ folder.id }})" 
-                    class="relative flex items-center space-x-3 px-6 py-4 focus-within:ring-2 focus-within:ring-primary-500 focus-within:ring-inset cursor-pointer transition-colors duration-150" 
+                    class="relative flex items-center space-x-3 px-6 py-4 cursor-pointer transition-colors duration-150" 
                     :class="isFolderSelected({{ folder.id }}) ? 'bg-primary-50 dark:bg-primary-500/10' : 'hover:bg-gray-50 dark:hover:bg-neutral-800'">
                   <div class="shrink-0">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-8 text-yellow-500/80">
@@ -56,6 +56,27 @@
                     <div class="focus:outline-hidden">
                       <p class="text-sm font-medium text-gray-900 dark:text-neutral-200 line-clamp-1">{{ folder.name }}</p>
                       <p class="truncate text-xs text-gray-500 dark:text-neutral-500 text-nowrap">{{ folder.count }} contents</p>
+                    </div>
+                  </div>
+
+                  <!-- Folder Actions Dropdown -->
+                  <div class="hs-dropdown [--placement:bottom-right] relative inline-flex" @click.stop>
+                    <button id="hs-pro-fldmd-{{ folder.id }}" type="button" class="size-7 inline-flex justify-center items-center text-gray-400 hover:bg-gray-100 rounded-full dark:text-neutral-500 dark:hover:bg-neutral-800 transition-colors focus:outline-none focus:bg-gray-100 dark:focus:bg-neutral-800">
+                      <svg class="shrink-0 size-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="8" r="1"></circle>
+                        <circle cx="12" cy="16" r="1"></circle>
+                      </svg>
+                    </button>
+
+                    <div class="hs-dropdown-menu hs-dropdown-open:opacity-100 w-32 z-50 transition-[opacity,margin] duration opacity-0 bg-white border border-gray-200 rounded-xl shadow-lg hidden dark:bg-neutral-900 dark:border-neutral-800" role="menu" aria-orientation="vertical" aria-labelledby="hs-pro-fldmd-{{ folder.id }}">
+                      <div class="p-1 space-y-0.5">
+                        <button @click="openRenameModal('{{ folder.name }}')" type="button" class="w-full flex items-center py-2 px-3 rounded-lg text-sm text-gray-800 dark:text-neutral-200 hover:bg-gray-100 dark:hover:bg-neutral-800">
+                          Rename
+                        </button>
+                        <button @click="openDeleteModal('{{ folder.name }}')" type="button" class="w-full flex items-center py-2 px-3 rounded-lg text-sm text-red-600 dark:text-red-500 hover:bg-gray-100 dark:hover:bg-neutral-800">
+                          Delete
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </li>

--- a/src/testpress/bookmarks/index.html
+++ b/src/testpress/bookmarks/index.html
@@ -49,6 +49,8 @@ new_student_page: true
 </style>
 <div x-data="useBookmarkFilter()" x-effect="selectedType; selectedFolderId; checkMatches()" x-init="console.log('Alpine Initialized', mobileFoldersOpen)" class="flex h-full">
   {% include "./add_folder_modal.html" %}
+  {% include "./rename_folder_modal.html" %}
+  {% include "./delete_folder_modal.html" %}
 
   <div class="flex min-w-0 flex-1 flex-col h-full min-h-0">
     <div class="relative z-20 flex flex-1 h-full min-h-0">

--- a/src/testpress/bookmarks/rename_folder_modal.html
+++ b/src/testpress/bookmarks/rename_folder_modal.html
@@ -1,0 +1,81 @@
+<!-- Rename Folder Modal (Pure Alpine) -->
+<template x-teleport="body">
+  <div 
+    x-show="showRenameFolderModal" 
+    x-cloak
+    x-init="console.log('Rename Folder Modal Rendering')"
+    class="fixed inset-0 z-[10001] overflow-y-auto"
+    role="dialog" 
+    aria-modal="true"
+  >
+    <!-- Backdrop -->
+    <div 
+      x-show="showRenameFolderModal"
+      x-transition:enter="ease-out duration-300"
+      x-transition:enter-start="opacity-0"
+      x-transition:enter-end="opacity-100"
+      x-transition:leave="ease-in duration-200"
+      x-transition:leave-start="opacity-100"
+      x-transition:leave-end="opacity-0"
+      @click="showRenameFolderModal = false"
+      class="fixed inset-0 bg-gray-900/60 backdrop-blur-sm transition-opacity"
+    ></div>
+
+    <!-- Modal Content -->
+    <div class="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
+      <div 
+        x-show="showRenameFolderModal"
+        x-transition:enter="ease-out duration-300"
+        x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+        x-transition:leave="ease-in duration-200"
+        x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+        x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        class="relative transform overflow-hidden rounded-2xl bg-white text-left shadow-2xl transition-all sm:my-8 sm:w-full sm:max-w-lg dark:bg-neutral-900"
+      >
+        <div class="px-6 pt-6 pb-4">
+          <div class="flex items-center justify-between mb-5">
+            <h3 class="text-xl font-bold text-gray-900 dark:text-neutral-200">Rename Folder</h3>
+            <button @click="showRenameFolderModal = false" type="button" class="text-gray-400 hover:text-gray-500 transition-colors">
+              <svg class="size-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+            </button>
+          </div>
+          
+          <div>
+            <label for="rename-folder-name" class="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-2">Folder Name</label>
+            <input 
+              x-model="newFolderName"
+              @keyup.enter="if (isValidFolderName() && newFolderName.trim() !== '') { showRenameFolderModal = false; console.log('Renaming folder to:', newFolderName); newFolderName = '' }"
+              type="text" 
+              id="rename-folder-name" 
+              class="block w-full rounded-xl px-4 py-3 text-sm focus:ring-blue-500 dark:bg-neutral-800 dark:text-neutral-200 dark:placeholder-neutral-500"
+              :class="!isValidFolderName() ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : 'border-gray-200 focus:border-blue-500 dark:border-neutral-700'"
+              placeholder="e.g. Physics Formula Sheets"
+              autofocus
+            >
+            <p x-show="!isValidFolderName()" x-cloak class="mt-2 text-xs text-red-500">Use only letters, numbers, spaces, -, _ and &</p>
+            <p x-show="isValidFolderName()" class="mt-2 text-xs text-gray-500 dark:text-neutral-500">Pick a new name for your folder.</p>
+          </div>
+        </div>
+        
+        <div class="bg-gray-50 px-6 py-4 flex flex-row-reverse gap-x-3 dark:bg-neutral-800/50">
+          <button 
+            @click="showRenameFolderModal = false; console.log('Renaming folder to:', newFolderName); newFolderName = ''"
+            :disabled="!isValidFolderName() || newFolderName.trim() === ''"
+            type="button" 
+            class="inline-flex justify-center rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus:outline-hidden transition-all disabled:opacity-50 disabled:pointer-events-none"
+          >
+            Rename Folder
+          </button>
+          <button 
+            @click="showRenameFolderModal = false"
+            type="button" 
+            class="inline-flex justify-center rounded-xl bg-white px-5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:outline-hidden dark:bg-neutral-900 dark:ring-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800 transition-all"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
- Users were shown browser alert popups when entering invalid folder names while creating or renaming bookmark folders in the new bookmarks page.
- This happened because folder name validation errors were handled through browser alerts instead of being displayed within the page UI.
- This is fixed by showing validation error messages inline within the bookmarks page for a more consistent and user-friendly experience.