### PR TITLE
Add the live viewer count to the live stream detail heading

### DIFF
--- a/src/tpstreams/live_streams/detail.html
+++ b/src/tpstreams/live_streams/detail.html
@@ -16,7 +16,6 @@ date: 2023-10-17
       <div class="px-4 mt-4 sm:px-0 lg:mt-8">
         <div class="grid grid-cols-1 2xl:grid-cols-3 gap-y-6">
           <div class="space-y-6 2xl:col-span-2">
-            {% include "./includes/stats.html" %}
             {% include "./includes/basic_info.html" %}
           </div>
           {% include "./includes/activity_feed.html" %}

--- a/src/tpstreams/live_streams/detail.html
+++ b/src/tpstreams/live_streams/detail.html
@@ -10,9 +10,8 @@ date: 2023-10-17
   emptychatui = !!(value && value.toLowerCase() === 'true');"
 >
   {% include "./includes/detail_heading.html" %}
-  <div class="grid items-start grid-cols-1 mt-6 xl:grid-cols-3 gap-x-6 2xl:gap-x-8 gap-y-6 2xl:gap-y-2">
+  <div class="grid items-start grid-cols-1 mt-4 xl:grid-cols-3 gap-x-6 2xl:gap-x-8 gap-y-6 2xl:gap-y-2">
     <div class="xl:col-span-2">
-      {% include "./includes/viewer_count.html" %}
       {% include "./includes/video_preview.html" %}
       <div class="px-4 mt-4 sm:px-0 lg:mt-8">
         <div class="grid grid-cols-1 2xl:grid-cols-3 gap-y-6">

--- a/src/tpstreams/live_streams/detail.html
+++ b/src/tpstreams/live_streams/detail.html
@@ -12,6 +12,7 @@ date: 2023-10-17
   {% include "./includes/detail_heading.html" %}
   <div class="grid items-start grid-cols-1 mt-6 xl:grid-cols-3 gap-x-6 2xl:gap-x-8 gap-y-6 2xl:gap-y-2">
     <div class="xl:col-span-2">
+      {% include "./includes/viewer_count.html" %}
       {% include "./includes/video_preview.html" %}
       <div class="px-4 mt-4 sm:px-0 lg:mt-8">
         <div class="grid grid-cols-1 2xl:grid-cols-3 gap-y-6">

--- a/src/tpstreams/live_streams/includes/detail_heading.html
+++ b/src/tpstreams/live_streams/includes/detail_heading.html
@@ -7,25 +7,25 @@
       <h1 class="text-2xl font-semibold text-gray-900">Ethics Class</h1>
       <div class="flex items-center space-x-2">
         <span
+          class="inline-flex items-center gap-x-1.5 rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700">
+          <svg class="h-1.5 w-1.5 fill-green-500" viewBox="0 0 6 6" aria-hidden="true">
+            <circle cx="3" cy="3" r="3" />
+          </svg>
+          Live
+        </span>
+        <!-- <span
           class="inline-flex items-center gap-x-1.5 rounded-full bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700">
           <svg class="h-1.5 w-1.5 fill-blue-500" viewBox="0 0 6 6" aria-hidden="true">
             <circle cx="3" cy="3" r="3" />
           </svg>
           Creating
         </span>
-        <!-- <span
+        <span
           class="flex items-center gap-x-1.5 rounded-full bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800">
           <svg class="h-1.5 w-1.5 fill-yellow-500" viewBox="0 0 6 6" aria-hidden="true">
             <circle cx="3" cy="3" r="3" />
           </svg>
           Ready To Stream
-        </span>
-        <span
-          class="inline-flex items-center gap-x-1.5 rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700">
-          <svg class="h-1.5 w-1.5 fill-green-500" viewBox="0 0 6 6" aria-hidden="true">
-            <circle cx="3" cy="3" r="3" />
-          </svg>
-          Live
         </span>
         <span
           class="inline-flex items-center gap-x-1.5 rounded-full bg-red-100 px-1.5 py-0.5 text-xs font-medium text-red-700">

