### PR TITLE
feat: Add embedded live chat support for Fermion livestream page

### DIFF
--- a/src/testpress/content_detail_page/includes/content_heading.html
+++ b/src/testpress/content_detail_page/includes/content_heading.html
@@ -6,6 +6,7 @@
         <path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/>
       </svg>                
     </a>
+    {% if not show_live_chat_toggle %}
     <button data-hs-overlay="#hs-pro-shwprm"
       x-on:click="if (!is_completed) { is_completed = true, isFeedbackModalOpen = true }"
       :class="is_completed ? 'cursor-not-allowed opacity-50' : 'hover:bg-emerald-500'"
@@ -18,6 +19,7 @@
         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd"></path>
       </svg>
     </button>
+    {% endif %}
     
     <a class="cursor-pointer" x-on:click="toggleSVG = !toggleSVG" title="Bookmark" x-show="!isBookmarked" x-cloak>
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-emerald-600 dark:text-emerald-500">
@@ -29,8 +31,20 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l1.664 1.664M21 21l-1.5-1.5m-5.485-1.242L12 17.25 4.5 21V8.742m.164-4.078a2.15 2.15 0 011.743-1.342 48.507 48.507 0 0111.186 0c1.1.128 1.907 1.077 1.907 2.185V19.5M4.664 4.664L19.5 19.5" />
       </svg>                
     </a>
+
+    {% if show_live_chat_toggle %}
+    <button type="button" class="py-1.5 px-3 inline-flex items-center gap-x-2 text-xs font-medium rounded-lg bg-emerald-600 dark:bg-emerald-500 border border-transparent text-white hover:bg-emerald-700 dark:hover:bg-emerald-600 disabled:opacity-50 disabled:pointer-events-none focus:outline-hidden focus:bg-emerald-700 dark:focus:bg-emerald-600" x-show="!isChatOpen" @click="$dispatch('toggle-transcript')">
+      <svg class="shrink-0 size-2.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M2.992 16.342a2 2 0 0 1 .094 1.167l-1.065 3.29a1 1 0 0 0 1.236 1.168l3.413-.998a2 2 0 0 1 1.099.092 10 10 0 1 0-4.777-4.719"></path>
+      </svg>
+      Chat
+    </button>
+    {% endif %}
+
+
   </div>
 </div>
+{% if not show_live_chat_toggle %}
 <button
       x-data="{ is_completed: false}"
       x-on:click="!is_completed && (is_completed = true)"
@@ -44,6 +58,7 @@
         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd"></path>
       </svg>
 </button>
+{% endif %}
 <div class="flex justify-end" x-show="!toggleSVG" x-cloak>
   <div class="absolute z-10">
     <input id="combobox" type="text" class="w-full rounded-md border-0 bg-white py-1.5 pl-3 pr-12 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-emerald-600 text-sm leading-6 dark:bg-neutral-900 dark:text-neutral-200 dark:ring-neutral-700 dark:placeholder:text-neutral-500" role="combobox" aria-controls="options" aria-expanded="false" placeholder="Search folder...">