--- a/src/tpstreams/live_streams/includes/detail_heading.html
+++ b/src/tpstreams/live_streams/includes/detail_heading.html
@@ -56,6 +56,21 @@
           Ended
         </span> -->
       </div>
+      <span title="Active viewers, updates every few seconds"
+        class="inline-flex items-center gap-x-1.5 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+        <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"
+          stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path
+            d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+          <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
+        </svg>
+        <span><span class="font-semibold text-gray-900">1.2K</span> watching</span>
+        <!-- Counts under a thousand read in full; past that they shorten to one
+             decimal so the pill keeps its width as an audience grows.
+        <span><span class="font-semibold text-gray-900">847</span> watching</span>
+        <span><span class="font-semibold text-gray-900">3.4M</span> watching</span>
+        <span class="text-gray-400">Viewer count unavailable</span> -->
+      </span>
     </div>
     <!-- <pre
       class="inline-block py-1 pl-1 pr-3 mt-1 text-sm text-gray-500 bg-gray-100 rounded">GET /api/v1/9mpasc/assets/BKCKNXh4Q7x/</pre> -->

--- a/src/tpstreams/live_streams/includes/detail_heading.html
+++ b/src/tpstreams/live_streams/includes/detail_heading.html
@@ -1,68 +1,70 @@
-<div class="sm:flex space-y-2 sm:space-y-0 items-start px-4 sm:px-0"
+<div class="sm:flex sm:justify-between space-y-2 sm:space-y-0 items-start px-4 sm:px-0"
   x-init="const urlParams = new URLSearchParams(window.location.search);
   const value = urlParams.get('start_live');
   start_live = !!(value && value.toLowerCase() === 'true');">
-  <div class="sm:flex-auto">
-    <!-- Wraps rather than squeezing the badge: titles run long. -->
-    <div class="flex flex-wrap items-center gap-3">
-      <h1 class="min-w-0 text-2xl font-semibold text-gray-900">Orientation Class 01 ( Mission Arakshaka B 08 ) — General Studies Paper 1 : Indian Polity &amp; Governance</h1>
-      <div class="flex items-center space-x-2">
-        <span
-          class="inline-flex items-center gap-x-1.5 rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700">
+  <!-- Capped to the width of the video column below, so a long title wraps at
+       the player's edge instead of running on across the chat column. 66% is
+       the two-of-three grid share once its gap is taken off. -->
+  <div class="min-w-0 sm:flex-auto xl:max-w-[66%]">
+    <!-- The badge sits in the heading's own text flow, so a title that wraps
+         carries it along on the last line instead of dropping it onto a line
+         of its own. -->
+    <h1 class="text-2xl font-semibold text-gray-900">Orientation Class 01 ( Mission Arakshaka B 08 ) — General Studies Paper 1 : Indian Polity &amp; Governance<span
+        class="ml-3 inline-flex items-center gap-x-1.5 rounded-full bg-green-100 px-1.5 py-0.5 align-middle text-xs font-medium text-green-700">
           <svg class="h-1.5 w-1.5 fill-green-500" viewBox="0 0 6 6" aria-hidden="true">
             <circle cx="3" cy="3" r="3" />
           </svg>
           Live
         </span>
         <!-- <span
-          class="inline-flex items-center gap-x-1.5 rounded-full bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700">
+          class="ml-3 inline-flex items-center gap-x-1.5 rounded-full bg-blue-100 px-1.5 py-0.5 align-middle text-xs font-medium text-blue-700">
           <svg class="h-1.5 w-1.5 fill-blue-500" viewBox="0 0 6 6" aria-hidden="true">
             <circle cx="3" cy="3" r="3" />
           </svg>
           Creating
         </span>
         <span
-          class="flex items-center gap-x-1.5 rounded-full bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800">
+          class="ml-3 inline-flex items-center gap-x-1.5 rounded-full bg-yellow-100 px-1.5 py-0.5 align-middle text-xs font-medium text-yellow-800">
           <svg class="h-1.5 w-1.5 fill-yellow-500" viewBox="0 0 6 6" aria-hidden="true">
             <circle cx="3" cy="3" r="3" />
           </svg>
           Ready To Stream
         </span>
         <span
-          class="inline-flex items-center gap-x-1.5 rounded-full bg-red-100 px-1.5 py-0.5 text-xs font-medium text-red-700">
+          class="ml-3 inline-flex items-center gap-x-1.5 rounded-full bg-red-100 px-1.5 py-0.5 align-middle text-xs font-medium text-red-700">
           <svg class="h-1.5 w-1.5 fill-red-500" viewBox="0 0 6 6" aria-hidden="true">
             <circle cx="3" cy="3" r="3" />
           </svg>
           Error
         </span>
         <span
-          class="inline-flex items-center gap-x-1.5 rounded-full bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800">
+          class="ml-3 inline-flex items-center gap-x-1.5 rounded-full bg-yellow-100 px-1.5 py-0.5 align-middle text-xs font-medium text-yellow-800">
           <svg class="h-1.5 w-1.5 fill-yellow-500" viewBox="0 0 6 6" aria-hidden="true">
             <circle cx="3" cy="3" r="3" />
           </svg>
           Awaiting Broadcast
         </span>
         <span
-          class="inline-flex items-center gap-x-1.5 rounded-full bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700">
+          class="ml-3 inline-flex items-center gap-x-1.5 rounded-full bg-blue-100 px-1.5 py-0.5 align-middle text-xs font-medium text-blue-700">
           <svg class="h-1.5 w-1.5 fill-blue-500" viewBox="0 0 6 6" aria-hidden="true">
             <circle cx="3" cy="3" r="3" />
           </svg>
           Ending
         </span>
         <span
-          class="inline-flex items-center gap-x-1.5 rounded-full bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600">
+          class="ml-3 inline-flex items-center gap-x-1.5 rounded-full bg-gray-100 px-1.5 py-0.5 align-middle text-xs font-medium text-gray-600">
           <svg class="h-1.5 w-1.5 fill-gray-400" viewBox="0 0 6 6" aria-hidden="true">
             <circle cx="3" cy="3" r="3" />
           </svg>
           Ended
-        </span> -->
-      </div>
-    </div>
+        </span> --></h1>
     {% include "./viewer_count.html" %}
     <!-- <pre
       class="inline-block py-1 pl-1 pr-3 mt-1 text-sm text-gray-500 bg-gray-100 rounded">GET /api/v1/9mpasc/assets/BKCKNXh4Q7x/</pre> -->
   </div>
-  <div class="flex items-center sm:justify-end sm:space-x-2">
+  <!-- shrink-0 so the buttons keep their own width and the title column is what
+       gives way; without it the labels wrap mid-word on a narrow desktop. -->
+  <div class="flex items-center shrink-0 sm:justify-end sm:space-x-2">
     <span class="hidden sm:block">
       <button type="submit" class="inline-flex items-center gap-x-1.5 rounded-md bg-white px-2.5 py-1.5 sm:px-3 sm:py-2 text-sm font-semibold text-blue-600 shadow-sm ring-1 ring-inset ring-blue-300 hover:bg-blue-50">
         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">

--- a/src/tpstreams/live_streams/includes/detail_heading.html
+++ b/src/tpstreams/live_streams/includes/detail_heading.html
@@ -5,7 +5,7 @@
   <div class="sm:flex-auto">
     <!-- Wraps rather than squeezing the badge: titles run long. -->
     <div class="flex flex-wrap items-center gap-3">
-      <h1 class="min-w-0 text-2xl font-semibold text-gray-900">Orientation Class 01 ( Mission Arakshaka B 08 )</h1>
+      <h1 class="min-w-0 text-2xl font-semibold text-gray-900">Orientation Class 01 ( Mission Arakshaka B 08 ) — General Studies Paper 1 : Indian Polity &amp; Governance</h1>
       <div class="flex items-center space-x-2">
         <span
           class="inline-flex items-center gap-x-1.5 rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700">