--- a/src/testpress/content_detail_page/includes/video_with_live_content.html
+++ b/src/testpress/content_detail_page/includes/video_with_live_content.html
@@ -1,0 +1,103 @@
+<div class="lg:px-8" x-data="{
+  toggleSVG: true,
+  isBookmarked: false,
+  is_renderable: false,
+  isDarkTheme: document.documentElement.classList.contains('dark'),
+  isChatOpen: true
+}"
+x-on:theme-changed.window="isDarkTheme = $event.detail.isDark"
+x-on:chat-status.window="isChatOpen = $event.detail.isOpen"
+>
+  {% set show_live_chat_toggle = true %}
+  {% include "./content_heading.html" %}
+  <div class="mt-6">
+    <div
+      class="flex flex-col lg:flex-row lg:items-stretch lg:gap-6"
+      x-data="{ showTranscript: true }"
+      x-on:toggle-transcript.window="showTranscript = !showTranscript"
+      x-effect="if (showTranscript) { $nextTick(() => syncChatHeight()) };
+                $dispatch('chat-status', { isOpen: showTranscript });
+                const themeStr = isDarkTheme ? 'dark' : 'light';
+                const iframes = [$el.querySelector('iframe'), $refs.chatIframe].filter(Boolean);
+                iframes.forEach(iframe => {
+                  if (iframe.contentWindow) {
+                    iframe.contentWindow.postMessage({ type: 'theme', theme: themeStr }, '*');
+                    iframe.contentWindow.postMessage({ type: 'set-theme', theme: themeStr }, '*');
+                    iframe.contentWindow.postMessage({ theme: themeStr }, '*');
+                  }
+                })"
+    >
+      <div class="flex-1">
+        <div id="live-video-container" class="w-full max-lg:aspect-video bg-black overflow-hidden rounded-md">
+          <iframe
+            class="w-full h-full"
+            :src="'https://testpress.fermion.app/embed/live-session?liveEventSessionId=6a05bdc1cd0b6de68c802f59&token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaXZlRXZlbnRTZXNzaW9uSWQiOiI2YTA1YmRjMWNkMGI2ZGU2OGM4MDJmNTkiLCJ1c2VySWQiOiIxNTkyOTciLCJ1c2VyTmFtZSI6ImJwYWxhMiIsIm5hbWUiOiJicGFsYTIiLCJwbGF5YmFja09wdGlvbnMiOnsiY3VzdG9tQnJhbmRpbmdEYXRhIjp7Im5hbWUiOiJUZXN0cHJlc3MgTE1TIERlbW8iLCJsb2dvVXJsIjoiaHR0cHM6Ly9kMzZ2cHVnMmI1ZHJxbC5jbG91ZGZyb250Lm5ldC9pbnN0aXR1dGUvbG1zZGVtby9pbnN0aXR1dGVzL2xtcy1kZW1vLzA0YjRiZmFjNmQ4OTQzODI5M2U5ZWRjMTMwZTE2YjEwLmpwZyJ9fX0.QN1W3m3YsMzv51s2sZV5-1RWLungDuntOTyTGvG5Df4&theme=' + (isDarkTheme ? 'dark' : 'light')"
+            allow="allow-same-origin; camera *;microphone *;display-capture *;encrypted-media;"
+            title="Fermion Livestream"
+            allowfullscreen="">
+          </iframe>
+        </div>
+      </div>
+      <div
+        class="mt-6 lg:mt-0 lg:w-1/3"
+        x-show="showTranscript"
+        x-transition:enter="transition ease-out duration-200"
+        x-transition:enter-start="opacity-0 translate-x-2"
+        x-transition:enter-end="opacity-100 translate-x-0"
+        x-transition:leave="transition ease-in duration-150"
+        x-transition:leave-start="opacity-100 translate-x-0"
+        x-transition:leave-end="opacity-0 translate-x-2"
+      >
+        <div
+          id="live-chat-box"
+          class="flex h-full flex-col text-sm leading-relaxed text-gray-900 dark:text-neutral-200 border border-gray-200 dark:border-neutral-700 rounded-md bg-white dark:bg-neutral-900"
+        >
+          <div class="py-2.5 px-4 flex justify-between items-center border-b border-gray-200 dark:border-neutral-700">
+            <h3 class="font-medium text-foreground text-sm">
+              Live Chat
+            </h3>
+            <button
+              type="button"
+              class="shrink-0 flex items-center justify-center text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200 focus:outline-hidden"
+              aria-label="Close live chat"
+              @click="showTranscript = false"
+            >
+              <span class="sr-only">Close live chat</span>
+              <svg class="shrink-0 w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 6 6 18"></path>
+                <path d="m6 6 12 12"></path>
+              </svg>
+            </button>
+          </div>
+          <div class="flex-1 min-h-0">
+            <iframe
+              x-ref="chatIframe"
+              class="w-full h-full"
+              :src="'https://testpress.fermion.app/embed/live-session-chat?liveEventSessionId=6a05bdc1cd0b6de68c802f59&token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaXZlRXZlbnRTZXNzaW9uSWQiOiI2YTA1YmRjMWNkMGI2ZGU2OGM4MDJmNTkiLCJ1c2VySWQiOiIxNTkyOTciLCJ1c2VyTmFtZSI6ImJwYWxhMiIsIm5hbWUiOiJicGFsYTIiLCJwbGF5YmFja09wdGlvbnMiOnsiY3VzdG9tQnJhbmRpbmdEYXRhIjp7Im5hbWUiOiJUZXN0cHJlc3MgTE1TIERlbW8iLCJsb2dvVXJsIjoiaHR0cHM6Ly9kMzZ2cHVnMmI1ZHJxbC5jbG91ZGZyb250Lm5ldC9pbnN0aXR1dGUvbG1zZGVtby9pbnN0aXR1dGVzL2xtcy1kZW1vLzA0YjRiZmFjNmQ4OTQzODI5M2U5ZWRjMTMwZTE2YjEwLmpwZyJ9fX0.QN1W3m3YsMzv51s2sZV5-1RWLungDuntOTyTGvG5Df4&theme=' + (isDarkTheme ? 'dark' : 'light')"
+              allow="allow-same-origin; camera *;microphone *;display-capture *;encrypted-media;"
+              title="Embedded Content"
+              allowfullscreen="">
+            </iframe>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% include "./video_question_modal.html" %}
+  </div>
+</div>
+<div class="px-4 lg:px-8">
+  <div class="mt-6 text-sm text-gray-900 description dark:text-neutral-200" x-data="{ showFullDescription: false }">
+    <div x-cloak x-show="!showFullDescription">
+      <span id="desc-chaptercontent-id" class="short-description">
+        Discover the secrets of digital marketing in this comprehensive guide! From SEO strategies to social media growth, we cover everything you need to boost your brand online. Learn expert tips, proven techniques, and the latest trends to stay ahead of the competition. Watch now and start growing!...
+      </span>
+      <span @click="showFullDescription = true" class="text-emerald-600 text-bold cursor-pointe dark:text-emerald-400">Show More</span>
+    </div>
+    <div x-cloak x-show="showFullDescription">
+      <span id="full-desc-chaptercontent-id" class="full-description">
+        Discover the secrets of digital marketing in this comprehensive guide! From SEO strategies to social media growth, we cover everything you need to boost your brand online. Learn expert tips, proven techniques, and the latest trends to stay ahead of the competition. Watch now and start growing! Learn how to optimize your website for search engines, create engaging content, and drive organic traffic that converts. We explore the importance of keyword research, backlink building, and on-page SEO to ensure your content ranks higher on Google.
+      </span>
+      <span @click="showFullDescription = false" class="text-emerald-600 text-bold cursor-pointer dark:text-emerald-400">Show Less</span>
+    </div>
+  </div>
+</div>