--- a/src/tpstreams/live_streams/includes/detail_heading.html
+++ b/src/tpstreams/live_streams/includes/detail_heading.html
@@ -1,4 +1,4 @@
-<div class="sm:flex space-y-2 sm:space-y-0 items-center px-4 sm:px-0"
+<div class="sm:flex space-y-2 sm:space-y-0 items-start px-4 sm:px-0"
   x-init="const urlParams = new URLSearchParams(window.location.search);
   const value = urlParams.get('start_live');
   start_live = !!(value && value.toLowerCase() === 'true');">
@@ -56,21 +56,13 @@
           Ended
         </span> -->
       </div>
-      <span title="Active viewers, updates every few seconds"
-        class="inline-flex items-center gap-x-1.5 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
-        <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"
-          stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path
-            d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
-          <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
-        </svg>
-        <span><span class="font-semibold text-gray-900">1.2K</span> watching</span>
-        <!-- Counts under a thousand read in full; past that they shorten to one
-             decimal so the pill keeps its width as an audience grows.
-        <span><span class="font-semibold text-gray-900">847</span> watching</span>
-        <span><span class="font-semibold text-gray-900">3.4M</span> watching</span>
-        <span class="text-gray-400">Viewer count unavailable</span> -->
-      </span>
+    </div>
+    <!-- Live meta line: only shown while the stream is out. -->
+    <div class="flex flex-wrap items-center mt-1 text-sm text-gray-600 gap-x-2 gap-y-1">
+      <span class="font-semibold text-gray-900">1,284 watching now</span>
+      <!-- <span class="text-gray-400">Viewer count unavailable</span> -->
+      <span aria-hidden="true">·</span>
+      <span>Started streaming 85 minutes ago</span>
     </div>
     <!-- <pre
       class="inline-block py-1 pl-1 pr-3 mt-1 text-sm text-gray-500 bg-gray-100 rounded">GET /api/v1/9mpasc/assets/BKCKNXh4Q7x/</pre> -->

--- a/src/tpstreams/live_streams/includes/detail_heading.html
+++ b/src/tpstreams/live_streams/includes/detail_heading.html
@@ -1,4 +1,4 @@
-<div class="sm:flex space-y-2 sm:space-y-0 items-center px-4 sm:px-0"
+<div class="sm:flex space-y-2 sm:space-y-0 items-start px-4 sm:px-0"
   x-init="const urlParams = new URLSearchParams(window.location.search);
   const value = urlParams.get('start_live');
   start_live = !!(value && value.toLowerCase() === 'true');">
@@ -58,6 +58,7 @@
         </span> -->
       </div>
     </div>
+    {% include "./viewer_count.html" %}
     <!-- <pre
       class="inline-block py-1 pl-1 pr-3 mt-1 text-sm text-gray-500 bg-gray-100 rounded">GET /api/v1/9mpasc/assets/BKCKNXh4Q7x/</pre> -->
   </div>

--- a/src/tpstreams/live_streams/includes/detail_heading.html
+++ b/src/tpstreams/live_streams/includes/detail_heading.html
@@ -3,8 +3,9 @@
   const value = urlParams.get('start_live');
   start_live = !!(value && value.toLowerCase() === 'true');">
   <div class="sm:flex-auto">
-    <div class="flex items-center space-x-2">
-      <h1 class="text-2xl font-semibold text-gray-900">Ethics Class</h1>
+    <!-- Wraps rather than squeezing the badge: titles run long. -->
+    <div class="flex flex-wrap items-center gap-3">
+      <h1 class="min-w-0 text-2xl font-semibold text-gray-900">Orientation Class 01 ( Mission Arakshaka B 08 )</h1>
       <div class="flex items-center space-x-2">
         <span
           class="inline-flex items-center gap-x-1.5 rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-700">

--- a/src/tpstreams/live_streams/includes/detail_heading.html
+++ b/src/tpstreams/live_streams/includes/detail_heading.html
@@ -1,4 +1,4 @@
-<div class="sm:flex space-y-2 sm:space-y-0 items-start px-4 sm:px-0"
+<div class="sm:flex space-y-2 sm:space-y-0 items-center px-4 sm:px-0"
   x-init="const urlParams = new URLSearchParams(window.location.search);
   const value = urlParams.get('start_live');
   start_live = !!(value && value.toLowerCase() === 'true');">
@@ -57,17 +57,10 @@
         </span> -->
       </div>
     </div>
-    <!-- Live meta line: only shown while the stream is out. -->
-    <div class="flex flex-wrap items-center mt-1 text-sm text-gray-600 gap-x-2 gap-y-1">
-      <span class="font-semibold text-gray-900">1,284 watching now</span>
-      <!-- <span class="text-gray-400">Viewer count unavailable</span> -->
-      <span aria-hidden="true">·</span>
-      <span>Started streaming 85 minutes ago</span>
-    </div>
     <!-- <pre
       class="inline-block py-1 pl-1 pr-3 mt-1 text-sm text-gray-500 bg-gray-100 rounded">GET /api/v1/9mpasc/assets/BKCKNXh4Q7x/</pre> -->
   </div>
-  <div class="flex items-center sm:space-x-2">
+  <div class="flex items-center sm:justify-end sm:space-x-2">
     <span class="hidden sm:block">
       <button type="submit" class="inline-flex items-center gap-x-1.5 rounded-md bg-white px-2.5 py-1.5 sm:px-3 sm:py-2 text-sm font-semibold text-blue-600 shadow-sm ring-1 ring-inset ring-blue-300 hover:bg-blue-50">
         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">

--- a/src/tpstreams/live_streams/includes/viewer_count.html
+++ b/src/tpstreams/live_streams/includes/viewer_count.html
@@ -1,7 +1,6 @@
-<!-- Live viewer count. Only shown while the stream is out. Sits above the
-     player, right-aligned to its edge — padded to match the video on mobile,
-     where the video runs edge to edge. -->
-<div class="flex flex-wrap items-center justify-end px-4 mb-2.5 text-sm text-gray-600 gap-x-2 gap-y-1 sm:px-0">
+<!-- Live viewer count. Only shown while the stream is out. Sits under the
+     title, inside the heading's own horizontal padding. -->
+<div class="flex flex-wrap items-center mt-1.5 text-sm text-gray-600 gap-x-2 gap-y-1">
   <span class="font-semibold text-gray-900">1,284 watching now</span>
   <!-- <span class="text-gray-400">Viewer count unavailable</span> -->
   <!-- Separator kept with the text after it, so it never trails a wrapped line. -->

--- a/src/tpstreams/live_streams/includes/viewer_count.html
+++ b/src/tpstreams/live_streams/includes/viewer_count.html
@@ -1,0 +1,12 @@
+<!-- Live viewer count. Only shown while the stream is out. Sits above the
+     player, right-aligned to its edge — padded to match the video on mobile,
+     where the video runs edge to edge. -->
+<div class="flex flex-wrap items-center justify-end px-4 mb-2.5 text-sm text-gray-600 gap-x-2 gap-y-1 sm:px-0">
+  <span class="font-semibold text-gray-900">1,284 watching now</span>
+  <!-- <span class="text-gray-400">Viewer count unavailable</span> -->
+  <!-- Separator kept with the text after it, so it never trails a wrapped line. -->
+  <span class="flex items-center gap-x-2">
+    <span aria-hidden="true" class="text-gray-300">·</span>
+    <span>Started streaming 85 minutes ago</span>
+  </span>
+</div>


### PR DESCRIPTION
- Sits beside the status badge, where a producer watching a stream go out is already looking. Neutral gray rather than another coloured pill, so it reads as a measurement of the stream and not as a second piece of its state.
- Counts under a thousand show in full; past that they shorten to one decimal, which keeps the pill from resizing as an audience grows through the numbers. The other counts and the unavailable state follow the badge convention above and stay commented out.