--- a/src/testpress/content_detail_page/video_with_live.html
+++ b/src/testpress/content_detail_page/video_with_live.html
@@ -1,0 +1,114 @@
+---
+title: Content Detail Page
+date: 2023-05-30
+---
+
+{% extends "layouts/student_base.html" %}
+{% block script %}
+<script>
+  function syncChatHeight() {
+    const videoContainer = document.getElementById('live-video-container');
+    const chatBox = document.getElementById('live-chat-box');
+    if (videoContainer && chatBox) {
+      if (window.innerWidth >= 1024) {
+        // Desktop behavior: stretch video to fill remaining screen space
+        document.body.style.overflow = ''; // Release scroll lock
+        
+        // Calculate the absolute top of the video container regardless of scroll position
+        const absoluteTop = videoContainer.getBoundingClientRect().top + window.scrollY;
+        
+        // Calculate exactly how much space is left to hit the bottom of the screen
+        // (subtracting 24px to leave a clean bottom margin matching the layout's gap)
+        const targetHeight = window.innerHeight - absoluteTop - 24;
+        
+        // Ensure the video doesn't get crushed on extremely wide/short monitors
+        if (targetHeight > 350) {
+          videoContainer.style.height = targetHeight + "px";
+        } else {
+          videoContainer.style.height = "500px"; // Safe fallback
+        }
+        
+        chatBox.style.height = ''; // Reset mobile specific height, allow h-full to stretch
+        const rect = videoContainer.getBoundingClientRect();
+        if (rect && rect.height) {
+          chatBox.style.maxHeight = rect.height + "px";
+        }
+      } else {
+        // Mobile behavior: fill remaining viewport height
+        videoContainer.style.height = ''; // Reset the desktop video filling for phone
+        document.body.style.overflow = 'hidden'; // Lock body scroll to eliminate gaps
+        chatBox.style.maxHeight = 'none'; // Reset desktop maxHeight
+        
+        // Calculate the absolute top offset of the chat box relative to the document
+        const absoluteTop = chatBox.getBoundingClientRect().top + window.scrollY;
+        
+        // Set exact height with 100dvh to perfectly align with mobile browser UI
+        chatBox.style.height = (window.innerHeight - absoluteTop) + "px"; // Fallback
+        chatBox.style.height = `calc(100dvh - ${absoluteTop}px)`; // Modern mobile fix
+      }
+    }
+  }
+  window.addEventListener('load', syncChatHeight);
+  window.addEventListener('resize', syncChatHeight);
+
+  document.addEventListener("DOMContentLoaded", function() {
+    const videoContainer = document.getElementById('live-video-container');
+    if (videoContainer && window.ResizeObserver) {
+      new ResizeObserver(syncChatHeight).observe(videoContainer);
+    }
+  });
+</script>
+{% endblock script %}
+
+{% block extra_head %} 
+ <style>
+  .vjs-marker {
+    position: absolute;
+    background: #FFD700;
+    width: 5px;
+    height: 110%;
+    top: -5%;
+    z-index: 30;
+    margin-left: -3px;
+  }
+
+  .vjs-marker:hover span {
+    opacity: 1;
+  }
+
+  .vjs-marker span {
+    position: absolute;
+    bottom: 15px;
+    opacity: 0;
+    margin-left: -20px;
+    z-index: 90;
+    background: rgba(0, 0, 0, 0.8);
+    padding: 8px;
+    font-size: 10px;
+  }
+    </style>
+    <link href="https://static.testpress.in/static/css/videojs.css" rel="stylesheet"/>
+    <script src="https://static.testpress.in/static/js/video.min.js?v=7.21.4"></script>
+    <link href="https://vjs.zencdn.net/7.8.4/video-js.css" rel="stylesheet" />
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/videojs-markers@1.0.0/dist/videojs.markers.css" rel="stylesheet"/>
+    <script src="https://cdn.jsdelivr.net/npm/videojs-markers@1.0.0/dist/videojs-markers.min.js"></script>
+    <script src="https://vjs.zencdn.net/ie8/1.1.2/videojs-ie8.min.js"></script>
+
+	<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.x.x/dist/cdn.min.js"></script>
+	{% include "./includes/content_scripts.html" %}
+	{% include "./includes/search_script.html" %}
+{% endblock extra_head %}
+
+{% block content %}
+{% set show_live_chat_toggle = true %}
+<div x-data="contents">
+	{% include "./includes/mobile_sidebar.html" %}  
+	{% include "./includes/desktop_sidebar.html" %}  
+	<main class="lg:pl-96 dark:bg-neutral-800">
+		{% include "./includes/navigate_content.html" %}
+		{% include "./includes/video_with_live_content.html" %}
+	</main>
+	{% include "./includes/global_search_modal.html"%}
+</div>
+{% endblock %}


### PR DESCRIPTION
- Users could not use chat while watching the livestream, so they had no way to ask doubts.
- This happened because only the video player was shown and chat was not added in HLS mode.
- This is fixed by adding a chat panel next to the livestream on desktop and a toggle chat panel on mobile.

**Todo**
https://3.basecamp.com/4160028/buckets/47205350/todos/9895010105